### PR TITLE
fix(core): eliminar detección de tenant por query param en vistas

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1407,9 +1407,9 @@ def get_tenant_config(request):
     tenant = getattr(request, "tenant", None)
 
     if not tenant:
-        # Si no hay tenant en el request (puede pasar en desarrollo)
-        # intentar obtenerlo desde el slug en los headers o query params
-        tenant_slug = request.headers.get("X-Tenant-Slug") or request.GET.get("tenant_slug")
+        # Fallback: intentar obtener tenant desde el header X-Tenant-Slug
+        # No se acepta query param para evitar tenant spoofing (ver issue #17)
+        tenant_slug = request.headers.get("X-Tenant-Slug")
         if tenant_slug:
             try:
                 tenant = Tenant.objects.get(slug=tenant_slug)
@@ -1520,7 +1520,9 @@ def get_tenant_website_content(request):
     """
     tenant = getattr(request, "tenant", None)
     if not tenant:
-        tenant_slug = request.headers.get("X-Tenant-Slug") or request.GET.get("tenant_slug")
+        # Fallback: intentar obtener tenant desde el header X-Tenant-Slug
+        # No se acepta query param para evitar tenant spoofing (ver issue #17)
+        tenant_slug = request.headers.get("X-Tenant-Slug")
         if tenant_slug:
             try:
                 tenant = Tenant.objects.get(slug=tenant_slug)


### PR DESCRIPTION
## Summary

- Elimina `request.GET.get('tenant_slug')` de `get_tenant_config` y `get_tenant_website_content` en `core/views.py`
- Previene **tenant spoofing** donde un usuario podría pasar `?tenant_slug=otro-tenant` y acceder a datos de otro tenant
- El tenant ahora se resuelve exclusivamente via `TenantMiddleware` (header/subdominio) o fallback por header `X-Tenant-Slug`

## Contexto

El `TenantMiddleware` ya protege la detección por query param con `_is_development()` (solo en `DEBUG=True`). Sin embargo, las vistas `get_tenant_config` (línea 1412) y `get_tenant_website_content` (línea 1523) tenían un fallback que aceptaba `request.GET.get('tenant_slug')` sin esa protección, creando un vector de tenant spoofing.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `backend/core/views.py` | Eliminar `request.GET.get('tenant_slug')` de ambos endpoints |

## Test plan

- [x] Verificar que `GET /api/tenant/config/` con header `X-Tenant-Slug` sigue funcionando
- [x] Verificar que `GET /api/tenant/website-content/` con header `X-Tenant-Slug` sigue funcionando
- [x] Verificar que `?tenant_slug=xxx` ya NO resuelve el tenant en ninguno de los dos endpoints
- [x] Verificar que el middleware sigue resolviendo el tenant por subdominio correctamente

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mejoras de Seguridad**
  * Se reforzó el mecanismo de validación de identificación de tenants en el sistema. La validación ahora es más rigurosa al determinar el tenant activo, protegiendo mejor el acceso a datos sensibles de configuración y contenido. Este cambio mejora la seguridad general para todos los usuarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->