### PR TITLE
docs(infra): reestructurar memoria de agentes y guía de subagentes

### DIFF
--- a/.claude/skills/multi-tenancy/SKILL.md
+++ b/.claude/skills/multi-tenancy/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: multi-tenancy
+description: >
+  Patrones y reglas de multi-tenancy para Django. Se activa cuando se crean o modifican
+  modelos, views, serializers, tests, o cualquier código que toque datos de tenant.
+user-invocable: false
+metadata:
+  author: nerbis-platform
+  version: "1.0.0"
+---
+
+# Multi-Tenancy — Django (Shared DB, Tenant-per-Request)
+
+## Arquitectura
+
+```
+Request → TenantMiddleware → request.tenant + thread-local context
+                                    ↓
+              TenantAwareModel → TenantAwareManager (auto-filtra por tenant)
+```
+
+- **Detección:** header `X-Tenant-Slug` > subdominio (middleware)
+- **Context:** thread-local storage (`core/context.py`) — disponible en todo el request
+- **Filtrado:** `TenantAwareManager` filtra automáticamente, pero views SIEMPRE filtran explícitamente
+- **Asignación:** `perform_create()` asigna `tenant=request.tenant`
+
+## Reglas CRÍTICAS (nunca violar)
+
+1. **NUNCA** crear un modelo de negocio sin heredar de `TenantAwareModel`
+2. **NUNCA** hacer queries sin filtro de tenant (excepto endpoints públicos)
+3. **NUNCA** exponer `tenant` o `tenant_id` en serializers o URLs
+4. **NUNCA** permitir cross-tenant queries (un tenant viendo datos de otro)
+5. **SIEMPRE** asignar tenant en `perform_create()`, nunca en el serializer
+6. **SIEMPRE** verificar `user.tenant == request.tenant` en permisos
+
+## Archivos clave del proyecto
+
+| Archivo | Propósito |
+|---------|-----------|
+| `backend/core/models.py` | TenantAwareModel, Tenant model |
+| `backend/core/managers.py` | TenantAwareManager (auto-filtrado) |
+| `backend/core/context.py` | Thread-local: set/get/clear_current_tenant |
+| `backend/core/permissions.py` | IsTenantUser, IsTenantAdmin, IsTenantStaffOrAdmin |
+| `backend/middleware/tenant.py` | TenantMiddleware (detección) |
+| `backend/conftest.py` | Fixtures de testing (tenant, api_client, auth clients) |
+
+## Patrones detallados
+
+- [Modelos](./rules/models.md) — cómo crear modelos tenant-aware
+- [Views](./rules/views.md) — patrones de viewsets
+- [Serializers](./rules/serializers.md) — reglas de serialización
+- [Testing](./rules/testing.md) — fixtures y patrones de test
+- [Permisos](./rules/permissions.md) — permission classes disponibles

--- a/.claude/skills/multi-tenancy/rules/models.md
+++ b/.claude/skills/multi-tenancy/rules/models.md
@@ -1,0 +1,52 @@
+---
+title: Modelos Tenant-Aware
+impact: CRITICAL
+tags: models, tenant, django
+---
+
+# Modelos Tenant-Aware
+
+Todo modelo de negocio DEBE heredar de `TenantAwareModel`. Esto le da automáticamente:
+- Campo `tenant` (FK a Tenant)
+- Campos `created_at` y `updated_at`
+- `TenantAwareManager` como manager por defecto
+- Index compuesto `(tenant, created_at)`
+
+## Patrón correcto
+
+```python
+from core.models import TenantAwareModel
+
+class MiModelo(TenantAwareModel):
+    name = models.CharField(max_length=200)
+    slug = models.SlugField(max_length=220, blank=True)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        verbose_name = "Mi Modelo"
+        ordering = ["name"]
+        # unique_together SIEMPRE incluye tenant
+        unique_together = [["tenant", "slug"]]
+        # indexes SIEMPRE incluyen tenant como primer campo
+        indexes = [
+            models.Index(fields=["tenant", "is_active"]),
+        ]
+```
+
+## Errores comunes
+
+**Incorrecto** — heredar de models.Model:
+```python
+class MiModelo(models.Model):  # MAL: sin tenant
+    name = models.CharField(max_length=200)
+```
+
+**Incorrecto** — unique sin tenant:
+```python
+unique_together = [["slug"]]  # MAL: slug puede colisionar entre tenants
+```
+
+**Correcto** — unique CON tenant:
+```python
+unique_together = [["tenant", "slug"]]  # BIEN: único por tenant
+```

--- a/.claude/skills/multi-tenancy/rules/permissions.md
+++ b/.claude/skills/multi-tenancy/rules/permissions.md
@@ -1,0 +1,43 @@
+---
+title: Permission Classes Tenant-Aware
+impact: HIGH
+tags: permissions, tenant, security, django
+---
+
+# Permission Classes Tenant-Aware
+
+Ubicación: `backend/core/permissions.py`
+
+## Clases disponibles
+
+| Clase | Uso |
+|-------|-----|
+| `IsTenantUser` | Usuario autenticado que pertenece al tenant del request |
+| `IsTenantAdmin` | Admin del tenant (role=admin + mismo tenant) |
+| `IsTenantStaffOrAdmin` | Staff o admin del tenant |
+| `IsOwnerOrStaff` | Dueño del objeto o staff/admin (object-level) |
+
+## Cuándo usar cada una
+
+```python
+# Endpoints que cualquier usuario del tenant puede ver (catálogo, horarios)
+permission_classes = [IsAuthenticated, IsTenantUser]
+
+# Endpoints de gestión (CRUD de productos, configuración)
+permission_classes = [IsAuthenticated, IsTenantAdmin]
+
+# Endpoints mixtos (staff puede gestionar, admin también)
+permission_classes = [IsAuthenticated, IsTenantStaffOrAdmin]
+
+# Endpoints donde el dueño puede ver/editar su propio recurso
+permission_classes = [IsAuthenticated, IsTenantUser, IsOwnerOrStaff]
+```
+
+## Regla crítica
+
+Toda permission class SIEMPRE verifica:
+```python
+request.user.tenant == request.tenant
+```
+Esto previene que un usuario de tenant A acceda a la API de tenant B,
+incluso si tiene un JWT válido.

--- a/.claude/skills/multi-tenancy/rules/serializers.md
+++ b/.claude/skills/multi-tenancy/rules/serializers.md
@@ -1,0 +1,38 @@
+---
+title: Serializers Tenant-Aware
+impact: HIGH
+tags: serializers, tenant, django, drf
+---
+
+# Serializers Tenant-Aware
+
+El campo `tenant` NUNCA debe aparecer en serializers. El tenant se asigna
+server-side en `perform_create()`, nunca desde el cliente.
+
+## Patrón correcto
+
+```python
+class MiModeloSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MiModelo
+        # NUNCA incluir 'tenant' en fields
+        fields = ["id", "name", "slug", "is_active"]
+        read_only_fields = ["id", "slug"]
+```
+
+## Errores comunes
+
+**Incorrecto** — exponer tenant:
+```python
+fields = ["id", "tenant", "name"]  # MAL: expone tenant_id al cliente
+```
+
+**Incorrecto** — tenant como campo writable:
+```python
+fields = "__all__"  # MAL: incluye tenant y permite que el cliente lo modifique
+```
+
+**Correcto** — listar campos explícitamente sin tenant:
+```python
+fields = ["id", "name", "slug", "is_active"]  # BIEN: sin tenant
+```

--- a/.claude/skills/multi-tenancy/rules/testing.md
+++ b/.claude/skills/multi-tenancy/rules/testing.md
@@ -1,0 +1,46 @@
+---
+title: Testing Tenant-Aware
+impact: HIGH
+tags: testing, tenant, pytest, fixtures
+---
+
+# Testing Tenant-Aware
+
+Usar las fixtures de `conftest.py` para tests con contexto de tenant.
+
+## Fixtures disponibles
+
+| Fixture | Descripción |
+|---------|-------------|
+| `tenant` | Tenant de prueba |
+| `tenant_context` | Setea tenant en thread-local (limpia al final) |
+| `api_client` | APIClient con header X-Tenant-Slug |
+| `auth_admin_client` | APIClient autenticado como admin (JWT) |
+| `auth_customer_client` | APIClient autenticado como customer (JWT) |
+| `second_tenant` | Segundo tenant para tests de aislamiento |
+
+## Patrón correcto
+
+```python
+class TestMiModelo:
+    def test_create(self, auth_admin_client, tenant):
+        response = auth_admin_client.post("/api/v1/mi-app/modelos/", {
+            "name": "Test",
+        })
+        assert response.status_code == 201
+        assert response.data["name"] == "Test"
+
+    def test_isolation(self, auth_admin_client, second_tenant):
+        """Datos de otro tenant no deben ser visibles."""
+        MiModelo.objects.create(tenant=second_tenant, name="Otro")
+        response = auth_admin_client.get("/api/v1/mi-app/modelos/")
+        assert response.status_code == 200
+        assert len(response.data["results"]) == 0  # No ve datos del otro tenant
+```
+
+## Reglas de testing
+
+1. **SIEMPRE** usar `tenant_context` o fixtures que lo incluyan (api_client, auth_admin_client)
+2. **SIEMPRE** probar aislamiento entre tenants (crear dato en second_tenant, verificar que no se ve)
+3. **NUNCA** crear APIClient sin header X-Tenant-Slug
+4. Las fixtures auth_admin_client y auth_customer_client son instancias independientes

--- a/.claude/skills/multi-tenancy/rules/views.md
+++ b/.claude/skills/multi-tenancy/rules/views.md
@@ -1,0 +1,58 @@
+---
+title: ViewSets Tenant-Aware
+impact: CRITICAL
+tags: views, viewsets, tenant, django
+---
+
+# ViewSets Tenant-Aware
+
+Toda view que acceda datos de tenant DEBE:
+1. Filtrar en `get_queryset()` por `request.tenant`
+2. Asignar tenant en `perform_create()` con `request.tenant`
+
+## Patrón correcto
+
+```python
+class MiModeloViewSet(viewsets.ModelViewSet):
+    serializer_class = MiModeloSerializer
+    permission_classes = [IsAuthenticated, IsTenantUser]
+
+    def get_queryset(self):
+        # Swagger/schema generation check
+        if getattr(self, "swagger_fake_view", False):
+            return MiModelo.objects.none()
+
+        # SIEMPRE filtrar por tenant explícitamente
+        queryset = MiModelo.objects.filter(tenant=self.request.tenant)
+
+        # Lógica de visibilidad por rol
+        user = self.request.user
+        if not (user.is_authenticated and user.role in ("admin", "staff")):
+            queryset = queryset.filter(is_active=True)
+
+        return queryset
+
+    def perform_create(self, serializer):
+        # SIEMPRE asignar tenant desde request
+        serializer.save(tenant=self.request.tenant)
+```
+
+## Errores comunes
+
+**Incorrecto** — no filtrar por tenant:
+```python
+def get_queryset(self):
+    return MiModelo.objects.all()  # MAL: expone datos de otros tenants
+```
+
+**Incorrecto** — asignar tenant en serializer:
+```python
+# En el serializer
+tenant = serializers.HiddenField(default=CurrentTenantDefault())  # MAL
+```
+
+**Correcto** — tenant se asigna en perform_create:
+```python
+def perform_create(self, serializer):
+    serializer.save(tenant=self.request.tenant)  # BIEN
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,43 +1,40 @@
-# NERBIS — Instrucciones del Proyecto
+# NERBIS — Instrucciones para Claude Code
 
-## Sobre el proyecto
+## Contexto rápido
 
-Plataforma SaaS multi-tenant multi-industria. Lee `docs/SDD.md` antes de hacer cambios arquitectónicos.
+Plataforma SaaS multi-tenant. Lee `AGENTS.md` para reglas universales del proyecto.
+Lee `docs/SDD.md` antes de cambios arquitectónicos.
 
 - **Stack:** Django 5 + DRF (backend) / Next.js 16 + React 19 (frontend)
 - **Monorepo:** backend/ + frontend/ + mobile/
 - **Repo:** https://github.com/nerbis-platform/nerbis-platform
 
-## Git y branching
+## Git (específico Claude)
 
-- **Flujo:** `feature/*` o `fix/*` o `docs/*` → PR → `develop` → PR → `main`
-- **PRs siempre a `develop`**, nunca directo a `main`
-- `main` = producción. `develop` = integración
-- Crear branches desde `develop` actualizado (`git checkout develop && git pull`)
-
-## Commits
-
-- **Conventional commits obligatorios** (commitlint + husky)
-- Formato: `tipo(scope): descripción en minúsculas`
-- Tipos: feat, fix, refactor, docs, ci, chore, test, style, perf
-- Scopes comunes: websites, ecommerce, bookings, core, billing, infra
-- Subject siempre en minúsculas (commitlint lo valida)
-- Incluir co-author: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- Incluir siempre: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- Subject en minúsculas (commitlint lo valida)
+- Crear branch desde `develop` actualizado
 
 ## Antes de codear
 
-1. Leer el SDD (`docs/SDD.md`) si el cambio toca la arquitectura
-2. Usar worktree si se trabaja en paralelo con otros agentes
-3. Verificar en qué branch estás antes de empezar
-4. Crear branch desde `develop` (no desde `main` ni desde otro feature)
+1. Leer `AGENTS.md` si es primera tarea de la sesión
+2. Leer `docs/SDD.md` si el cambio toca la arquitectura
+3. Usar worktree si se trabaja en paralelo con otros agentes
+4. Verificar branch actual antes de empezar
 
-## CI/CD
+## Subagentes y paralelismo
 
-- **Backend:** Ruff lint + format check + Pytest (en PRs a main y develop)
-- **Frontend:** ESLint + Next.js build (en PRs a main y develop)
-- **CodeRabbit:** Review automático en PRs a main y develop
-- **Release Please:** Versionamiento semántico automático en push a main
-- Correr lint local antes de push: `ruff check backend/` y `cd frontend && npm run lint`
+### Cuándo usar subagentes (Task tool)
+- **Exploración**: buscar patrones en el codebase sin saturar contexto principal
+- **Tareas independientes**: lint backend + lint frontend en paralelo
+- **Investigación**: leer docs largas (SDD.md) y resumir lo relevante
+- **NO usar** para tareas que modifican los mismos archivos (riesgo de conflictos)
+
+### Cuándo usar worktrees
+- Múltiples agentes Claude trabajando en paralelo
+- Tarea larga que no debe bloquear el branch principal
+- Comando: usar EnterWorktree al inicio de sesión
+- Los worktrees se crean en `.claude/worktrees/`
 
 ## Skills
 
@@ -47,25 +44,17 @@ Para tareas de frontend, leer los skills instalados en `.claude/skills/` antes d
 - `.claude/skills/shadcn` — uso correcto de shadcn/ui + Radix UI
 - `.claude/skills/vercel-react-best-practices` — patrones React 19 + Next.js performance
 
-## Código
+## Código (específico Claude)
 
-- No modificar migraciones existentes de Django (son registros inmutables)
 - Python: type hints modernos (`dict`, `list`, `str | None` — no `Dict`, `List`, `Optional`)
-- Backend: excluir migraciones del linting (ya configurado en pyproject.toml)
-- Frontend: Shadcn/ui + Radix UI para componentes base
-- Frontend: TailwindCSS 4 para estilos
-- Frontend: Context API para estado global (AuthContext, CartContext, TenantContext, WebsiteContentContext)
+- No modificar migraciones existentes de Django
+- Frontend: Context API para estado (AuthContext, CartContext, TenantContext, WebsiteContentContext)
+- Todas las reglas de código, multi-tenancy y seguridad están en `AGENTS.md`
 
-## Multi-tenancy
+## CI/CD
 
-- Todos los modelos de datos heredan de `TenantAwareModel`
-- El tenant se detecta por: header `X-Tenant-Slug` > subdominio (middleware)
-- El `TenantAwareManager` auto-filtra queries por tenant
-- Nunca hacer queries sin filtro de tenant (excepto endpoints públicos)
-
-## Seguridad
-
-- No hardcodear secretos. Usar variables de entorno
-- No commitear .env, credentials, o archivos con datos sensibles
-- Actions de GitHub: pinear con commit hash (no tags)
-- Rate limiting configurado en endpoints de auth
+- **Backend:** Ruff lint + format check + Pytest (en PRs a main y develop)
+- **Frontend:** ESLint + Next.js build (en PRs a main y develop)
+- **CodeRabbit:** Review automático en PRs
+- **Release Please:** Versionamiento semántico en push a main
+- Correr lint local antes de push: `ruff check backend/` y `cd frontend && npm run lint`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,11 +40,15 @@ Lee `docs/SDD.md` antes de cambios arquitectónicos.
 
 ## Skills
 
-Para tareas de frontend, leer los skills instalados en `.claude/skills/` antes de actuar:
+Leer los skills relevantes en `.claude/skills/` antes de actuar:
 
+**Frontend:**
 - `.claude/skills/web-design-guidelines` — diseño web, UI/UX, layouts, accesibilidad
 - `.claude/skills/shadcn` — uso correcto de shadcn/ui + Radix UI
 - `.claude/skills/vercel-react-best-practices` — patrones React 19 + Next.js performance
+
+**Backend:**
+- `.claude/skills/multi-tenancy` — patrones multi-tenant (modelos, views, serializers, permisos, tests)
 
 ## Código (específico Claude)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Lee `docs/SDD.md` antes de cambios arquitectónicos.
 
 - Incluir siempre: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
 - Subject en minúsculas (commitlint lo valida)
-- Crear branch desde `develop` actualizado
+- Usar prefijos: `feature/*`, `fix/*`, `docs/*` según el tipo de cambio
+- Crear branch desde `develop` actualizado (`feature/*` o `fix/*` o `docs/*` → PR → `develop`)
 
 ## Antes de codear
 
@@ -33,8 +34,9 @@ Lee `docs/SDD.md` antes de cambios arquitectónicos.
 ### Cuándo usar worktrees
 - Múltiples agentes Claude trabajando en paralelo
 - Tarea larga que no debe bloquear el branch principal
-- Comando: usar EnterWorktree al inicio de sesión
-- Los worktrees se crean en `.claude/worktrees/`
+- Activar con: `claude -w nombre-feature "descripción de tarea"` o `claude --worktree nombre-feature "..."`
+- Claude crea automáticamente `.claude/worktrees/nombre-feature` y el branch `worktree-nombre-feature`
+- `EnterWorktree` es una acción interna de permisos — no es un comando manual
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Reestructura `CLAUDE.md`: agrega sección de subagentes/worktrees, reduce duplicación con AGENTS.md
- Crea archivos de memoria especializada (`patterns.md`, `debugging.md`, `decisions.md`) en la memoria de Claude Code
- Elimina `dev-workflow-plan.md` obsoleto
- Refactoriza `MEMORY.md` como índice compacto

## Contexto
Resuelve los 3 problemas de arquitectura de agentes IA:
1. **Context Overload** → memoria estructurada por temas, no todo en un archivo
2. **Amnesia entre sesiones** → registro de decisiones (ADRs) y patrones aprendidos
3. **God Agent** → guía de cuándo usar subagentes y worktrees

## Test plan
- [ ] Verificar que CLAUDE.md se carga correctamente en nuevas sesiones
- [ ] Verificar que las referencias a AGENTS.md son correctas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentación**
  * Renombrado del documento principal a “Contexto rápido” y adopción de convenciones centradas en Claude.
  * Actualización de guía de Git/branching y convenciones de commits con flujo y prefijos específicos.
  * Nueva guía sobre subagentes, paralelismo y uso de worktrees, incluyendo casos de uso y restricciones.
  * Consolidación de Skills/Código y referencias a AGENTS.md/SDD.md.
  * Documentación completa de multi-tenancy: modelos, permisos, serializadores, vistas y pruebas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->