### PR TITLE
fix(infra): corregir hash de release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple


### PR DESCRIPTION
## Summary
- Corrige el hash de `googleapis/release-please-action` en el workflow
- El hash anterior (`c3fc4de...`) era del **tag object**, no del commit real
- Hash correcto: `16a9c90...` (commit real de v4)

## Contexto
Detectado por CodeRabbit en PR #13. El `gh api` devolvió el SHA del tag object en lugar del commit subyacente.

## Test plan
- [x] Verificar que el hash `16a9c90...` corresponde al commit real de v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Chores**
  * Se actualizó la configuración de automatización interna de procesos de lanzamiento. No hay cambios visibles para los usuarios finales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->