### PR TITLE
docs(infra): agregar context7 y skills-lock al proyecto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,15 @@ Leer los skills relevantes en `.claude/skills/` antes de actuar:
 **Backend:**
 - `.claude/skills/multi-tenancy` — patrones multi-tenant (modelos, views, serializers, permisos, tests)
 
+## Context7 — Documentación en tiempo real
+
+Usar Context7 (MCP) para consultar documentación actualizada cuando:
+- Implementes componentes con Next.js 16, React 19, TailwindCSS 4 o shadcn/ui
+- Uses APIs específicas de Django 5 o DRF
+- No estés seguro si una API cambió entre versiones
+
+NO usar Context7 para: git, CI/CD, documentación, refactoring, o tareas que no tocan APIs de librerías.
+
 ## Código (específico Claude)
 
 - Python: type hints modernos (`dict`, `list`, `str | None` — no `Dict`, `List`, `Optional`)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "skills": {
+    "shadcn": {
+      "source": "shadcn/ui",
+      "sourceType": "github",
+      "computedHash": "1ec42c9b918b315d8e5c6c856b78c3c4725fc93dea30b9b7e9975c69848fcce6"
+    },
+    "vercel-react-best-practices": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "computedHash": "afeca00ac2f492d88fdd010e73d91719a5b57c564bb4a73325b0bd77e11323ab"
+    },
+    "web-design-guidelines": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "computedHash": "a6a44d5498f7e8f68289902f3dedfc6f38ae0cee1e96527c80724cf27f727c2a"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Agrega sección de Context7 en `CLAUDE.md` para que Claude Code consulte documentación actualizada de librerías (Next.js 16, React 19, Django 5, etc.)
- Incluye `skills-lock.json` para versionar los skills instalados (shadcn, vercel-react-best-practices, web-design-guidelines)

## Test plan
- [ ] Verificar que `CLAUDE.md` se renderiza correctamente
- [ ] Verificar que `skills-lock.json` tiene formato JSON válido

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas Características**
  * Sección de documentación en tiempo real sobre Context7 con orientación detallada sobre cuándo utilizar, incluyendo ejemplos prácticos de stack tecnológico y definición clara de exclusiones.

* **Chores**
  * Archivo de configuración de skills establecido con estructura versionada que mapea tres competencias clave, asociando cada una con su fuente, tipo de fuente e identificador de hash para verificación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->