### PR TITLE
style(websites): bold NERBIS text in copyright

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -41,7 +41,7 @@ export default function HomePage() {
 
       {/* Footer */}
       <p className="mt-16 text-slate-500 text-sm">
-        © {new Date().getFullYear()} NERBIS — Todos los derechos reservados
+        © {new Date().getFullYear()} <span className="font-bold">NERBIS</span> — Todos los derechos reservados
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Aplica `font-bold` al texto "NERBIS" en el copyright del footer de la página principal

## Test plan
- [ ] Verificar visualmente que "NERBIS" aparece en negrilla en el footer de la landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Estilo**
  * El texto "NERBIS" en el pie de página ahora se muestra en negrita.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->