### PR TITLE
fix(ui): improve normal toast contrast and auth toast variants

### DIFF
--- a/frontend/src/components/auth/PasskeyButton.tsx
+++ b/frontend/src/components/auth/PasskeyButton.tsx
@@ -18,7 +18,7 @@ export function PasskeyButton({ onClick }: PasskeyButtonProps) {
     if (onClick) {
       onClick();
     } else {
-      toast('Estamos trabajando en esto', {
+      toast.info('Estamos trabajando en esto', {
         description: 'Pronto podrás iniciar sesión con huella o Face ID. Por ahora, usa tu email y contraseña.',
       });
     }

--- a/frontend/src/components/auth/SocialLoginButtons.tsx
+++ b/frontend/src/components/auth/SocialLoginButtons.tsx
@@ -62,7 +62,7 @@ export function SocialLoginButtons({
   if (!features.socialLogin) return null;
 
   const comingSoon = (provider: string) => {
-    toast('Estamos trabajando en esto', {
+    toast.info('Estamos trabajando en esto', {
       description: `Pronto podrás acceder con ${provider}. Por ahora, usa tu email y contraseña.`,
     });
   };

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -42,9 +42,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
+          "--normal-bg": "var(--card)",
+          "--normal-text": "var(--card-foreground)",
+          "--normal-border": "var(--primary)",
           "--border-radius": "var(--radius)",
         } as React.CSSProperties
       }


### PR DESCRIPTION
## Summary

- Normal toasts now use `--card` bg with `--primary` border instead of `--popover` for better contrast
- Auth "coming soon" toasts (`SocialLoginButtons`, `PasskeyButton`) switched from `toast()` to `toast.info()` for clear visual distinction

Closes #39

## Test plan

- [ ] Click social login buttons (Google, Apple, Facebook) — toast should show sky/blue info style
- [ ] Click passkey button — toast should show sky/blue info style
- [ ] Verify normal toasts (e.g., website builder autosave) have visible border and contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)