### PR TITLE
fix(auth): corregir issues de coderabbit round 2

### DIFF
--- a/.claude/skills/_shared/persistence-contract.md
+++ b/.claude/skills/_shared/persistence-contract.md
@@ -83,8 +83,10 @@ to engram before returning:
 Do NOT return without saving what you learned.
 ```
 
-**SDD (with dependencies)**:
-```
+**SDD (with dependencies)** — the orchestrator MUST select the correct block based on `artifact_store.mode`:
+
+When mode is `engram` or `hybrid`:
+```text
 Artifact store mode: {artifact_store.mode}
 Read these artifacts before starting (two-step — search returns truncated previews):
   mem_search(query: "sdd/{change-name}/{type}", project: "nerbis-platform") → get ID
@@ -103,8 +105,30 @@ If you return without calling mem_save, the next phase CANNOT find your artifact
 and the pipeline BREAKS.
 ```
 
-**SDD (no dependencies)**:
+When mode is `openspec`:
+```text
+Artifact store mode: openspec
+Read these artifacts before starting:
+  Read file: openspec/changes/{change-name}/{type}.md
+
+PERSISTENCE (MANDATORY — do NOT skip):
+After completing your work, you MUST write your artifact to:
+  openspec/changes/{change-name}/{artifact-type}.md
+If you return without writing the file, the next phase CANNOT find your artifact
+and the pipeline BREAKS.
 ```
+
+When mode is `none`:
+```text
+Artifact store mode: none
+No persistence backend available. Return your full artifact inline in your response.
+The orchestrator will pass it to the next phase via prompt context.
+```
+
+**SDD (no dependencies)** — same mode branching applies:
+
+When mode is `engram` or `hybrid`:
+```text
 Artifact store mode: {artifact_store.mode}
 
 PERSISTENCE (MANDATORY — do NOT skip):
@@ -118,6 +142,23 @@ After completing your work, you MUST call:
   )
 If you return without calling mem_save, the next phase CANNOT find your artifact
 and the pipeline BREAKS.
+```
+
+When mode is `openspec`:
+```text
+Artifact store mode: openspec
+
+PERSISTENCE (MANDATORY — do NOT skip):
+After completing your work, you MUST write your artifact to:
+  openspec/changes/{change-name}/{artifact-type}.md
+If you return without writing the file, the next phase CANNOT find your artifact
+and the pipeline BREAKS.
+```
+
+When mode is `none`:
+```text
+Artifact store mode: none
+No persistence backend available. Return your full artifact inline in your response.
 ```
 
 ## Skill Registry

--- a/frontend/src/components/auth/RegisterStep1.tsx
+++ b/frontend/src/components/auth/RegisterStep1.tsx
@@ -3,7 +3,7 @@
 
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Input } from '@/components/ui/input';
 import {
   FormControl,
@@ -23,6 +23,7 @@ import { ArrowRight } from 'lucide-react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { RegisterBusinessFormValues } from './schemas';
 import { countries, DEBOUNCE_DELAY_MS } from './constants';
+import { useDebounce } from './hooks';
 import { StepIndicator } from './StepIndicator';
 
 // ─── Props ──────────────────────────────────────────────────────
@@ -47,10 +48,12 @@ export function RegisterStep1({
   // Business name existence check
   const [businessNameExists, setBusinessNameExists] = useState(false);
   const [checkingName, setCheckingName] = useState(false);
-  const nameCheckTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const businessName = form.watch('business_name');
+  const debouncedName = useDebounce(businessName, DEBOUNCE_DELAY_MS);
 
   const checkBusinessName = useCallback(
-    async (name: string) => {
+    async (name: string, signal: AbortSignal) => {
       if (!name || name.trim().length < 2) {
         setBusinessNameExists(false);
         return;
@@ -59,35 +62,30 @@ export function RegisterStep1({
       try {
         const res = await fetch(
           `${API_URL}/api/public/check-business-name/?name=${encodeURIComponent(name.trim())}`,
+          { signal },
         );
         if (res.ok) {
           const data = await res.json();
-          setBusinessNameExists(data.exists);
+          if (!signal.aborted) setBusinessNameExists(data.exists);
         }
-      } catch {
-        /* silent */
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
       } finally {
-        setCheckingName(false);
+        if (!signal.aborted) setCheckingName(false);
       }
     },
     [API_URL],
   );
 
-  const businessName = form.watch('business_name');
   useEffect(() => {
-    if (nameCheckTimer.current) clearTimeout(nameCheckTimer.current);
-    if (!businessName || businessName.trim().length < 2) {
+    if (!debouncedName || debouncedName.trim().length < 2) {
       setBusinessNameExists(false);
       return;
     }
-    nameCheckTimer.current = setTimeout(
-      () => checkBusinessName(businessName),
-      DEBOUNCE_DELAY_MS,
-    );
-    return () => {
-      if (nameCheckTimer.current) clearTimeout(nameCheckTimer.current);
-    };
-  }, [businessName, checkBusinessName]);
+    const controller = new AbortController();
+    checkBusinessName(debouncedName, controller.signal);
+    return () => controller.abort();
+  }, [debouncedName, checkBusinessName]);
 
   return (
     <div data-auth-animated>


### PR DESCRIPTION
## Summary

- **Fix race condition** en `RegisterStep1.tsx`: reemplazar debounce manual (`setTimeout` + `useRef`) con `useDebounce` hook + `AbortController` para cancelar fetches anteriores y evitar actualizaciones con respuestas stale
- **Fix templates SDD** en `persistence-contract.md`: hacer `mem_*` calls condicionales por `artifact_store.mode` — solo emitir instrucciones de engram cuando el modo es `engram` o `hybrid`, con alternativas para `openspec` y `none`

Reemplaza PR #44 (tenía conflictos por historia divergente del squash merge).

## Test plan

- [ ] Verificar que el check de nombre de negocio funciona con debounce
- [ ] Verificar que no hay warnings de state update on unmounted component

🤖 Generated with [Claude Code](https://claude.com/claude-code)