### PR TITLE
fix(ui): corregir espaciado y jerarquía visual de labels en auth

### DIFF
--- a/frontend/src/components/auth/ForgotPasswordForm.tsx
+++ b/frontend/src/components/auth/ForgotPasswordForm.tsx
@@ -30,6 +30,7 @@ import { OtpInput } from './OtpInput';
 import { PasswordField } from './PasswordField';
 import { SubmitButton } from './SubmitButton';
 import type { ForgotStep } from './types';
+import { LABEL_CLASS, LABEL_STYLE } from './constants';
 
 // ─── Props ──────────────────────────────────────────────────────
 
@@ -146,13 +147,7 @@ export function ForgotPasswordForm({
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel
-                      className="text-[0.8125rem] font-normal"
-                      style={{
-                        color: 'var(--auth-text-muted)',
-                        fontFamily: 'var(--auth-font-body)',
-                      }}
-                    >
+                    <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                       Email
                     </FormLabel>
                     <FormControl>
@@ -242,13 +237,7 @@ export function ForgotPasswordForm({
                 name="code"
                 render={() => (
                   <FormItem>
-                    <FormLabel
-                      className="text-[0.8125rem] font-normal"
-                      style={{
-                        color: 'var(--auth-text-muted)',
-                        fontFamily: 'var(--auth-font-body)',
-                      }}
-                    >
+                    <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                       Código de verificación
                     </FormLabel>
                     <FormControl>

--- a/frontend/src/components/auth/ForgotPasswordForm.tsx
+++ b/frontend/src/components/auth/ForgotPasswordForm.tsx
@@ -147,9 +147,9 @@ export function ForgotPasswordForm({
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel
-                      className="text-[0.9375rem] font-normal"
+                      className="text-[0.8125rem] font-normal"
                       style={{
-                        color: 'var(--auth-text)',
+                        color: 'var(--auth-text-muted)',
                         fontFamily: 'var(--auth-font-body)',
                       }}
                     >
@@ -243,9 +243,9 @@ export function ForgotPasswordForm({
                 render={() => (
                   <FormItem>
                     <FormLabel
-                      className="text-[0.9375rem] font-normal"
+                      className="text-[0.8125rem] font-normal"
                       style={{
-                        color: 'var(--auth-text)',
+                        color: 'var(--auth-text-muted)',
                         fontFamily: 'var(--auth-font-body)',
                       }}
                     >

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -20,6 +20,7 @@ import { ApiError } from '@/lib/api/client';
 import { requestReactivationOTP } from '@/lib/api/auth';
 import { features } from '@/lib/features';
 import { loginSchema, type LoginFormValues } from './schemas';
+import { LABEL_CLASS, LABEL_STYLE } from './constants';
 import { useAuthForm } from './hooks/useAuthForm';
 import { PasswordField } from './PasswordField';
 import { SubmitButton } from './SubmitButton';
@@ -144,13 +145,7 @@ export function LoginForm({
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel
-                    className="text-[0.8125rem] font-normal"
-                    style={{
-                      color: 'var(--auth-text-muted)',
-                      fontFamily: 'var(--auth-font-body)',
-                    }}
-                  >
+                  <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                     Correo electrónico
                   </FormLabel>
                   <FormControl>
@@ -173,13 +168,7 @@ export function LoginForm({
 
             <div>
               <div className="flex items-center justify-between mb-2">
-                <FormLabel
-                  className="text-[0.8125rem] font-normal"
-                  style={{
-                    color: 'var(--auth-text-muted)',
-                    fontFamily: 'var(--auth-font-body)',
-                  }}
-                >
+                <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                   Contraseña
                 </FormLabel>
                 <button

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -145,9 +145,9 @@ export function LoginForm({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel
-                    className="text-[0.9375rem] font-normal"
+                    className="text-[0.8125rem] font-normal"
                     style={{
-                      color: 'var(--auth-text)',
+                      color: 'var(--auth-text-muted)',
                       fontFamily: 'var(--auth-font-body)',
                     }}
                   >
@@ -172,11 +172,11 @@ export function LoginForm({
             />
 
             <div>
-              <div className="flex items-center justify-between mb-1.5">
+              <div className="flex items-center justify-between mb-2">
                 <FormLabel
-                  className="text-[0.9375rem] font-normal"
+                  className="text-[0.8125rem] font-normal"
                   style={{
-                    color: 'var(--auth-text)',
+                    color: 'var(--auth-text-muted)',
                     fontFamily: 'var(--auth-font-body)',
                   }}
                 >
@@ -185,7 +185,7 @@ export function LoginForm({
                 <button
                   type="button"
                   onClick={onForgotPassword}
-                  className="text-[0.75rem] transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--auth-accent)] focus-visible:ring-offset-2 rounded-sm"
+                  className="text-[0.75rem] leading-none transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--auth-accent)] focus-visible:ring-offset-2 rounded-sm"
                   style={{ color: 'var(--auth-accent, #0D9488)' }}
                 >
                   ¿Olvidaste tu contraseña?

--- a/frontend/src/components/auth/PasswordField.tsx
+++ b/frontend/src/components/auth/PasswordField.tsx
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import type { PasswordFieldProps } from './types';
+import { LABEL_CLASS, LABEL_STYLE } from './constants';
 
 export function PasswordField({
   name,
@@ -33,10 +34,7 @@ export function PasswordField({
       render={({ field, fieldState }) => (
         <FormItem>
           {label && (
-            <FormLabel
-              className="text-[0.8125rem] font-normal"
-              style={{ color: 'var(--auth-text-muted)', fontFamily: 'var(--auth-font-body)' }}
-            >
+            <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
               {label}
             </FormLabel>
           )}

--- a/frontend/src/components/auth/PasswordField.tsx
+++ b/frontend/src/components/auth/PasswordField.tsx
@@ -32,12 +32,14 @@ export function PasswordField({
       name={name}
       render={({ field, fieldState }) => (
         <FormItem>
-          <FormLabel
-            className="text-[var(--auth-text)] text-[0.9375rem] font-normal"
-            style={{ fontFamily: 'var(--auth-font-body)' }}
-          >
-            {label}
-          </FormLabel>
+          {label && (
+            <FormLabel
+              className="text-[0.8125rem] font-normal"
+              style={{ color: 'var(--auth-text-muted)', fontFamily: 'var(--auth-font-body)' }}
+            >
+              {label}
+            </FormLabel>
+          )}
           <FormControl>
             <div className="relative" data-auth-animated>
               <Input

--- a/frontend/src/components/auth/RegisterStep1.tsx
+++ b/frontend/src/components/auth/RegisterStep1.tsx
@@ -123,9 +123,9 @@ export function RegisterStep1({
           render={({ field }) => (
             <FormItem>
               <FormLabel
-                className="text-[0.9375rem] font-normal"
+                className="text-[0.8125rem] font-normal"
                 style={{
-                  color: 'var(--auth-text)',
+                  color: 'var(--auth-text-muted)',
                   fontFamily: 'var(--auth-font-body)',
                 }}
               >
@@ -169,9 +169,9 @@ export function RegisterStep1({
           render={({ field }) => (
             <FormItem>
               <FormLabel
-                className="text-[0.9375rem] font-normal"
+                className="text-[0.8125rem] font-normal"
                 style={{
-                  color: 'var(--auth-text)',
+                  color: 'var(--auth-text-muted)',
                   fontFamily: 'var(--auth-font-body)',
                 }}
               >

--- a/frontend/src/components/auth/RegisterStep1.tsx
+++ b/frontend/src/components/auth/RegisterStep1.tsx
@@ -22,7 +22,7 @@ import {
 import { ArrowRight } from 'lucide-react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { RegisterBusinessFormValues } from './schemas';
-import { countries, DEBOUNCE_DELAY_MS } from './constants';
+import { countries, DEBOUNCE_DELAY_MS, LABEL_CLASS, LABEL_STYLE } from './constants';
 import { StepIndicator } from './StepIndicator';
 
 // ─── Props ──────────────────────────────────────────────────────
@@ -122,13 +122,7 @@ export function RegisterStep1({
           name="business_name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel
-                className="text-[0.8125rem] font-normal"
-                style={{
-                  color: 'var(--auth-text-muted)',
-                  fontFamily: 'var(--auth-font-body)',
-                }}
-              >
+              <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                 Nombre del negocio
               </FormLabel>
               <FormControl>
@@ -168,13 +162,7 @@ export function RegisterStep1({
           name="country"
           render={({ field }) => (
             <FormItem>
-              <FormLabel
-                className="text-[0.8125rem] font-normal"
-                style={{
-                  color: 'var(--auth-text-muted)',
-                  fontFamily: 'var(--auth-font-body)',
-                }}
-              >
+              <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                 País
               </FormLabel>
               <Select

--- a/frontend/src/components/auth/RegisterStep2.tsx
+++ b/frontend/src/components/auth/RegisterStep2.tsx
@@ -148,9 +148,9 @@ export function RegisterStep2({
             render={({ field }) => (
               <FormItem>
                 <FormLabel
-                  className="text-[0.9375rem] font-normal"
+                  className="text-[0.8125rem] font-normal"
                   style={{
-                    color: 'var(--auth-text)',
+                    color: 'var(--auth-text-muted)',
                     fontFamily: 'var(--auth-font-body)',
                   }}
                 >
@@ -177,9 +177,9 @@ export function RegisterStep2({
             render={({ field }) => (
               <FormItem>
                 <FormLabel
-                  className="text-[0.9375rem] font-normal"
+                  className="text-[0.8125rem] font-normal"
                   style={{
-                    color: 'var(--auth-text)',
+                    color: 'var(--auth-text-muted)',
                     fontFamily: 'var(--auth-font-body)',
                   }}
                 >
@@ -209,9 +209,9 @@ export function RegisterStep2({
           render={({ field }) => (
             <FormItem>
               <FormLabel
-                className="text-[0.9375rem] font-normal"
+                className="text-[0.8125rem] font-normal"
                 style={{
-                  color: 'var(--auth-text)',
+                  color: 'var(--auth-text-muted)',
                   fontFamily: 'var(--auth-font-body)',
                 }}
               >
@@ -259,9 +259,9 @@ export function RegisterStep2({
           render={({ field }) => (
             <FormItem>
               <FormLabel
-                className="text-[0.9375rem] font-normal"
+                className="text-[0.8125rem] font-normal"
                 style={{
-                  color: 'var(--auth-text)',
+                  color: 'var(--auth-text-muted)',
                   fontFamily: 'var(--auth-font-body)',
                 }}
               >

--- a/frontend/src/components/auth/RegisterStep2.tsx
+++ b/frontend/src/components/auth/RegisterStep2.tsx
@@ -29,7 +29,7 @@ import {
 import { ArrowLeft, Check, ChevronsUpDown } from 'lucide-react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { RegisterBusinessFormValues } from './schemas';
-import { countries, DEBOUNCE_DELAY_MS } from './constants';
+import { countries, DEBOUNCE_DELAY_MS, LABEL_CLASS, LABEL_STYLE } from './constants';
 import { PasswordField } from './PasswordField';
 import { SubmitButton } from './SubmitButton';
 import { StepIndicator } from './StepIndicator';
@@ -147,13 +147,7 @@ export function RegisterStep2({
             name="first_name"
             render={({ field }) => (
               <FormItem>
-                <FormLabel
-                  className="text-[0.8125rem] font-normal"
-                  style={{
-                    color: 'var(--auth-text-muted)',
-                    fontFamily: 'var(--auth-font-body)',
-                  }}
-                >
+                <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                   Nombre
                 </FormLabel>
                 <FormControl>
@@ -176,13 +170,7 @@ export function RegisterStep2({
             name="last_name"
             render={({ field }) => (
               <FormItem>
-                <FormLabel
-                  className="text-[0.8125rem] font-normal"
-                  style={{
-                    color: 'var(--auth-text-muted)',
-                    fontFamily: 'var(--auth-font-body)',
-                  }}
-                >
+                <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                   Apellido
                 </FormLabel>
                 <FormControl>
@@ -208,13 +196,7 @@ export function RegisterStep2({
           name="email"
           render={({ field }) => (
             <FormItem>
-              <FormLabel
-                className="text-[0.8125rem] font-normal"
-                style={{
-                  color: 'var(--auth-text-muted)',
-                  fontFamily: 'var(--auth-font-body)',
-                }}
-              >
+              <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                 Email
               </FormLabel>
               <FormControl>
@@ -258,13 +240,7 @@ export function RegisterStep2({
           name="phone"
           render={({ field }) => (
             <FormItem>
-              <FormLabel
-                className="text-[0.8125rem] font-normal"
-                style={{
-                  color: 'var(--auth-text-muted)',
-                  fontFamily: 'var(--auth-font-body)',
-                }}
-              >
+              <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
                 Teléfono{' '}
                 <span
                   className="font-normal"

--- a/frontend/src/components/auth/constants.ts
+++ b/frontend/src/components/auth/constants.ts
@@ -1,5 +1,7 @@
 // src/components/auth/constants.ts
-// Static data extracted from AuthSplitScreen.tsx.
+// Static data and shared styles for auth components.
+
+import type React from 'react';
 
 export interface IndustryOption {
   value: string;
@@ -79,6 +81,13 @@ export const DEBOUNCE_DELAY_MS = 600;
 
 /** OTP code length */
 export const OTP_LENGTH = 6;
+
+/** Shared form label styling for all auth forms */
+export const LABEL_CLASS = 'text-[0.8125rem] font-normal';
+export const LABEL_STYLE: React.CSSProperties = {
+  color: 'var(--auth-text-muted)',
+  fontFamily: 'var(--auth-font-body)',
+};
 
 /** Auth gradient for the brand panel (dark side) */
 export const AUTH_GRADIENT =


### PR DESCRIPTION
## Summary
- Unifica el gap entre labels e inputs en LoginForm (`mb-1.5` → `mb-2`, `leading-none` en botón)
- Elimina `FormLabel` vacío fantasma en PasswordField que agregaba 8px extra invisibles
- Reduce prominencia visual de todos los labels de auth (`--auth-text-muted` + `0.8125rem`) para mejor jerarquía con el diseño minimalista

## Archivos modificados
- `LoginForm.tsx` — fix espaciado + labels sutiles
- `PasswordField.tsx` — label condicional + estilo actualizado
- `RegisterStep1.tsx` — labels actualizados
- `RegisterStep2.tsx` — labels actualizados
- `ForgotPasswordForm.tsx` — labels actualizados

## Test plan
- [ ] Verificar visualmente que el gap entre label e input sea idéntico en email y contraseña (LoginForm)
- [ ] Verificar que labels se vean sutiles y no compitan con el título principal
- [ ] Verificar RegisterStep1, RegisterStep2 y ForgotPasswordForm con el mismo estilo
- [ ] Verificar que PasswordField con `label=""` no genere espacio extra

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Estandarización de la apariencia de las etiquetas en los formularios de autenticación para consistencia visual.
  * Ajustes de espaciado y tamaños de texto en formularios de inicio de sesión y registro para mejorar la jerarquía visual.
* **Refactor**
  * Centralización de estilos de etiqueta y renderizado condicional de etiquetas para simplificar la presentación sin alterar el comportamiento.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->