### PR TITLE
chore(infra): agregar pr template con checklist estándar

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Descripción
+<!-- ¿Qué cambia este PR y por qué? -->
+
+
+## Tipo de cambio
+- [ ] feat: Nueva funcionalidad
+- [ ] fix: Corrección de bug
+- [ ] refactor: Reestructuración sin cambio funcional
+- [ ] docs: Documentación
+- [ ] style: Formato / UI
+- [ ] test: Tests
+- [ ] chore: Mantenimiento / config
+
+## Módulo(s) afectado(s)
+- [ ] Backend
+- [ ] Frontend
+- [ ] Mobile
+- [ ] Infra / CI
+
+## Checklist
+- [ ] Mi código sigue las convenciones del proyecto
+- [ ] He probado los cambios localmente
+- [ ] No hay credenciales ni secretos en el código
+- [ ] Las migraciones están incluidas (si aplica)
+- [ ] He actualizado la documentación (si aplica)
+
+## Screenshots (si hay cambios de UI)
+<!-- Pega capturas aquí si aplica -->
+
+## Issue relacionado
+<!-- Closes #número -->


### PR DESCRIPTION
## Descripción
Agrega template automático para PRs con checklist de verificación.

## Tipo de cambio
- [x] chore: Mantenimiento / config

## Módulo(s) afectado(s)
- [x] Infra / CI

## Checklist
- [x] Mi código sigue las convenciones del proyecto
- [x] He probado los cambios localmente
- [x] No hay credenciales ni secretos en el código

## Issue relacionado
Parte del setup de control de desarrollo profesional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)