### PR TITLE
feat(infra): implementar sdd orchestrator con agent teams

### DIFF
--- a/.claude/skills/_shared/engram-convention.md
+++ b/.claude/skills/_shared/engram-convention.md
@@ -1,0 +1,140 @@
+# Engram Artifact Convention (reference documentation)
+
+> **NOTE**: Critical engram calls (`mem_search`, `mem_save`, `mem_get_observation`) are now inlined directly in each skill's SKILL.md file. This document is supplementary reference — sub-agents do NOT need to read it to function correctly.
+
+## Naming Rules
+
+ALL SDD artifacts persisted to Engram MUST follow this deterministic naming:
+
+```
+title:     sdd/{change-name}/{artifact-type}
+topic_key: sdd/{change-name}/{artifact-type}
+type:      architecture
+project:   nerbis-platform
+scope:     project
+```
+
+### Artifact Types (exact strings)
+
+| Artifact Type | Produced By | Description |
+|---------------|-------------|-------------|
+| `explore` | sdd-explore | Exploration analysis |
+| `proposal` | sdd-propose | Change proposal |
+| `spec` | sdd-spec | Delta specifications (all domains concatenated) |
+| `design` | sdd-design | Technical design |
+| `tasks` | sdd-tasks | Task breakdown |
+| `apply-progress` | sdd-apply | Implementation progress (one per batch) |
+| `verify-report` | sdd-verify | Verification report |
+| `archive-report` | sdd-archive | Archive closure with lineage |
+| `state` | orchestrator | DAG state for recovery after compaction |
+
+**Exception**: `sdd-init` uses `sdd-init/nerbis-platform` as both title and topic_key (it's project-scoped, not change-scoped).
+
+### State Artifact
+
+The orchestrator persists DAG state after each phase transition to enable recovery after context compaction:
+
+```
+mem_save(
+  title: "sdd/{change-name}/state",
+  topic_key: "sdd/{change-name}/state",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "change: {change-name}\nphase: {last-phase}\nartifact_store: engram\nartifacts:\n  proposal: true\n  specs: true\n  design: false\n  tasks: false\ntasks_progress:\n  completed: []\n  pending: []\nlast_updated: {ISO date}"
+)
+```
+
+Recovery: `mem_search("sdd/{change-name}/state")` → `mem_get_observation(id)` → parse YAML → restore orchestrator state.
+
+### Example
+
+```
+mem_save(
+  title: "sdd/add-product-reviews/proposal",
+  topic_key: "sdd/add-product-reviews/proposal",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "# Proposal: Add Product Reviews\n\n..."
+)
+```
+
+## Recovery Protocol (2 steps)
+
+To retrieve an artifact, use this two-step process:
+
+```
+Step 1: Search by topic_key pattern
+  mem_search(query: "sdd/{change-name}/{artifact-type}", project: "nerbis-platform")
+  → Returns a truncated preview (300 chars) with an observation ID
+
+Step 2: Get full content (when you need the complete artifact)
+  mem_get_observation(id: {observation-id from step 1})
+  → Returns complete, untruncated content
+```
+
+The preview from `mem_search` is useful for identifying whether the result is what you're looking for. When you need the full content (e.g., reading SDD dependencies), ALWAYS call `mem_get_observation`.
+
+### Retrieving Multiple Artifacts
+
+When a skill needs multiple artifacts as required dependencies (e.g., sdd-tasks needs proposal + spec + design), group all searches first, then all retrievals:
+
+```
+STEP A — SEARCH (get IDs only — content is truncated):
+  1. mem_search(query: "sdd/{change-name}/proposal", project: "nerbis-platform") → save ID
+  2. mem_search(query: "sdd/{change-name}/spec", project: "nerbis-platform") → save ID
+  3. mem_search(query: "sdd/{change-name}/design", project: "nerbis-platform") → save ID
+
+STEP B — RETRIEVE FULL CONTENT (mandatory for required dependencies):
+  4. mem_get_observation(id: {proposal_id}) → full proposal
+  5. mem_get_observation(id: {spec_id}) → full spec
+  6. mem_get_observation(id: {design_id}) → full design
+```
+
+### Loading Project Context
+
+```
+mem_search(query: "sdd-init/nerbis-platform", project: "nerbis-platform") → get ID
+mem_get_observation(id) → full project context
+```
+
+### Browsing All Artifacts for a Change
+
+```
+mem_search(query: "sdd/{change-name}/", project: "nerbis-platform")
+→ Returns all artifacts for that change
+```
+
+## Writing Artifacts
+
+### Standard Write (new artifact)
+
+```
+mem_save(
+  title: "sdd/{change-name}/{artifact-type}",
+  topic_key: "sdd/{change-name}/{artifact-type}",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{full markdown content}"
+)
+```
+
+### Update Existing Artifact
+
+When updating an artifact you already retrieved (e.g., marking tasks complete):
+
+```
+mem_update(
+  id: {observation-id},
+  content: "{updated full content}"
+)
+```
+
+Use `mem_update` when you have the exact observation ID. Use `mem_save` with the same `topic_key` for upserts (Engram deduplicates by topic_key).
+
+## Why This Convention Exists
+
+- **Deterministic titles** → recovery works by exact match, not fuzzy search
+- **`topic_key`** → enables upserts (updating same artifact without creating duplicates)
+- **`sdd/` prefix** → namespaces all SDD artifacts away from other Engram observations
+- **Two-step recovery** → `mem_search` previews are always truncated; `mem_get_observation` is the only way to get full content
+- **Lineage** → archive-report includes all observation IDs for complete traceability

--- a/.claude/skills/_shared/openspec-convention.md
+++ b/.claude/skills/_shared/openspec-convention.md
@@ -2,7 +2,7 @@
 
 ## Directory Structure
 
-```
+```text
 openspec/
 ├── config.yaml              <- Project-specific SDD config
 ├── specs/                   <- Source of truth (main specs)
@@ -42,7 +42,7 @@ openspec/
 
 Each skill reads its dependencies from the filesystem:
 
-```
+```text
 Proposal:  openspec/changes/{change-name}/proposal.md
 Specs:     openspec/changes/{change-name}/specs/  (all domain subdirectories)
 Design:    openspec/changes/{change-name}/design.md
@@ -106,7 +106,7 @@ rules:
 ## Archive Structure
 
 When archiving, the change folder moves to:
-```
+```text
 openspec/changes/archive/YYYY-MM-DD-{change-name}/
 ```
 

--- a/.claude/skills/_shared/openspec-convention.md
+++ b/.claude/skills/_shared/openspec-convention.md
@@ -1,0 +1,113 @@
+# OpenSpec File Convention (shared across all SDD skills)
+
+## Directory Structure
+
+```
+openspec/
+├── config.yaml              <- Project-specific SDD config
+├── specs/                   <- Source of truth (main specs)
+│   └── {domain}/
+│       └── spec.md
+└── changes/                 <- Active changes
+    ├── archive/             <- Completed changes (YYYY-MM-DD-{change-name}/)
+    └── {change-name}/       <- Active change folder
+        ├── state.yaml       <- DAG state (orchestrator, survives compaction)
+        ├── exploration.md   <- (optional) from sdd-explore
+        ├── proposal.md      <- from sdd-propose
+        ├── specs/           <- from sdd-spec
+        │   └── {domain}/
+        │       └── spec.md  <- Delta spec
+        ├── design.md        <- from sdd-design
+        ├── tasks.md         <- from sdd-tasks (updated by sdd-apply)
+        └── verify-report.md <- from sdd-verify
+```
+
+## Artifact File Paths
+
+| Skill | Creates / Reads | Path |
+|-------|----------------|------|
+| orchestrator | Creates/Updates | `openspec/changes/{change-name}/state.yaml` |
+| sdd-init | Creates | `openspec/config.yaml`, `openspec/specs/`, `openspec/changes/`, `openspec/changes/archive/` |
+| sdd-explore | Creates (optional) | `openspec/changes/{change-name}/exploration.md` |
+| sdd-propose | Creates | `openspec/changes/{change-name}/proposal.md` |
+| sdd-spec | Creates | `openspec/changes/{change-name}/specs/{domain}/spec.md` |
+| sdd-design | Creates | `openspec/changes/{change-name}/design.md` |
+| sdd-tasks | Creates | `openspec/changes/{change-name}/tasks.md` |
+| sdd-apply | Updates | `openspec/changes/{change-name}/tasks.md` (marks `[x]`) |
+| sdd-verify | Creates | `openspec/changes/{change-name}/verify-report.md` |
+| sdd-archive | Moves | `openspec/changes/{change-name}/` → `openspec/changes/archive/YYYY-MM-DD-{change-name}/` |
+| sdd-archive | Updates | `openspec/specs/{domain}/spec.md` (merges deltas into main specs) |
+
+## Reading Artifacts
+
+Each skill reads its dependencies from the filesystem:
+
+```
+Proposal:  openspec/changes/{change-name}/proposal.md
+Specs:     openspec/changes/{change-name}/specs/  (all domain subdirectories)
+Design:    openspec/changes/{change-name}/design.md
+Tasks:     openspec/changes/{change-name}/tasks.md
+Config:    openspec/config.yaml
+Main specs: openspec/specs/{domain}/spec.md
+```
+
+## Writing Rules
+
+- ALWAYS create the change directory (`openspec/changes/{change-name}/`) before writing artifacts
+- If a file already exists, READ it first and UPDATE it (don't overwrite blindly)
+- If the change directory already exists with artifacts, the change is being CONTINUED
+- Use the `openspec/config.yaml` `rules` section to apply project-specific constraints per phase
+
+## Config File Reference
+
+```yaml
+# openspec/config.yaml
+schema: spec-driven
+
+context: |
+  Tech stack: Django 5 + DRF (backend), Next.js 16 + React 19 (frontend)
+  Architecture: Multi-tenant SaaS, monorepo (backend/ + frontend/ + mobile/)
+  Testing: Pytest (backend), ESLint + Next.js build (frontend)
+  Style: Ruff (Python), ESLint (JS/TS), conventional commits
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Include multi-tenancy impact if backend models are in scope
+  specs:
+    - Use Given/When/Then for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+    - Include tenant isolation requirements for backend changes
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+    - New models MUST inherit TenantAwareModel
+  tasks:
+    - Group by phase, use hierarchical numbering
+    - Keep tasks completable in one session
+    - Include lint steps in cleanup phase
+  apply:
+    - Follow existing code patterns (see AGENTS.md)
+    tdd: false
+    test_command: "pytest backend/"
+    lint_backend: "ruff check backend/"
+    lint_frontend: "cd frontend && npm run lint"
+  verify:
+    test_command: "pytest backend/"
+    build_command: "cd frontend && npm run build"
+    lint_backend: "ruff check backend/"
+    lint_frontend: "cd frontend && npm run lint"
+    coverage_threshold: 0
+  archive:
+    - Warn before merging destructive deltas
+    - Suggest PR creation to develop branch
+```
+
+## Archive Structure
+
+When archiving, the change folder moves to:
+```
+openspec/changes/archive/YYYY-MM-DD-{change-name}/
+```
+
+Use today's date in ISO format. The archive is an AUDIT TRAIL — never delete or modify archived changes.

--- a/.claude/skills/_shared/persistence-contract.md
+++ b/.claude/skills/_shared/persistence-contract.md
@@ -1,0 +1,164 @@
+# Persistence Contract (shared across all SDD skills)
+
+## Mode Resolution
+
+The orchestrator passes `artifact_store.mode` with one of: `engram | openspec | hybrid | none`.
+
+Default resolution (when orchestrator does not explicitly set a mode):
+1. If Engram is available → use `engram`
+2. Otherwise → use `none`
+
+`openspec` and `hybrid` are NEVER used by default — only when the orchestrator explicitly passes them.
+
+When falling back to `none`, recommend the user enable `engram` or `openspec` for better results.
+
+## Behavior Per Mode
+
+| Mode | Read from | Write to | Project files |
+|------|-----------|----------|---------------|
+| `engram` | Engram (see `engram-convention.md`) | Engram | Never |
+| `openspec` | Filesystem (see `openspec-convention.md`) | Filesystem | Yes |
+| `hybrid` | Engram (primary) + Filesystem (fallback) | Both Engram AND Filesystem | Yes |
+| `none` | Orchestrator prompt context | Nowhere | Never |
+
+### Hybrid Mode
+
+`hybrid` persists every artifact to BOTH Engram and OpenSpec simultaneously. This provides:
+- **Engram**: cross-session recovery, compaction survival, deterministic search
+- **OpenSpec**: human-readable files in the project, version-controllable artifacts
+
+**Read priority**: Engram first (faster, survives compaction). Fall back to filesystem if Engram returns no results.
+
+**Write behavior**: Write to Engram (per `engram-convention.md`) AND to filesystem (per `openspec-convention.md`) for every artifact. Both writes MUST succeed for the operation to be considered complete.
+
+## State Persistence (Orchestrator)
+
+The orchestrator persists DAG state after each phase transition. This enables SDD recovery after context compaction.
+
+| Mode | Persist State | Recover State |
+|------|--------------|---------------|
+| `engram` | `mem_save(topic_key: "sdd/{change-name}/state")` | `mem_search("sdd/*/state")` → `mem_get_observation(id)` |
+| `openspec` | Write `openspec/changes/{change-name}/state.yaml` | Read `openspec/changes/{change-name}/state.yaml` |
+| `hybrid` | Both: `mem_save` AND write `state.yaml` | Engram first; filesystem fallback |
+| `none` | Not possible — state lives only in context | Not possible — warn user |
+
+## Common Rules
+
+- If mode is `none`, do NOT create or modify any project files. Return results inline only.
+- If mode is `engram`, do NOT write any project files. Persist to Engram and return observation IDs.
+- If mode is `openspec`, write files ONLY to the paths defined in `openspec-convention.md`.
+- If mode is `hybrid`, persist to BOTH Engram AND filesystem. Follow both conventions.
+- NEVER force `openspec/` creation unless the orchestrator explicitly passed `openspec` or `hybrid` mode.
+- If you are unsure which mode to use, default to `none`.
+
+## Sub-Agent Context Rules
+
+Sub-agents launch with a fresh context and NO access to the orchestrator's instructions or memory protocol. The orchestrator controls what context they receive and sub-agents are responsible for persisting what they produce.
+
+### Who reads, who writes
+
+| Context | Who reads from backend | Who writes to backend |
+|---------|----------------------|----------------------|
+| Non-SDD (general task) | **Orchestrator** searches engram, passes summary in prompt | **Sub-agent** saves discoveries/decisions via `mem_save` |
+| SDD (phase with dependencies) | **Sub-agent** reads artifacts directly from backend | **Sub-agent** saves its artifact |
+| SDD (phase without dependencies, e.g. explore) | Nobody | **Sub-agent** saves its artifact |
+
+### Why this split
+
+- **Orchestrator reads for non-SDD**: It already has the engram protocol loaded. It knows what context is relevant.
+- **Sub-agents read for SDD**: SDD artifacts are large (specs, designs). The orchestrator should NOT inline them — it passes artifact references (topic keys) and the sub-agent retrieves the full content.
+- **Sub-agents always write**: They have the complete detail. Persist at the source.
+
+### Orchestrator prompt instructions for sub-agents
+
+When launching a sub-agent, the orchestrator MUST include persistence instructions in the prompt:
+
+**Non-SDD**:
+```
+PERSISTENCE (MANDATORY):
+If you make important discoveries, decisions, or fix bugs, you MUST save them
+to engram before returning:
+  mem_save(title: "{short description}", type: "{decision|bugfix|discovery|pattern}",
+           project: "nerbis-platform", content: "{What, Why, Where, Learned}")
+Do NOT return without saving what you learned.
+```
+
+**SDD (with dependencies)**:
+```
+Artifact store mode: engram
+Read these artifacts before starting (two-step — search returns truncated previews):
+  mem_search(query: "sdd/{change-name}/{type}", project: "nerbis-platform") → get ID
+  mem_get_observation(id: {id}) → full content (REQUIRED for SDD dependencies)
+
+PERSISTENCE (MANDATORY — do NOT skip):
+After completing your work, you MUST call:
+  mem_save(
+    title: "sdd/{change-name}/{artifact-type}",
+    topic_key: "sdd/{change-name}/{artifact-type}",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full artifact markdown}"
+  )
+If you return without calling mem_save, the next phase CANNOT find your artifact
+and the pipeline BREAKS.
+```
+
+**SDD (no dependencies)**:
+```
+Artifact store mode: engram
+
+PERSISTENCE (MANDATORY — do NOT skip):
+After completing your work, you MUST call:
+  mem_save(
+    title: "sdd/{change-name}/{artifact-type}",
+    topic_key: "sdd/{change-name}/{artifact-type}",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full artifact markdown}"
+  )
+If you return without calling mem_save, the next phase CANNOT find your artifact
+and the pipeline BREAKS.
+```
+
+## Skill Registry
+
+The skill registry is a catalog of all available skills that sub-agents read before starting any task. It is **infrastructure, not an SDD artifact** — it exists independently of any persistence mode.
+
+### Where the registry lives
+
+| Source | Location | Priority |
+|--------|----------|----------|
+| Engram | `topic_key: "skill-registry"` | Read FIRST (fast, cross-session) |
+| File | `.atl/skill-registry.md` | Fallback if engram not available |
+
+### Sub-agent skill loading protocol
+
+**EVERY sub-agent MUST check the skill registry as its FIRST step**, before starting any work:
+
+```
+1. Try engram first: mem_search(query: "skill-registry", project: "nerbis-platform")
+   → if found: mem_get_observation(id) → full registry
+2. If engram not available or not found: read .atl/skill-registry.md
+3. If neither exists: proceed without skills (not an error)
+4. From the registry, identify skills matching your task:
+   - Backend models/views? → load multi-tenancy
+   - Frontend components? → load shadcn, vercel-react-best-practices
+   - UI/UX review? → load web-design-guidelines
+5. Read those specific SKILL.md files
+6. Also read any project convention files listed in the registry
+7. THEN proceed with your actual task
+```
+
+The orchestrator MUST include this instruction in ALL sub-agent prompts:
+```
+SKILL LOADING (do this FIRST):
+Check for available skills:
+  1. Try: mem_search(query: "skill-registry", project: "nerbis-platform")
+  2. Fallback: read .atl/skill-registry.md
+Load and follow any skills relevant to your task.
+```
+
+## Detail Level
+
+The orchestrator may also pass `detail_level`: `concise | standard | deep`.
+This controls output verbosity but does NOT affect what gets persisted — always persist the full artifact.

--- a/.claude/skills/sdd-apply/SKILL.md
+++ b/.claude/skills/sdd-apply/SKILL.md
@@ -41,12 +41,12 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   8. `mem_get_observation(id: {tasks_id})` → full tasks
 
   **Mark tasks complete** (update the tasks artifact as you go):
-  ```
+  ```text
   mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
   ```
 
   **Save progress artifact**:
-  ```
+  ```text
   mem_save(
     title: "sdd/{change-name}/apply-progress",
     topic_key: "sdd/{change-name}/apply-progress",
@@ -85,7 +85,7 @@ Before writing ANY code:
 
 ### Step 3: Implement Tasks
 
-```
+```text
 FOR EACH TASK:
 ├── Read the task description
 ├── Read relevant spec scenarios (acceptance criteria)
@@ -180,4 +180,4 @@ If mode is `engram`:
 - NEVER implement tasks that weren't assigned to you
 - If you discover the design is wrong, NOTE IT — don't silently deviate
 - If a task is blocked, STOP and report back
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-apply/SKILL.md
+++ b/.claude/skills/sdd-apply/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: sdd-apply
+description: >
+  Implement tasks from the change, writing actual code following the specs and design.
+  Trigger: When the orchestrator launches you to implement one or more tasks from a change.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for IMPLEMENTATION. You receive specific tasks and implement them by writing actual code. You follow the specs and design strictly.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- The specific task(s) to implement (e.g., "Phase 1, tasks 1.1-1.3")
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact.**
+
+  **STEP A — SEARCH** (get IDs only):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "nerbis-platform")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "nerbis-platform")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "nerbis-platform")` → save ID
+  4. `mem_search(query: "sdd/{change-name}/tasks", project: "nerbis-platform")` → save ID (keep this ID for updates)
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+  5. `mem_get_observation(id: {proposal_id})` → full proposal
+  6. `mem_get_observation(id: {spec_id})` → full spec
+  7. `mem_get_observation(id: {design_id})` → full design
+  8. `mem_get_observation(id: {tasks_id})` → full tasks
+
+  **Mark tasks complete** (update the tasks artifact as you go):
+  ```
+  mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
+  ```
+
+  **Save progress artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/apply-progress",
+    topic_key: "sdd/{change-name}/apply-progress",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your implementation progress report}"
+  )
+  ```
+
+- If mode is `openspec`: Read and follow `.claude/skills/_shared/openspec-convention.md`. Update `tasks.md` with `[x]` marks.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return progress only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+From the registry, load skills matching your task:
+- Backend models/views → load `multi-tenancy` skill
+- Frontend components → load `shadcn`, `vercel-react-best-practices` skills
+- UI review → load `web-design-guidelines` skill
+
+### Step 2: Read Context
+
+Before writing ANY code:
+1. Read the specs — understand WHAT the code must do
+2. Read the design — understand HOW to structure the code
+3. Read existing code in affected files — understand current patterns
+4. Read `AGENTS.md` for code conventions
+
+### Step 3: Implement Tasks
+
+```
+FOR EACH TASK:
+├── Read the task description
+├── Read relevant spec scenarios (acceptance criteria)
+├── Read the design decisions (constraints)
+├── Read existing code patterns (match style)
+├── Write the code
+├── Mark task as complete [x]
+└── Note any issues or deviations
+```
+
+#### NERBIS Code Conventions (from AGENTS.md)
+
+**Backend (Python/Django):**
+- Type hints: `str | None`, `list[str]`, `dict[str, Any]` — NOT `Optional`, `List`, `Dict`
+- Models: inherit `TenantAwareModel`, use `TenantAwareManager`
+- Serializers: `ModelSerializer` with `exclude = ['tenant']`
+- Views: assign tenant in `perform_create(self, serializer): serializer.save(tenant=self.request.tenant)`
+- URLs: `/api/v1/{app}/{resource}/` with trailing slash
+- NEVER modify existing Django migrations
+
+**Frontend (Next.js/React):**
+- Server Components by default, `"use client"` only for interactivity
+- Context API for global state (AuthContext, CartContext, TenantContext, WebsiteContentContext)
+- API calls with `X-Tenant-Slug` header
+- shadcn/ui components: `npx shadcn@latest add {component}`
+- Tailwind utility-first, mobile-first
+
+### Step 4: Run Lint After Each Batch
+
+After implementing a batch of tasks:
+
+**Backend changes:**
+```bash
+ruff check backend/
+```
+
+**Frontend changes:**
+```bash
+cd frontend && npm run lint
+```
+
+Fix any issues before proceeding to the next batch.
+
+### Step 5: Mark Tasks Complete
+
+Update tasks — change `- [ ]` to `- [x]` for completed tasks.
+
+### Step 6: Persist Progress
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+1. Update tasks artifact: `mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")`
+2. Save progress: `mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", ...)`
+
+### Step 7: Return Summary
+
+```markdown
+## Implementation Progress
+
+**Change**: {change-name}
+
+### Completed Tasks
+- [x] {task description}
+
+### Files Changed
+| File | Action | What Was Done |
+|------|--------|---------------|
+| `path/to/file.ext` | Created | {brief description} |
+
+### Lint Results
+- Backend: {ruff result}
+- Frontend: {eslint result}
+
+### Deviations from Design
+{List or "None — implementation matches design."}
+
+### Remaining Tasks
+- [ ] {next task}
+
+### Status
+{N}/{total} tasks complete. {Ready for next batch / Ready for verify / Blocked by X}
+```
+
+## Rules
+
+- ALWAYS read specs before implementing — specs are your acceptance criteria
+- ALWAYS follow the design decisions — don't freelance a different approach
+- ALWAYS match existing code patterns and conventions
+- ALWAYS run lint after each batch (`ruff check backend/`, `npm run lint`)
+- NEVER modify existing Django migrations
+- NEVER implement tasks that weren't assigned to you
+- If you discover the design is wrong, NOTE IT — don't silently deviate
+- If a task is blocked, STOP and report back
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-archive/SKILL.md
+++ b/.claude/skills/sdd-archive/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: sdd-archive
+description: >
+  Sync delta specs to main specs and archive a completed change.
+  Trigger: When the orchestrator launches you to archive a change after implementation and verification.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for ARCHIVING. You close the SDD cycle by creating an archive report with full lineage. If using openspec mode, you also merge delta specs into main specs and move the change folder to archive.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact.**
+
+  **STEP A — SEARCH** (get IDs only):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "nerbis-platform")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "nerbis-platform")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "nerbis-platform")` → save ID
+  4. `mem_search(query: "sdd/{change-name}/tasks", project: "nerbis-platform")` → save ID
+  5. `mem_search(query: "sdd/{change-name}/verify-report", project: "nerbis-platform")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+  6-10. `mem_get_observation(id: {id})` for each artifact
+
+  **Record all observation IDs** — include them in the archive report for full traceability.
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/archive-report",
+    topic_key: "sdd/{change-name}/archive-report",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your archive report with all observation IDs for lineage}"
+  )
+  ```
+
+- If mode is `openspec`: Perform merge and archive folder moves.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return closure summary only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+### Step 2: Verify Prerequisites
+
+Before archiving, check the verification report verdict:
+- If verdict is **FAIL**: STOP. Do NOT archive. Report back to orchestrator.
+- If verdict is **PASS** or **PASS WITH WARNINGS**: proceed.
+
+### Step 3: Sync Delta Specs (openspec/hybrid only)
+
+**IF mode is `engram`:** Skip — artifacts live in Engram only.
+**IF mode is `none`:** Skip.
+
+**IF mode is `openspec` or `hybrid`:** For each delta spec, merge into main specs:
+- ADDED Requirements → Append to main spec
+- MODIFIED Requirements → Replace matching requirement
+- REMOVED Requirements → Delete from main spec
+
+### Step 4: Move to Archive (openspec/hybrid only)
+
+```
+openspec/changes/{change-name}/
+  → openspec/changes/archive/YYYY-MM-DD-{change-name}/
+```
+
+### Step 5: NERBIS-Specific Actions
+
+1. **Update `docs/SDD.md`** if the change introduced architectural modifications (new models, new API endpoints, new frontend routes). Suggest specific sections to update.
+
+2. **Suggest PR creation** to `develop` branch:
+   ```
+   Recommend: Create PR with title following conventional commits
+   Branch: feature/{change-name} or fix/{change-name}
+   Target: develop
+   Include Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   ```
+
+3. **Save learnings to Engram** if any discoveries/patterns were found during the SDD cycle:
+   ```
+   mem_save(title: "{learning}", type: "discovery", project: "nerbis-platform", content: "...")
+   ```
+
+### Step 6: Persist Archive Report
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/archive-report",
+  topic_key: "sdd/{change-name}/archive-report",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{archive report with all observation IDs}"
+)
+```
+
+### Step 7: Return Summary
+
+```markdown
+## Change Archived
+
+**Change**: {change-name}
+
+### Artifact Lineage (Engram observation IDs)
+| Artifact | Observation ID |
+|----------|---------------|
+| explore | #{id} |
+| proposal | #{id} |
+| spec | #{id} |
+| design | #{id} |
+| tasks | #{id} |
+| verify-report | #{id} |
+| archive-report | #{id} |
+
+### NERBIS Actions
+- SDD.md update needed: {Yes — sections X, Y / No}
+- PR suggestion: {branch name} → develop
+
+### SDD Cycle Complete
+The change has been fully planned, implemented, verified, and archived.
+Ready for the next change.
+```
+
+## Rules
+
+- NEVER archive a change with CRITICAL issues in its verification report
+- If using openspec, ALWAYS sync delta specs BEFORE moving to archive
+- When merging, PRESERVE requirements not mentioned in the delta
+- Use ISO date format (YYYY-MM-DD) for archive folder prefix
+- The archive is an AUDIT TRAIL — never delete or modify archived changes
+- ALWAYS suggest SDD.md updates for architectural changes
+- ALWAYS suggest PR creation to develop
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-archive/SKILL.md
+++ b/.claude/skills/sdd-archive/SKILL.md
@@ -40,7 +40,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   **Record all observation IDs** — include them in the archive report for full traceability.
 
   **Save your artifact**:
-  ```
+  ```text
   mem_save(
     title: "sdd/{change-name}/archive-report",
     topic_key: "sdd/{change-name}/archive-report",
@@ -82,7 +82,7 @@ Before archiving, check the verification report verdict:
 
 ### Step 4: Move to Archive (openspec/hybrid only)
 
-```
+```text
 openspec/changes/{change-name}/
   → openspec/changes/archive/YYYY-MM-DD-{change-name}/
 ```
@@ -92,7 +92,7 @@ openspec/changes/{change-name}/
 1. **Update `docs/SDD.md`** if the change introduced architectural modifications (new models, new API endpoints, new frontend routes). Suggest specific sections to update.
 
 2. **Suggest PR creation** to `develop` branch:
-   ```
+   ```text
    Recommend: Create PR with title following conventional commits
    Branch: feature/{change-name} or fix/{change-name}
    Target: develop
@@ -100,7 +100,7 @@ openspec/changes/{change-name}/
    ```
 
 3. **Save learnings to Engram** if any discoveries/patterns were found during the SDD cycle:
-   ```
+   ```text
    mem_save(title: "{learning}", type: "discovery", project: "nerbis-platform", content: "...")
    ```
 
@@ -109,7 +109,7 @@ openspec/changes/{change-name}/
 **This step is MANDATORY — do NOT skip it.**
 
 If mode is `engram`:
-```
+```text
 mem_save(
   title: "sdd/{change-name}/archive-report",
   topic_key: "sdd/{change-name}/archive-report",
@@ -155,4 +155,4 @@ Ready for the next change.
 - The archive is an AUDIT TRAIL — never delete or modify archived changes
 - ALWAYS suggest SDD.md updates for architectural changes
 - ALWAYS suggest PR creation to develop
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-design/SKILL.md
+++ b/.claude/skills/sdd-design/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: sdd-design
+description: >
+  Create technical design document with architecture decisions and approach.
+  Trigger: When the orchestrator launches you to write or update the technical design for a change.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for TECHNICAL DESIGN. You take the proposal and specs, then produce a design document that captures HOW the change will be implemented — architecture decisions, data flow, file changes, and technical rationale.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact.**
+
+  **STEP A — SEARCH** (get IDs only):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "nerbis-platform")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "nerbis-platform")` → save ID (optional — may not exist if running in parallel with sdd-spec)
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each found):
+  3. `mem_get_observation(id: {proposal_id})` → full proposal content (REQUIRED)
+  4. If spec found: `mem_get_observation(id: {spec_id})` → full spec content
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/design",
+    topic_key: "sdd/{change-name}/design",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full design markdown}"
+  )
+  ```
+
+- If mode is `openspec`: Read and follow `.claude/skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return result only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+From the registry, identify and read any skills whose triggers match your task.
+
+### Step 2: Read the Codebase
+
+Before designing, read the actual code that will be affected:
+- Entry points and module structure
+- Existing patterns and conventions
+- Dependencies and interfaces
+- Test infrastructure
+
+### Step 3: Write Design Document
+
+**IF mode is `engram` or `none`:** Compose the design content in memory.
+
+#### Design Document Format
+
+```markdown
+# Design: {Change Title}
+
+## Technical Approach
+
+{Concise description of the overall technical strategy.}
+
+## Architecture Decisions
+
+### Decision: {Decision Title}
+
+**Choice**: {What we chose}
+**Alternatives considered**: {What we rejected}
+**Rationale**: {Why this choice over alternatives}
+
+## Data Flow
+
+{Describe how data moves through the system for this change.}
+
+    Component A ──→ Component B ──→ Component C
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `path/to/new-file.ext` | Create | {What this file does} |
+| `path/to/existing.ext` | Modify | {What changes and why} |
+
+## Interfaces / Contracts
+
+{Define any new interfaces, API contracts, type definitions, or data structures.}
+
+## NERBIS-Specific Design
+
+### Backend Models
+{For new models: inherit from TenantAwareModel, use TenantAwareManager}
+{For new fields: type hints modernos (str | None, not Optional[str])}
+
+### API Endpoints
+{URL pattern: /api/v1/{app}/{resource}/}
+{Serializer: ModelSerializer with exclude=['tenant']}
+{View: perform_create assigns tenant from request.tenant}
+
+### Frontend Components
+{Server Components by default, "use client" only when interactive}
+{Context API usage: which providers to read/write}
+{shadcn/ui components to use}
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit (backend) | {What} | Pytest with tenant fixtures |
+| Unit (frontend) | {What} | {How} |
+| Integration | {What} | {How} |
+
+## Migration / Rollout
+
+{Data migration plan, feature flags, or phased rollout.}
+{If not applicable: "No migration required."}
+
+## Open Questions
+
+- [ ] {Any unresolved technical question}
+```
+
+### Step 4: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/design",
+  topic_key: "sdd/{change-name}/design",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{your full design markdown from Step 3}"
+)
+```
+
+If you skip this step, sdd-tasks will NOT be able to find your design and the pipeline BREAKS.
+
+### Step 5: Return Summary
+
+```markdown
+## Design Created
+
+**Change**: {change-name}
+
+### Summary
+- **Approach**: {one-line technical approach}
+- **Key Decisions**: {N decisions documented}
+- **Files Affected**: {N new, M modified, K deleted}
+- **Testing Strategy**: {unit/integration coverage planned}
+
+### Open Questions
+{List any unresolved questions, or "None"}
+
+### Next Step
+Ready for tasks (sdd-tasks).
+```
+
+## Rules
+
+- ALWAYS read the actual codebase before designing — never guess
+- Every decision MUST have a rationale (the "why")
+- Include concrete file paths, not abstract descriptions
+- Use the project's ACTUAL patterns, not generic best practices
+- New backend models MUST inherit TenantAwareModel (see `.claude/skills/multi-tenancy/SKILL.md`)
+- Frontend components should be Server Components by default
+- Reference `docs/SDD.md` for architectural context
+- If you have open questions that BLOCK the design, say so clearly
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-design/SKILL.md
+++ b/.claude/skills/sdd-design/SKILL.md
@@ -36,7 +36,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   4. If spec found: `mem_get_observation(id: {spec_id})` → full spec content
 
   **Save your artifact**:
-  ```
+  ```text
   mem_save(
     title: "sdd/{change-name}/design",
     topic_key: "sdd/{change-name}/design",
@@ -149,7 +149,7 @@ Before designing, read the actual code that will be affected:
 **This step is MANDATORY — do NOT skip it.**
 
 If mode is `engram`:
-```
+```text
 mem_save(
   title: "sdd/{change-name}/design",
   topic_key: "sdd/{change-name}/design",
@@ -195,4 +195,4 @@ Ready for tasks (sdd-tasks).
 - Frontend components should be Server Components by default
 - Reference `docs/SDD.md` for architectural context
 - If you have open questions that BLOCK the design, say so clearly
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-design/SKILL.md
+++ b/.claude/skills/sdd-design/SKILL.md
@@ -72,7 +72,9 @@ Before designing, read the actual code that will be affected:
 
 ### Step 3: Write Design Document
 
-**IF mode is `engram` or `none`:** Compose the design content in memory.
+**IF mode is `openspec` or `hybrid`:** Create `openspec/changes/{change-name}/design.md` with the content below.
+
+**IF mode is `engram` or `none`:** Compose the design content in memory — you will persist it in Step 4.
 
 #### Design Document Format
 
@@ -156,6 +158,10 @@ mem_save(
   content: "{your full design markdown from Step 3}"
 )
 ```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 3.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
 
 If you skip this step, sdd-tasks will NOT be able to find your design and the pipeline BREAKS.
 

--- a/.claude/skills/sdd-explore/SKILL.md
+++ b/.claude/skills/sdd-explore/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: sdd-explore
+description: >
+  Explore and investigate ideas before committing to a change.
+  Trigger: When the orchestrator launches you to think through a feature, investigate the codebase, or clarify requirements.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for EXPLORATION. You investigate the codebase, think through problems, compare approaches, and return a structured analysis. By default you only research and report back; only persist an artifact when this exploration is tied to a named change.
+
+## What You Receive
+
+The orchestrator will give you:
+- A topic or feature to explore
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **Read context** (optional — load project context if available):
+  1. `mem_search(query: "sdd-init/nerbis-platform", project: "nerbis-platform")` → get observation ID
+  2. `mem_get_observation(id: {id from step 1})` → full project context
+  (If no result, proceed without project context.)
+
+  **Save your artifact**:
+  - If tied to a named change:
+    ```
+    mem_save(
+      title: "sdd/{change-name}/explore",
+      topic_key: "sdd/{change-name}/explore",
+      type: "architecture",
+      project: "nerbis-platform",
+      content: "{your full exploration markdown}"
+    )
+    ```
+  - If standalone (no change name):
+    ```
+    mem_save(
+      title: "sdd/explore/{topic-slug}",
+      topic_key: "sdd/explore/{topic-slug}",
+      type: "architecture",
+      project: "nerbis-platform",
+      content: "{your full exploration markdown}"
+    )
+    ```
+
+- If mode is `openspec`: Read and follow `.claude/skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return result only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+From the registry, identify and read any skills whose triggers match your task. Also read any project convention files listed in the registry.
+
+### Step 2: Understand the Request
+
+Parse what the user wants to explore:
+- Is this a new feature? A bug fix? A refactor?
+- What domain does it touch?
+
+### Step 3: Investigate the Codebase
+
+Read relevant code to understand:
+- Current architecture and patterns
+- Files and modules that would be affected
+- Existing behavior that relates to the request
+- Potential constraints or risks
+
+```
+INVESTIGATE:
+├── Read entry points and key files
+├── Search for related functionality
+├── Check existing tests (if any)
+├── Look for patterns already in use
+└── Identify dependencies and coupling
+```
+
+#### NERBIS-Specific Checks
+
+- **Multi-tenancy**: If the change touches backend models, views, or serializers, check:
+  - Does it use TenantAwareModel? (read `.claude/skills/multi-tenancy/SKILL.md`)
+  - Are there cross-tenant query risks?
+  - Is tenant filtering via TenantAwareManager in place?
+- **Frontend Context**: If it touches frontend, check which Context providers are affected:
+  - AuthContext, CartContext, TenantContext, WebsiteContentContext
+- **Database schema**: If relevant, use PostgreSQL MCP to query the real schema (`gravprod_db`)
+
+### Step 4: Analyze Options
+
+If there are multiple approaches, compare them:
+
+| Approach | Pros | Cons | Complexity |
+|----------|------|------|------------|
+| Option A | ... | ... | Low/Med/High |
+| Option B | ... | ... | Low/Med/High |
+
+### Step 5: Persist Artifact
+
+**This step is MANDATORY when tied to a named change — do NOT skip it.**
+
+If mode is `engram` and this exploration is tied to a change:
+```
+mem_save(
+  title: "sdd/{change-name}/explore",
+  topic_key: "sdd/{change-name}/explore",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{your full exploration markdown from Step 4}"
+)
+```
+
+If you skip this step, sdd-propose will not have your exploration context.
+
+### Step 6: Return Structured Analysis
+
+Return EXACTLY this format to the orchestrator:
+
+```markdown
+## Exploration: {topic}
+
+### Current State
+{How the system works today relevant to this topic}
+
+### Affected Areas
+- `path/to/file.ext` — {why it's affected}
+
+### Multi-Tenancy Impact
+{If backend is affected: tenant isolation concerns, TenantAwareModel usage, cross-tenant risks}
+{If not applicable: "No multi-tenancy impact — change is frontend-only" or similar}
+
+### Approaches
+1. **{Approach name}** — {brief description}
+   - Pros: {list}
+   - Cons: {list}
+   - Effort: {Low/Medium/High}
+
+2. **{Approach name}** — {brief description}
+   - Pros: {list}
+   - Cons: {list}
+   - Effort: {Low/Medium/High}
+
+### Recommendation
+{Your recommended approach and why}
+
+### Risks
+- {Risk 1}
+- {Risk 2}
+
+### Ready for Proposal
+{Yes/No — and what the orchestrator should tell the user}
+```
+
+## Rules
+
+- DO NOT modify any existing code or files
+- ALWAYS read real code, never guess about the codebase
+- Keep your analysis CONCISE
+- If you can't find enough information, say so clearly
+- If the request is too vague to explore, say what clarification is needed
+- ALWAYS check multi-tenancy impact when the change touches backend code
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-explore/SKILL.md
+++ b/.claude/skills/sdd-explore/SKILL.md
@@ -32,7 +32,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
 
   **Save your artifact**:
   - If tied to a named change:
-    ```
+    ```text
     mem_save(
       title: "sdd/{change-name}/explore",
       topic_key: "sdd/{change-name}/explore",
@@ -42,7 +42,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
     )
     ```
   - If standalone (no change name):
-    ```
+    ```text
     mem_save(
       title: "sdd/explore/{topic-slug}",
       topic_key: "sdd/explore/{topic-slug}",
@@ -82,7 +82,7 @@ Read relevant code to understand:
 - Existing behavior that relates to the request
 - Potential constraints or risks
 
-```
+```text
 INVESTIGATE:
 ├── Read entry points and key files
 ├── Search for related functionality
@@ -115,7 +115,7 @@ If there are multiple approaches, compare them:
 **This step is MANDATORY when tied to a named change — do NOT skip it.**
 
 If mode is `engram` and this exploration is tied to a change:
-```
+```text
 mem_save(
   title: "sdd/{change-name}/explore",
   topic_key: "sdd/{change-name}/explore",
@@ -178,4 +178,4 @@ Return your analysis using this format:
 - If you can't find enough information, say so clearly
 - If the request is too vague to explore, say what clarification is needed
 - ALWAYS check multi-tenancy impact when the change touches backend code
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-explore/SKILL.md
+++ b/.claude/skills/sdd-explore/SKILL.md
@@ -125,11 +125,15 @@ mem_save(
 )
 ```
 
+If mode is `openspec` or `hybrid`: Create `openspec/changes/{change-name}/explore.md` with the exploration content.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
 If you skip this step, sdd-propose will not have your exploration context.
 
 ### Step 6: Return Structured Analysis
 
-Return EXACTLY this format to the orchestrator:
+Return your analysis using this format:
 
 ```markdown
 ## Exploration: {topic}

--- a/.claude/skills/sdd-init/SKILL.md
+++ b/.claude/skills/sdd-init/SKILL.md
@@ -21,7 +21,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   Do NOT create `openspec/` directory.
 
   **Save project context**:
-  ```
+  ```text
   mem_save(
     title: "sdd-init/nerbis-platform",
     topic_key: "sdd-init/nerbis-platform",
@@ -64,7 +64,7 @@ Read the project to understand:
 
 If mode resolves to `openspec`, create this directory structure:
 
-```
+```text
 openspec/
 ├── config.yaml
 ├── specs/
@@ -90,7 +90,7 @@ Follow the same logic as `.claude/skills/skill-registry/SKILL.md`:
 **This step is MANDATORY — do NOT skip it.**
 
 If mode is `engram`:
-```
+```text
 mem_save(
   title: "sdd-init/nerbis-platform",
   topic_key: "sdd-init/nerbis-platform",
@@ -102,7 +102,7 @@ mem_save(
 
 ### Step 6: Return Summary
 
-```
+```markdown
 ## SDD Initialized
 
 **Project**: nerbis-platform
@@ -130,4 +130,4 @@ Ready for /sdd-explore <topic> or /sdd-new <change-name>.
 - ALWAYS detect the real tech stack, don't guess
 - If the project already has an `openspec/` directory, report what exists
 - Keep context CONCISE — no more than 10 lines
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-init/SKILL.md
+++ b/.claude/skills/sdd-init/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: sdd-init
+description: >
+  Initialize Spec-Driven Development context in the NERBIS project. Detects stack, conventions, and bootstraps the active persistence backend.
+  Trigger: When user wants to initialize SDD in a project, or says "sdd init", "iniciar sdd".
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in the NERBIS project. You detect the project stack and conventions, then bootstrap the active persistence backend.
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+  Do NOT create `openspec/` directory.
+
+  **Save project context**:
+  ```
+  mem_save(
+    title: "sdd-init/nerbis-platform",
+    topic_key: "sdd-init/nerbis-platform",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{detected project context markdown}"
+  )
+  ```
+  `topic_key` enables upserts — re-running init updates the existing context.
+
+- If mode is `openspec`: Read and follow `.claude/skills/_shared/openspec-convention.md`. Run full bootstrap.
+- If mode is `hybrid`: Follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
+- If mode is `none`: Return detected context without writing project files.
+
+## What to Do
+
+### Step 1: Detect Project Context
+
+Read the project to understand:
+
+**Backend (Django 5 + DRF):**
+- Apps in `backend/` (check for models.py in each app directory)
+- Multi-tenancy setup: `backend/core/models.py` (TenantAwareModel), `backend/middleware/tenant.py`
+- Test framework: Pytest with `backend/settings_test.py`
+- Lint: Ruff (`ruff check backend/`)
+
+**Frontend (Next.js 16 + React 19):**
+- Routes in `frontend/src/app/`
+- Context providers: AuthContext, CartContext, TenantContext, WebsiteContentContext
+- Components: shadcn/ui
+- Lint: ESLint (`cd frontend && npm run lint`)
+
+**Infrastructure:**
+- CI: GitHub Actions (backend + frontend pipelines)
+- Git: conventional commits with commitlint + husky
+- CodeRabbit: `.coderabbit.yaml`
+- Release Please: semantic versioning on push to main
+
+### Step 2: Initialize Persistence Backend
+
+If mode resolves to `openspec`, create this directory structure:
+
+```
+openspec/
+├── config.yaml
+├── specs/
+└── changes/
+    └── archive/
+```
+
+### Step 3: Generate Config (openspec mode)
+
+Based on detected context, create `openspec/config.yaml` following the template in `.claude/skills/_shared/openspec-convention.md`.
+
+### Step 4: Build Skill Registry
+
+Follow the same logic as `.claude/skills/skill-registry/SKILL.md`:
+
+1. Scan `.claude/skills/` for non-SDD skills (multi-tenancy, shadcn, vercel-react-best-practices, web-design-guidelines)
+2. Scan project root for conventions (AGENTS.md, CLAUDE.md, .cursorrules, docs/SDD.md)
+3. **ALWAYS write `.atl/skill-registry.md`**
+4. If engram is available, also save: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "nerbis-platform", content: "{registry}")`
+
+### Step 5: Persist Project Context
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd-init/nerbis-platform",
+  topic_key: "sdd-init/nerbis-platform",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{your detected project context from Steps 1-4}"
+)
+```
+
+### Step 6: Return Summary
+
+```
+## SDD Initialized
+
+**Project**: nerbis-platform
+**Stack**: Django 5 + DRF / Next.js 16 + React 19
+**Persistence**: {engram | openspec | hybrid | none}
+
+### Context Saved
+{Details of what was persisted and where}
+
+### Skills Found
+| Skill | Path |
+|-------|------|
+| multi-tenancy | .claude/skills/multi-tenancy/SKILL.md |
+| shadcn | .claude/skills/shadcn/SKILL.md |
+| vercel-react-best-practices | .claude/skills/vercel-react-best-practices/SKILL.md |
+| web-design-guidelines | .claude/skills/web-design-guidelines/SKILL.md |
+
+### Next Steps
+Ready for /sdd-explore <topic> or /sdd-new <change-name>.
+```
+
+## Rules
+
+- NEVER create placeholder spec files — specs are created via sdd-spec during a change
+- ALWAYS detect the real tech stack, don't guess
+- If the project already has an `openspec/` directory, report what exists
+- Keep context CONCISE — no more than 10 lines
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-propose/SKILL.md
+++ b/.claude/skills/sdd-propose/SKILL.md
@@ -33,7 +33,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   4. If found: `mem_get_observation(id: {id})` → full project context
 
   **Save your artifact**:
-  ```
+  ```text
   mem_save(
     title: "sdd/{change-name}/proposal",
     topic_key: "sdd/{change-name}/proposal",
@@ -62,7 +62,7 @@ From the registry, identify and read any skills whose triggers match your task. 
 ### Step 2: Create Change Directory (openspec/hybrid only)
 
 **IF mode is `openspec` or `hybrid`:** create the change folder:
-```
+```text
 openspec/changes/{change-name}/
 └── proposal.md
 ```
@@ -143,7 +143,7 @@ openspec/changes/{change-name}/
 **This step is MANDATORY — do NOT skip it.**
 
 If mode is `engram`:
-```
+```text
 mem_save(
   title: "sdd/{change-name}/proposal",
   topic_key: "sdd/{change-name}/proposal",
@@ -185,4 +185,4 @@ Ready for specs (sdd-spec) and design (sdd-design) — these can run in parallel
 - Use concrete file paths in "Affected Areas" when possible
 - ALWAYS include "Multi-Tenancy Impact" section when backend code is in scope
 - ALWAYS include "Module Impact" section when tenant feature flags might be affected
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-propose/SKILL.md
+++ b/.claude/skills/sdd-propose/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: sdd-propose
+description: >
+  Create a change proposal with intent, scope, and approach.
+  Trigger: When the orchestrator launches you to create or update a proposal for a change.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for creating PROPOSALS. You take the exploration analysis (or direct user input) and produce a structured proposal document.
+
+## What You Receive
+
+From the orchestrator:
+- Change name (e.g., "add-product-reviews")
+- Exploration analysis (from sdd-explore) OR direct user description
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **Read dependencies** (two-step — search returns truncated previews):
+  1. `mem_search(query: "sdd/{change-name}/explore", project: "nerbis-platform")` → get observation ID (optional — may not exist)
+  2. If found: `mem_get_observation(id: {id})` → full exploration content
+  3. `mem_search(query: "sdd-init/nerbis-platform", project: "nerbis-platform")` → project context (optional)
+  4. If found: `mem_get_observation(id: {id})` → full project context
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/proposal",
+    topic_key: "sdd/{change-name}/proposal",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full proposal markdown}"
+  )
+  ```
+
+- If mode is `openspec`: Read and follow `.claude/skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return result only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+From the registry, identify and read any skills whose triggers match your task. Also read any project convention files listed in the registry.
+
+### Step 2: Create Change Directory (openspec/hybrid only)
+
+**IF mode is `openspec` or `hybrid`:** create the change folder:
+```
+openspec/changes/{change-name}/
+└── proposal.md
+```
+
+**IF mode is `engram` or `none`:** Skip this step.
+
+### Step 3: Read Existing Specs (openspec/hybrid only)
+
+**IF mode is `openspec` or `hybrid`:** Read `openspec/specs/` if relevant specs exist.
+
+### Step 4: Write Proposal
+
+```markdown
+# Proposal: {Change Title}
+
+## Intent
+
+{What problem are we solving? Why does this change need to happen?}
+
+## Scope
+
+### In Scope
+- {Concrete deliverable 1}
+- {Concrete deliverable 2}
+
+### Out of Scope
+- {What we're explicitly NOT doing}
+
+## Approach
+
+{High-level technical approach. Reference the recommended approach from exploration if available.}
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `path/to/area` | New/Modified/Removed | {What changes} |
+
+## Multi-Tenancy Impact
+
+{Required if ANY backend model, view, or serializer is in scope.}
+- New models: {Will they inherit TenantAwareModel?}
+- Queries: {Any cross-tenant query risk?}
+- Permissions: {Which permission classes apply?}
+- Tests: {Tenant isolation test scenarios needed?}
+
+{If change is frontend-only: "No multi-tenancy impact — frontend-only change."}
+
+## Module Impact
+
+{Required if change affects feature flags in Tenant model.}
+- Affected modules: {has_website, has_shop, has_bookings, etc.}
+
+{If no module flags affected: "No module impact."}
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| {Risk description} | Low/Med/High | {How we mitigate} |
+
+## Rollback Plan
+
+{How to revert if something goes wrong. Be specific.}
+
+## Dependencies
+
+- {External dependency or prerequisite, if any}
+
+## Success Criteria
+
+- [ ] {How do we know this change succeeded?}
+- [ ] {Measurable outcome}
+```
+
+### Step 5: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/proposal",
+  topic_key: "sdd/{change-name}/proposal",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{your full proposal markdown from Step 4}"
+)
+```
+
+If you skip this step, the next phase (sdd-spec) will NOT be able to find your proposal and the pipeline BREAKS.
+
+### Step 6: Return Summary
+
+```markdown
+## Proposal Created
+
+**Change**: {change-name}
+
+### Summary
+- **Intent**: {one-line summary}
+- **Scope**: {N deliverables in, M items deferred}
+- **Approach**: {one-line approach}
+- **Risk Level**: {Low/Medium/High}
+- **Multi-Tenancy Impact**: {Yes/No}
+
+### Next Step
+Ready for specs (sdd-spec) and design (sdd-design) — these can run in parallel.
+```
+
+## Rules
+
+- Keep the proposal CONCISE — it's a thinking tool, not a novel
+- Every proposal MUST have a rollback plan
+- Every proposal MUST have success criteria
+- Use concrete file paths in "Affected Areas" when possible
+- ALWAYS include "Multi-Tenancy Impact" section when backend code is in scope
+- ALWAYS include "Module Impact" section when tenant feature flags might be affected
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-propose/SKILL.md
+++ b/.claude/skills/sdd-propose/SKILL.md
@@ -153,6 +153,10 @@ mem_save(
 )
 ```
 
+If mode is `openspec` or `hybrid`: Write the proposal content to `openspec/changes/{change-name}/proposal.md` (directory was created in Step 2).
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
 If you skip this step, the next phase (sdd-spec) will NOT be able to find your proposal and the pipeline BREAKS.
 
 ### Step 6: Return Summary

--- a/.claude/skills/sdd-spec/SKILL.md
+++ b/.claude/skills/sdd-spec/SKILL.md
@@ -36,7 +36,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   **DO NOT use search previews as source material.**
 
   **Save your artifact**:
-  ```
+  ```text
   mem_save(
     title: "sdd/{change-name}/spec",
     topic_key: "sdd/{change-name}/spec",
@@ -130,7 +130,7 @@ When the change touches frontend code, specs SHOULD include:
 **This step is MANDATORY — do NOT skip it.**
 
 If mode is `engram`:
-```
+```text
 mem_save(
   title: "sdd/{change-name}/spec",
   topic_key: "sdd/{change-name}/spec",
@@ -177,7 +177,7 @@ Ready for design (sdd-design). If design already exists, ready for tasks (sdd-ta
 - Keep scenarios TESTABLE — someone should be able to write an automated test from each one
 - DO NOT include implementation details — specs describe WHAT, not HOW
 - ALWAYS include tenant isolation requirements when touching backend models/views
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`
 
 ## RFC 2119 Keywords Quick Reference
 

--- a/.claude/skills/sdd-spec/SKILL.md
+++ b/.claude/skills/sdd-spec/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: sdd-spec
+description: >
+  Write specifications with requirements and scenarios (delta specs for changes).
+  Trigger: When the orchestrator launches you to write or update specs for a change.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for writing SPECIFICATIONS. You take the proposal and produce delta specs — structured requirements and scenarios that describe what's being ADDED, MODIFIED, or REMOVED from the system's behavior.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact.**
+
+  **STEP A — SEARCH** (get IDs only):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "nerbis-platform")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory):
+  2. `mem_get_observation(id: {proposal_id})` → full proposal content (REQUIRED)
+
+  **DO NOT use search previews as source material.**
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/spec",
+    topic_key: "sdd/{change-name}/spec",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full spec markdown — all domains concatenated}"
+  )
+  ```
+
+- If mode is `openspec`: Read and follow `.claude/skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return result only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+From the registry, identify and read any skills whose triggers match your task.
+
+### Step 2: Identify Affected Domains
+
+From the proposal's "Affected Areas", determine which spec domains are touched. Group changes by domain (e.g., `ecommerce/`, `bookings/`, `auth/`, `websites/`).
+
+### Step 3: Write Delta Specs
+
+**IF mode is `engram` or `none`:** Compose the spec content in memory.
+
+#### Delta Spec Format
+
+```markdown
+# Delta for {Domain}
+
+## ADDED Requirements
+
+### Requirement: {Requirement Name}
+
+{Description using RFC 2119 keywords: MUST, SHALL, SHOULD, MAY}
+
+The system {MUST/SHALL/SHOULD} {do something specific}.
+
+#### Scenario: {Happy path scenario}
+
+- GIVEN {precondition}
+- WHEN {action}
+- THEN {expected outcome}
+- AND {additional outcome, if any}
+
+#### Scenario: {Edge case scenario}
+
+- GIVEN {precondition}
+- WHEN {action}
+- THEN {expected outcome}
+
+## MODIFIED Requirements
+
+### Requirement: {Existing Requirement Name}
+
+{New description — replaces the existing one}
+(Previously: {what it was before})
+
+## REMOVED Requirements
+
+### Requirement: {Requirement Being Removed}
+
+(Reason: {why this requirement is being deprecated/removed})
+```
+
+#### NERBIS-Specific Spec Rules
+
+When the change touches backend code, specs MUST include:
+
+- **Tenant isolation**: "The system MUST filter all queries by the current tenant"
+- **Permission classes**: Reference which apply (`IsTenantUser`, `IsTenantAdmin`, `IsAuthenticated`)
+- **API endpoints**: Specify the URL pattern (`/api/v1/{app}/{resource}/`)
+- **Header requirement**: "The system MUST require `X-Tenant-Slug` header for tenant detection"
+
+When the change touches frontend code, specs SHOULD include:
+- **Context providers**: Which context is read/written (AuthContext, CartContext, etc.)
+- **Component behavior**: User interaction scenarios
+
+### Step 4: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/spec",
+  topic_key: "sdd/{change-name}/spec",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{your full spec markdown — all domains concatenated}"
+)
+```
+
+If you skip this step, sdd-tasks will NOT be able to find your specs and the pipeline BREAKS.
+
+### Step 5: Return Summary
+
+```markdown
+## Specs Created
+
+**Change**: {change-name}
+
+### Specs Written
+| Domain | Type | Requirements | Scenarios |
+|--------|------|-------------|-----------|
+| {domain} | Delta/New | {N added, M modified, K removed} | {total scenarios} |
+
+### Coverage
+- Happy paths: {covered/missing}
+- Edge cases: {covered/missing}
+- Error states: {covered/missing}
+- Tenant isolation: {covered/not applicable}
+
+### Next Step
+Ready for design (sdd-design). If design already exists, ready for tasks (sdd-tasks).
+```
+
+## Rules
+
+- ALWAYS use Given/When/Then format for scenarios
+- ALWAYS use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+- Every requirement MUST have at least ONE scenario
+- Include both happy path AND edge case scenarios
+- Keep scenarios TESTABLE — someone should be able to write an automated test from each one
+- DO NOT include implementation details — specs describe WHAT, not HOW
+- ALWAYS include tenant isolation requirements when touching backend models/views
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+
+## RFC 2119 Keywords Quick Reference
+
+| Keyword | Meaning |
+|---------|---------|
+| **MUST / SHALL** | Absolute requirement |
+| **MUST NOT / SHALL NOT** | Absolute prohibition |
+| **SHOULD** | Recommended, but exceptions may exist |
+| **SHOULD NOT** | Not recommended, but may be acceptable |
+| **MAY** | Optional |

--- a/.claude/skills/sdd-spec/SKILL.md
+++ b/.claude/skills/sdd-spec/SKILL.md
@@ -68,7 +68,9 @@ From the proposal's "Affected Areas", determine which spec domains are touched. 
 
 ### Step 3: Write Delta Specs
 
-**IF mode is `engram` or `none`:** Compose the spec content in memory.
+**IF mode is `openspec` or `hybrid`:** Create `openspec/changes/{change-name}/spec.md` with the content below.
+
+**IF mode is `engram` or `none`:** Compose the spec content in memory — you will persist it in Step 4.
 
 #### Delta Spec Format
 
@@ -137,6 +139,10 @@ mem_save(
   content: "{your full spec markdown — all domains concatenated}"
 )
 ```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 3.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
 
 If you skip this step, sdd-tasks will NOT be able to find your specs and the pipeline BREAKS.
 

--- a/.claude/skills/sdd-tasks/SKILL.md
+++ b/.claude/skills/sdd-tasks/SKILL.md
@@ -38,7 +38,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   6. `mem_get_observation(id: {design_id})` → full design (REQUIRED)
 
   **Save your artifact**:
-  ```
+  ```text
   mem_save(
     title: "sdd/{change-name}/tasks",
     topic_key: "sdd/{change-name}/tasks",
@@ -90,16 +90,21 @@ From the design document, identify:
 - [ ] 2.1 {Concrete action}
 - [ ] 2.2 {Concrete action}
 
-## Phase 3: {Phase Name} (e.g., Testing)
+## Phase 3: {Phase Name} (e.g., Integration)
 
-- [ ] 3.1 {Write tests for ...}
-- [ ] 3.2 {Verify integration between ...}
+- [ ] 3.1 {Connect backend + frontend}
+- [ ] 3.2 {Wire routes, API calls, context}
 
-## Phase 4: Cleanup & Lint
+## Phase 4: {Phase Name} (e.g., Testing)
 
-- [ ] 4.1 Run `ruff check backend/` and fix issues
-- [ ] 4.2 Run `cd frontend && npm run lint` and fix issues
-- [ ] 4.3 {Update docs/comments if needed}
+- [ ] 4.1 {Write tests for ...}
+- [ ] 4.2 {Verify integration between ...}
+
+## Phase 5: Cleanup & Lint
+
+- [ ] 5.1 Run `ruff check backend/` and fix issues
+- [ ] 5.2 Run `cd frontend && npm run lint` and fix issues
+- [ ] 5.3 {Update docs/comments if needed}
 ```
 
 ### Task Writing Rules
@@ -115,7 +120,7 @@ Each task MUST be:
 
 ### Phase Organization (NERBIS convention)
 
-```
+```text
 Phase 1: Foundation
   └─ Models (TenantAwareModel), migrations, config
   └─ Things other tasks depend on
@@ -143,7 +148,7 @@ Phase 5: Cleanup & Lint
 **This step is MANDATORY — do NOT skip it.**
 
 If mode is `engram`:
-```
+```text
 mem_save(
   title: "sdd/{change-name}/tasks",
   topic_key: "sdd/{change-name}/tasks",
@@ -190,4 +195,4 @@ Ready for implementation (sdd-apply).
 - NEVER include vague tasks like "implement feature"
 - ALWAYS include lint/cleanup phase with `ruff check backend/` and `npm run lint`
 - NEVER include tasks that modify existing Django migrations
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-tasks/SKILL.md
+++ b/.claude/skills/sdd-tasks/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: sdd-tasks
+description: >
+  Break down a change into an implementation task checklist.
+  Trigger: When the orchestrator launches you to create or update the task breakdown for a change.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for creating the TASK BREAKDOWN. You take the proposal, specs, and design, then produce a checklist with concrete, actionable implementation steps organized by phase.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact.**
+
+  **STEP A — SEARCH** (get IDs only):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "nerbis-platform")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "nerbis-platform")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "nerbis-platform")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+  4. `mem_get_observation(id: {proposal_id})` → full proposal (REQUIRED)
+  5. `mem_get_observation(id: {spec_id})` → full spec (REQUIRED)
+  6. `mem_get_observation(id: {design_id})` → full design (REQUIRED)
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/tasks",
+    topic_key: "sdd/{change-name}/tasks",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full tasks markdown}"
+  )
+  ```
+
+- If mode is `openspec`: Read and follow `.claude/skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return result only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+### Step 2: Analyze the Design
+
+From the design document, identify:
+- All files that need to be created/modified/deleted
+- The dependency order (what must come first)
+- Testing requirements per component
+
+### Step 3: Write Tasks
+
+**IF mode is `engram` or `none`:** Compose tasks in memory.
+
+#### Task File Format
+
+```markdown
+# Tasks: {Change Title}
+
+## Phase 1: {Phase Name} (e.g., Foundation)
+
+- [ ] 1.1 {Concrete action — what file, what change}
+- [ ] 1.2 {Concrete action}
+
+## Phase 2: {Phase Name} (e.g., Core Implementation)
+
+- [ ] 2.1 {Concrete action}
+- [ ] 2.2 {Concrete action}
+
+## Phase 3: {Phase Name} (e.g., Testing)
+
+- [ ] 3.1 {Write tests for ...}
+- [ ] 3.2 {Verify integration between ...}
+
+## Phase 4: Cleanup & Lint
+
+- [ ] 4.1 Run `ruff check backend/` and fix issues
+- [ ] 4.2 Run `cd frontend && npm run lint` and fix issues
+- [ ] 4.3 {Update docs/comments if needed}
+```
+
+### Task Writing Rules
+
+Each task MUST be:
+
+| Criteria | Example | Anti-example |
+|----------|---------|--------------|
+| **Specific** | "Create `backend/reviews/models.py` with ReviewModel inheriting TenantAwareModel" | "Add reviews" |
+| **Actionable** | "Add `ReviewSerializer` to `backend/reviews/serializers.py` with exclude=['tenant']" | "Handle serialization" |
+| **Verifiable** | "Test: `POST /api/v1/ecommerce/reviews/` returns 201 with valid data" | "Make sure it works" |
+| **Small** | One file or one logical unit of work | "Implement the feature" |
+
+### Phase Organization (NERBIS convention)
+
+```
+Phase 1: Foundation
+  └─ Models (TenantAwareModel), migrations, config
+  └─ Things other tasks depend on
+
+Phase 2: Core Implementation
+  └─ Serializers, views, URLs (backend)
+  └─ Components, pages, context (frontend)
+
+Phase 3: Integration
+  └─ Connect backend + frontend
+  └─ Routes, API calls, context wiring
+
+Phase 4: Testing
+  └─ Pytest tests (backend) with tenant fixtures
+  └─ Verify against spec scenarios
+
+Phase 5: Cleanup & Lint
+  └─ ruff check backend/
+  └─ cd frontend && npm run lint
+  └─ NEVER modify existing Django migrations
+```
+
+### Step 4: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/tasks",
+  topic_key: "sdd/{change-name}/tasks",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{your full tasks markdown from Step 3}"
+)
+```
+
+If you skip this step, sdd-apply will NOT be able to find your tasks and the pipeline BREAKS.
+
+### Step 5: Return Summary
+
+```markdown
+## Tasks Created
+
+**Change**: {change-name}
+
+### Breakdown
+| Phase | Tasks | Focus |
+|-------|-------|-------|
+| Phase 1 | {N} | {Phase name} |
+| Phase 2 | {N} | {Phase name} |
+| Total | {N} | |
+
+### Implementation Order
+{Brief description of the recommended order and why}
+
+### Next Step
+Ready for implementation (sdd-apply).
+```
+
+## Rules
+
+- ALWAYS reference concrete file paths in tasks
+- Tasks MUST be ordered by dependency — Phase 1 shouldn't depend on Phase 2
+- Testing tasks should reference specific scenarios from the specs
+- Each task should be completable in ONE session
+- Use hierarchical numbering: 1.1, 1.2, 2.1, 2.2
+- NEVER include vague tasks like "implement feature"
+- ALWAYS include lint/cleanup phase with `ruff check backend/` and `npm run lint`
+- NEVER include tasks that modify existing Django migrations
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-tasks/SKILL.md
+++ b/.claude/skills/sdd-tasks/SKILL.md
@@ -71,7 +71,9 @@ From the design document, identify:
 
 ### Step 3: Write Tasks
 
-**IF mode is `engram` or `none`:** Compose tasks in memory.
+**IF mode is `openspec` or `hybrid`:** Create `openspec/changes/{change-name}/tasks.md` with the content below.
+
+**IF mode is `engram` or `none`:** Compose tasks in memory — you will persist them in Step 4.
 
 #### Task File Format
 
@@ -150,6 +152,10 @@ mem_save(
   content: "{your full tasks markdown from Step 3}"
 )
 ```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 3.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
 
 If you skip this step, sdd-apply will NOT be able to find your tasks and the pipeline BREAKS.
 

--- a/.claude/skills/sdd-verify/SKILL.md
+++ b/.claude/skills/sdd-verify/SKILL.md
@@ -42,7 +42,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
   8. `mem_get_observation(id: {tasks_id})` → full tasks
 
   **Save your artifact**:
-  ```
+  ```text
   mem_save(
     title: "sdd/{change-name}/verify-report",
     topic_key: "sdd/{change-name}/verify-report",
@@ -69,7 +69,7 @@ Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolu
 ### Step 2: Check Completeness
 
 Verify ALL tasks are done:
-```
+```text
 Read tasks
 ├── Count total tasks
 ├── Count completed tasks [x]
@@ -80,7 +80,7 @@ Read tasks
 ### Step 3: Check Correctness (Static Specs Match)
 
 For EACH spec requirement and scenario, search the codebase for structural evidence:
-```
+```text
 FOR EACH REQUIREMENT:
 ├── Search codebase for implementation evidence
 ├── For each SCENARIO:
@@ -94,7 +94,7 @@ FOR EACH REQUIREMENT:
 ### Step 4: Check Coherence (Design Match)
 
 Verify design decisions were followed:
-```
+```text
 FOR EACH DECISION:
 ├── Was the chosen approach actually used?
 ├── Were rejected alternatives accidentally implemented?
@@ -149,7 +149,7 @@ Capture exit codes, errors, and results for each.
 
 Cross-reference EVERY spec scenario against test results:
 
-```
+```text
 FOR EACH REQUIREMENT:
   FOR EACH SCENARIO:
   ├── Find tests that cover this scenario
@@ -167,7 +167,7 @@ FOR EACH REQUIREMENT:
 **This step is MANDATORY — do NOT skip it.**
 
 If mode is `engram`:
-```
+```text
 mem_save(
   title: "sdd/{change-name}/verify-report",
   topic_key: "sdd/{change-name}/verify-report",
@@ -232,4 +232,4 @@ If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
 - ALWAYS check for hardcoded credentials
 - DO NOT fix any issues — only report them
 - CRITICAL issues = must fix before archive
-- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`
+- After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-verify/SKILL.md
+++ b/.claude/skills/sdd-verify/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: sdd-verify
+description: >
+  Validate that implementation matches specs, design, and tasks.
+  Trigger: When the orchestrator launches you to verify a completed (or partially completed) change.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for VERIFICATION. You are the quality gate. Your job is to prove — with real execution evidence — that the implementation is complete, correct, and behaviorally compliant with the specs.
+
+Static analysis alone is NOT enough. You must execute the code.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+Read and follow `.claude/skills/_shared/persistence-contract.md` for mode resolution rules.
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact.**
+
+  **STEP A — SEARCH** (get IDs only):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "nerbis-platform")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "nerbis-platform")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "nerbis-platform")` → save ID
+  4. `mem_search(query: "sdd/{change-name}/tasks", project: "nerbis-platform")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+  5. `mem_get_observation(id: {proposal_id})` → full proposal
+  6. `mem_get_observation(id: {spec_id})` → full spec (REQUIRED for compliance matrix)
+  7. `mem_get_observation(id: {design_id})` → full design
+  8. `mem_get_observation(id: {tasks_id})` → full tasks
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/verify-report",
+    topic_key: "sdd/{change-name}/verify-report",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full verification report markdown}"
+  )
+  ```
+
+- If mode is `openspec`: Save to `openspec/changes/{change-name}/verify-report.md`.
+- If mode is `hybrid`: Follow BOTH conventions.
+- If mode is `none`: Return inline only.
+
+## What to Do
+
+### Step 1: Load Skill Registry
+
+**Do this FIRST, before any other work.**
+
+1. Try engram first: `mem_search(query: "skill-registry", project: "nerbis-platform")` → if found, `mem_get_observation(id)` for the full registry
+2. If engram not available or not found: read `.atl/skill-registry.md` from the project root
+3. If neither exists: proceed without skills (not an error)
+
+### Step 2: Check Completeness
+
+Verify ALL tasks are done:
+```
+Read tasks
+├── Count total tasks
+├── Count completed tasks [x]
+├── List incomplete tasks [ ]
+└── Flag: CRITICAL if core tasks incomplete, WARNING if cleanup tasks incomplete
+```
+
+### Step 3: Check Correctness (Static Specs Match)
+
+For EACH spec requirement and scenario, search the codebase for structural evidence:
+```
+FOR EACH REQUIREMENT:
+├── Search codebase for implementation evidence
+├── For each SCENARIO:
+│   ├── Is the GIVEN precondition handled in code?
+│   ├── Is the WHEN action implemented?
+│   ├── Is the THEN outcome produced?
+│   └── Are edge cases covered?
+└── Flag: CRITICAL if requirement missing, WARNING if scenario partially covered
+```
+
+### Step 4: Check Coherence (Design Match)
+
+Verify design decisions were followed:
+```
+FOR EACH DECISION:
+├── Was the chosen approach actually used?
+├── Were rejected alternatives accidentally implemented?
+├── Do file changes match the "File Changes" table?
+└── Flag: WARNING if deviation found
+```
+
+### Step 5: NERBIS-Specific Checks
+
+**Multi-Tenancy Isolation:**
+- All new models inherit `TenantAwareModel`
+- All new managers inherit `TenantAwareManager`
+- No raw SQL or `.objects.all()` that bypasses tenant filtering
+- Serializers use `exclude = ['tenant']`
+- Views assign tenant in `perform_create`
+- No cross-tenant query risks
+
+**Security:**
+- No hardcoded credentials or API keys
+- No `SECRET_KEY`, passwords, or tokens in code
+- Permission classes applied to all new endpoints
+
+**Code Conventions:**
+- Python type hints use modern syntax (`str | None`, not `Optional[str]`)
+- Existing Django migrations NOT modified
+
+### Step 6: Run Tests & Lint (Real Execution)
+
+**Backend lint:**
+```bash
+ruff check backend/
+```
+
+**Backend tests:**
+```bash
+pytest backend/
+```
+
+**Frontend lint:**
+```bash
+cd frontend && npm run lint
+```
+
+**Frontend build:**
+```bash
+cd frontend && npm run build
+```
+
+Capture exit codes, errors, and results for each.
+
+### Step 7: Spec Compliance Matrix
+
+Cross-reference EVERY spec scenario against test results:
+
+```
+FOR EACH REQUIREMENT:
+  FOR EACH SCENARIO:
+  ├── Find tests that cover this scenario
+  ├── Look up test result from Step 6
+  ├── Assign compliance:
+  │   ├── ✅ COMPLIANT   → test exists AND passed
+  │   ├── ❌ FAILING     → test exists BUT failed (CRITICAL)
+  │   ├── ❌ UNTESTED    → no test found (CRITICAL)
+  │   └── ⚠️ PARTIAL    → test passes but covers only part
+  └── Record: requirement, scenario, test file, result
+```
+
+### Step 8: Persist Verification Report
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/verify-report",
+  topic_key: "sdd/{change-name}/verify-report",
+  type: "architecture",
+  project: "nerbis-platform",
+  content: "{your full verification report}"
+)
+```
+
+### Step 9: Return Report
+
+```markdown
+## Verification Report
+
+**Change**: {change-name}
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | {N} |
+| Tasks complete | {N} |
+| Tasks incomplete | {N} |
+
+### Build & Tests Execution
+
+**Ruff (backend lint)**: ✅ Passed / ❌ Failed
+**Pytest (backend tests)**: ✅ {N} passed / ❌ {N} failed
+**ESLint (frontend lint)**: ✅ Passed / ❌ Failed
+**Next.js build**: ✅ Passed / ❌ Failed
+
+### NERBIS Checks
+- Multi-tenancy isolation: ✅ / ❌ {details}
+- Security (no hardcoded secrets): ✅ / ❌
+- Code conventions: ✅ / ❌ {details}
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| {REQ-01} | {Scenario} | `{test file}` | ✅ COMPLIANT |
+
+### Issues Found
+
+**CRITICAL** (must fix): {list or "None"}
+**WARNING** (should fix): {list or "None"}
+**SUGGESTION** (nice to have): {list or "None"}
+
+### Verdict
+{PASS / PASS WITH WARNINGS / FAIL}
+```
+
+## Rules
+
+- ALWAYS read the actual source code — don't trust summaries
+- ALWAYS execute tests — static analysis alone is not verification
+- A spec scenario is only COMPLIANT when a test that covers it has PASSED
+- ALWAYS check multi-tenancy isolation for backend changes
+- ALWAYS check for hardcoded credentials
+- DO NOT fix any issues — only report them
+- CRITICAL issues = must fix before archive
+- Return a structured envelope with: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`

--- a/.claude/skills/sdd-verify/SKILL.md
+++ b/.claude/skills/sdd-verify/SKILL.md
@@ -177,6 +177,10 @@ mem_save(
 )
 ```
 
+If mode is `openspec` or `hybrid`: Write the report to `openspec/changes/{change-name}/verify-report.md`.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
 ### Step 9: Return Report
 
 ```markdown

--- a/.claude/skills/skill-registry/SKILL.md
+++ b/.claude/skills/skill-registry/SKILL.md
@@ -85,13 +85,13 @@ Read the convention files listed above for project-specific patterns and rules. 
 
 Create the `.atl/` directory in the project root if it doesn't exist, then write:
 
-```
+```text
 .atl/skill-registry.md
 ```
 
 #### B. If engram is available, also save to engram (cross-session bonus):
 
-```
+```text
 mem_save(
   title: "skill-registry",
   topic_key: "skill-registry",

--- a/.claude/skills/skill-registry/SKILL.md
+++ b/.claude/skills/skill-registry/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: skill-registry
+description: >
+  Create or update the skill registry for the current project. Scans user skills and project conventions, writes .atl/skill-registry.md, and saves to engram if available.
+  Trigger: When user says "update skills", "skill registry", "actualizar skills", "update registry", or after installing/removing skills.
+license: MIT
+metadata:
+  author: nerbis-platform
+  version: "1.0"
+---
+
+## Purpose
+
+You generate or update the **skill registry** — a catalog of all available skills (user-level and project-level) that sub-agents read before starting any task. This ensures every sub-agent knows what skills exist and can load the relevant ones.
+
+## When to Run
+
+- After installing or removing skills
+- After setting up a new project
+- When the user explicitly asks to update the registry
+- As part of `sdd-init` (it calls this same logic)
+
+## What to Do
+
+### Step 1: Scan User Skills
+
+1. Glob for `*/SKILL.md` files across ALL known skill directories. Check every path below — scan ALL that exist, not just the first match:
+
+   **User-level (global skills):**
+   - `~/.claude/skills/`
+
+   **Project-level (workspace skills):**
+   - `{project-root}/.claude/skills/`
+
+2. **SKIP `sdd-*` and `_shared`** — those are SDD workflow skills, not coding/task skills
+3. Also **SKIP `skill-registry`** — that's this skill
+4. **Deduplicate** — if the same skill name appears in multiple locations, keep the project-level version (more specific)
+5. For each skill found, read only the frontmatter (first 10 lines) to extract:
+   - `name` field
+   - `description` field → extract the trigger text (after "Trigger:" in the description)
+6. Build a table of: Trigger | Skill Name | Full Path
+
+### Step 2: Scan Project Conventions
+
+1. Check the project root for convention files:
+   - `AGENTS.md`
+   - `CLAUDE.md` (only project-level, not `~/.claude/CLAUDE.md`)
+   - `.cursorrules`
+   - `docs/SDD.md`
+2. **If an index file is found** (e.g., `AGENTS.md`): READ its contents and extract all referenced file paths. Include both the index file AND all paths it references in the registry.
+3. For non-index files: record the file directly.
+
+### Step 3: Write the Registry
+
+Build the registry markdown:
+
+```markdown
+# Skill Registry
+
+As your FIRST step before starting any work, identify and load skills relevant to your task from this registry.
+
+## User Skills
+
+| Trigger | Skill | Path |
+|---------|-------|------|
+| {trigger from frontmatter} | {skill name} | {full path to SKILL.md} |
+| ... | ... | ... |
+
+## Project Conventions
+
+| File | Path | Notes |
+|------|------|-------|
+| {index file} | {path} | Index — references files below |
+| {referenced file} | {extracted path} | Referenced by {index file} |
+| {standalone file} | {path} | |
+
+Read the convention files listed above for project-specific patterns and rules. All referenced paths have been extracted — no need to read index files to discover more.
+```
+
+### Step 4: Persist the Registry
+
+**This step is MANDATORY — do NOT skip it.**
+
+#### A. Always write the file (guaranteed availability):
+
+Create the `.atl/` directory in the project root if it doesn't exist, then write:
+
+```
+.atl/skill-registry.md
+```
+
+#### B. If engram is available, also save to engram (cross-session bonus):
+
+```
+mem_save(
+  title: "skill-registry",
+  topic_key: "skill-registry",
+  type: "config",
+  project: "nerbis-platform",
+  content: "{registry markdown from Step 3}"
+)
+```
+
+`topic_key` ensures upserts — running again updates the same observation.
+
+### Step 5: Return Summary
+
+```markdown
+## Skill Registry Updated
+
+**Project**: nerbis-platform
+**Location**: .atl/skill-registry.md
+**Engram**: {saved / not available}
+
+### User Skills Found
+| Skill | Trigger |
+|-------|---------|
+| {name} | {trigger} |
+
+### Project Conventions Found
+| File | Path |
+|------|------|
+| {file} | {path} |
+
+### Next Steps
+Sub-agents will automatically load relevant skills from this registry.
+To update after installing/removing skills, run this again.
+```
+
+## Rules
+
+- ALWAYS write `.atl/skill-registry.md` regardless of any SDD persistence mode
+- ALWAYS save to engram if the `mem_save` tool is available
+- SKIP `sdd-*`, `_shared`, and `skill-registry` directories when scanning
+- Only read frontmatter (first 10 lines) — do NOT read full skill files
+- Include ALL convention files found (not just the first)
+- If no skills or conventions are found, write an empty registry
+- Add `.atl/` to the project's `.gitignore` if it exists and `.atl` is not already listed

--- a/.claude/skills/skill-registry/SKILL.md
+++ b/.claude/skills/skill-registry/SKILL.md
@@ -35,7 +35,7 @@ You generate or update the **skill registry** — a catalog of all available ski
 2. **SKIP `sdd-*` and `_shared`** — those are SDD workflow skills, not coding/task skills
 3. Also **SKIP `skill-registry`** — that's this skill
 4. **Deduplicate** — if the same skill name appears in multiple locations, keep the project-level version (more specific)
-5. For each skill found, read only the frontmatter (first 10 lines) to extract:
+5. For each skill found, read the YAML frontmatter block (from the opening `---` to the closing `---`) to extract:
    - `name` field
    - `description` field → extract the trigger text (after "Trigger:" in the description)
 6. Build a table of: Trigger | Skill Name | Full Path
@@ -132,7 +132,7 @@ To update after installing/removing skills, run this again.
 - ALWAYS write `.atl/skill-registry.md` regardless of any SDD persistence mode
 - ALWAYS save to engram if the `mem_save` tool is available
 - SKIP `sdd-*`, `_shared`, and `skill-registry` directories when scanning
-- Only read frontmatter (first 10 lines) — do NOT read full skill files
+- Only read frontmatter (from `---` to closing `---`) — do NOT read full skill files
 - Include ALL convention files found (not just the first)
 - If no skills or conventions are found, write an empty registry
 - Add `.atl/` to the project's `.gitignore` if it exists and `.atl` is not already listed

--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,9 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Agent Teams Lite — runtime generated
+.atl/
+
 # Marimo
 marimo/_static/
 marimo/_lsp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ vía Task tool, y sintetizar sus resultados.
 
 ### Grafo de dependencias (DAG)
 
-```
+```text
 explore → propose → 🚪 → spec + design (paralelo) → 🚪 → tasks → apply → 🚪 → verify → archive
 ```
 
@@ -116,7 +116,7 @@ explore → propose → 🚪 → spec + design (paralelo) → 🚪 → tasks →
 
 Al lanzar un sub-agente SDD, SIEMPRE incluir en el prompt:
 
-```
+```text
 SKILL LOADING (do this FIRST):
 Check for available skills:
   1. Try: mem_search(query: "skill-registry", project: "nerbis-platform")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,93 @@ Usar Context7 (MCP) para consultar documentación actualizada cuando:
 
 NO usar Context7 para: git, CI/CD, documentación, refactoring, o tareas que no tocan APIs de librerías.
 
+## SDD Orchestrator (Spec-Driven Development)
+
+Eres un COORDINADOR, no un ejecutor. Cuando se activa el flujo SDD, tu único trabajo es
+mantener un hilo de conversación con el usuario, delegar TODO el trabajo real a sub-agentes
+vía Task tool, y sintetizar sus resultados.
+
+### Reglas de delegación (SIEMPRE ACTIVAS en flujo SDD)
+
+1. **NUNCA hacer trabajo real inline.** Si la tarea involucra leer código, escribir código,
+   analizar arquitectura, diseñar soluciones, correr tests — delegar a un sub-agente.
+2. **Estás permitido a:** responder preguntas cortas, coordinar sub-agentes, mostrar
+   resúmenes, pedir decisiones al usuario, y trackear estado.
+3. **Self-check:** "¿Estoy por leer código, escribir código, o hacer análisis?
+   Si sí → delegar."
+
+### Escalamiento de tareas
+
+1. Pregunta simple → responder brevemente o delegar
+2. Tarea pequeña (edición de un archivo) → delegar a sub-agente general
+3. Feature/refactor sustancial → sugerir SDD: `/sdd-new {nombre}`
+
+### Comandos SDD
+
+| Comando | Acción |
+|---------|--------|
+| `/sdd-init` | Lanzar sub-agente sdd-init (detectar stack, generar skill registry) |
+| `/sdd-explore <tema>` | Lanzar sub-agente sdd-explore (investigación standalone) |
+| `/sdd-new <cambio>` | Ejecutar explore → propose → HUMAN GATE |
+| `/sdd-continue [cambio]` | Crear siguiente artifact faltante en el DAG |
+| `/sdd-ff <cambio>` | Fast-forward: propose → spec+design → tasks (sin gates) |
+| `/sdd-apply [cambio]` | Lanzar sdd-apply en batches |
+| `/sdd-verify [cambio]` | Lanzar sdd-verify |
+| `/sdd-archive [cambio]` | Lanzar sdd-archive |
+
+### Grafo de dependencias (DAG)
+
+```
+explore → propose → 🚪 → spec + design (paralelo) → 🚪 → tasks → apply → 🚪 → verify → archive
+```
+
+### Human Gates
+
+- Después de propose: mostrar resumen, preguntar "¿Procedo con la fase de diseño?"
+- Después de spec + design: mostrar resumen, preguntar "¿Procedo con la implementación?"
+- Después de apply: mostrar resumen, preguntar "¿Procedo con la verificación?"
+
+### Persistencia
+
+- **Backend por defecto**: Engram (ya configurado vía MCP)
+- **Artifact naming**: `sdd/{change-name}/{artifact-type}` (ver `.claude/skills/_shared/engram-convention.md`)
+- **State recovery**: Persistir estado del DAG después de cada fase para recuperar tras compresión de contexto
+- **Project name en Engram**: `nerbis-platform`
+
+### Patrón de lanzamiento de sub-agentes
+
+Al lanzar un sub-agente SDD, SIEMPRE incluir en el prompt:
+
+```
+SKILL LOADING (do this FIRST):
+Check for available skills:
+  1. Try: mem_search(query: "skill-registry", project: "nerbis-platform")
+  2. Fallback: read .atl/skill-registry.md
+Load and follow any skills relevant to your task.
+
+Artifact store mode: engram
+
+PERSISTENCE (MANDATORY — do NOT skip):
+After completing your work, you MUST call:
+  mem_save(
+    title: "sdd/{change-name}/{artifact-type}",
+    topic_key: "sdd/{change-name}/{artifact-type}",
+    type: "architecture",
+    project: "nerbis-platform",
+    content: "{your full artifact markdown}"
+  )
+If you return without calling mem_save, the next phase CANNOT find your artifact
+and the pipeline BREAKS.
+```
+
+### Fases paralelas (spec + design)
+
+Lanzar DOS Task calls en el mismo mensaje:
+- Task 1: "Read `.claude/skills/sdd-spec/SKILL.md`. Change: {name}. [persistence instructions]"
+- Task 2: "Read `.claude/skills/sdd-design/SKILL.md`. Change: {name}. [persistence instructions]"
+
+Ambos corren simultáneamente. Esperar a que ambos terminen antes de continuar.
+
 ## Código (específico Claude)
 
 - Python: type hints modernos (`dict`, `list`, `str | None` — no `Dict`, `List`, `Optional`)


### PR DESCRIPTION
## Summary
- Implementa un orquestador SDD (Spec-Driven Development) Nivel 3 basado en el patrón [agent-teams-lite](https://github.com/Gentleman-Programming/agent-teams-lite)
- 8 sub-agentes especializados en un DAG: Explorer → Proposer → Spec Writer + Designer (paralelo) → Task Planner → Implementer → Verifier → Archiver
- Convenciones compartidas (`_shared/`): naming de artifacts en Engram, contratos de persistencia, OpenSpec
- Skill registry para auto-descubrimiento de skills existentes (multi-tenancy, shadcn, etc.)
- Human gates entre fases para control del usuario
- Persistencia con Engram como backend por defecto
- Adaptado para NERBIS: multi-tenancy awareness, lint con ruff + eslint, project `nerbis-platform`

## Files added (14 new, 2 modified)
- `.claude/skills/_shared/` — 3 convenciones compartidas
- `.claude/skills/skill-registry/` — auto-descubrimiento de skills
- `.claude/skills/sdd-*/` — 9 skills del pipeline SDD
- `CLAUDE.md` — sección del orquestador con reglas de delegación y comandos
- `.gitignore` — excluir `.atl/` (generado en runtime)

## Test plan
- [ ] Verificar que todos los SKILL.md se renderizan correctamente
- [ ] Ejecutar `/sdd-init` para validar detección de stack y generación de skill registry
- [ ] Ejecutar `/sdd-new test-feature` para validar el flujo completo del pipeline
- [ ] Verificar persistencia en Engram con `mem_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lanzamiento

* **Nuevas Funcionalidades**
  * Se añadieron múltiples guías de habilidad SDD para flujo completo: init, explore, propose, spec, design, tasks, apply, verify y archive.
  * Nuevo procedimiento de registro de habilidades para descubrir y listar habilidades del proyecto.

* **Documentación**
  * Nuevas convenciones compartidas: Engram Artifact, OpenSpec y contrato de persistencia (modos, reglas de lectura/escritura y flujos).
  * Ampliada la guía del orquestador SDD con flujos, delegación y reportes esperados.

* **Chores**
  * Actualizadas reglas de .gitignore para artefactos y carpetas generadas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->