### PR TITLE
ci(infra): agregar github actions para backend y frontend

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,0 +1,77 @@
+# CI Backend — Se ejecuta cuando hay cambios en backend/
+name: CI Backend
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/ci-backend.yml'
+
+jobs:
+  lint:
+    name: Lint (Ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Instalar Ruff
+        run: pip install ruff
+
+      - name: Ejecutar Ruff (linting)
+        run: ruff check backend/ --output-format=github
+
+      - name: Ejecutar Ruff (formato)
+        run: ruff format backend/ --check
+
+  test:
+    name: Tests (Pytest)
+    runs-on: ubuntu-latest
+    needs: lint
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: test_db
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Instalar dependencias
+        run: pip install -r backend/requirements.txt
+
+      - name: Ejecutar tests
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
+          REDIS_URL: redis://localhost:6379/0
+          SECRET_KEY: test-secret-key-only-for-ci
+          DEBUG: 'True'
+          PLATFORM_BASE_DOMAIN: localhost
+        run: |
+          cd backend
+          python manage.py test --verbosity=2 --no-input

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,0 +1,38 @@
+# CI Frontend — Se ejecuta cuando hay cambios en frontend/
+name: CI Frontend
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/ci-frontend.yml'
+
+jobs:
+  lint-and-build:
+    name: Lint + Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Instalar dependencias
+        run: npm ci
+        working-directory: frontend
+
+      - name: Ejecutar ESLint
+        run: npm run lint
+        working-directory: frontend
+
+      - name: Verificar build
+        run: npm run build
+        working-directory: frontend
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:8000/api
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_placeholder

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,12 +1,28 @@
-[tool.black]
+# Ruff — Linter + Formatter para Python (reemplaza flake8, black, isort)
+# Docs: https://docs.astral.sh/ruff/
+
+[tool.ruff]
 line-length = 120
+target-version = "py312"
 
-[tool.flake8]
-max-line-length = 120
-extend-ignore = ["E203", "W503"]
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle errors
+  "W",    # pycodestyle warnings
+  "F",    # pyflakes
+  "I",    # isort (orden de imports)
+  "B",    # flake8-bugbear
+  "UP",   # pyupgrade
+]
+ignore = [
+  "E501",  # line too long (lo maneja el formatter)
+  "B008",  # do not perform function calls in argument defaults (común en Django)
+  "B905",  # zip() without strict= (compatible con Python < 3.10)
+]
 
-[tool.pylint.format]
-max-line-length = 120
+[tool.ruff.lint.isort]
+known-first-party = ["config", "core", "ecommerce", "bookings", "services", "orders", "cart", "notifications", "subscriptions", "billing", "reviews", "coupons", "promotions", "websites", "middleware"]
 
-[tool.pycodestyle]
-max-line-length = 120
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
## Summary
- Agrega CI pipeline con GitHub Actions para el monorepo
- **Backend**: Lint con Ruff + Tests con pytest (PostgreSQL + Redis en CI)
- **Frontend**: ESLint + Next.js build verification
- Ambos workflows solo se ejecutan cuando hay cambios en su área (paths filter)
- Cache de dependencias para builds más rápidos

## Archivos
- `.github/workflows/ci-backend.yml` — CI del backend
- `.github/workflows/ci-frontend.yml` — CI del frontend
- `backend/pyproject.toml` — Configuración de Ruff (linter/formatter)

## Test plan
- [ ] Verificar que los workflows aparecen en la pestaña Actions de GitHub
- [ ] Crear un PR de prueba que toque backend/ y verificar que CI corre
- [ ] Crear un PR de prueba que toque frontend/ y verificar que CI corre

🤖 Generated with [Claude Code](https://claude.com/claude-code)