### PR TITLE
fix(infra): robustecer bootstrap sdd con branch aislado y symlinks dinámicos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,10 +202,11 @@ echo "📌 Branch anterior del usuario: $USER_BRANCH"
 # En worktrees, el branch ya fue asignado al crear el worktree.
 # Solo verificar que NO estamos en develop o main directamente.
 if [ "$CURRENT_BRANCH" = "develop" ] || [ "$CURRENT_BRANCH" = "main" ]; then
-  echo "❌ ERROR: El worktree está en '$CURRENT_BRANCH'. Crear un branch dedicado:"
-  git checkout -b {branch-name}
+  echo "❌ ERROR: El worktree está en '$CURRENT_BRANCH'. Creando branch desde develop..."
+  git fetch origin develop
+  git checkout -b {branch-name} origin/develop
 fi
-echo "✅ Worktree en branch: $CURRENT_BRANCH"
+echo "✅ Worktree en branch: $(git branch --show-current)"
 ```
 
 **Verificación post-branch (OBLIGATORIO):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,24 +47,48 @@ Lee `docs/SDD.md` antes de cambios arquitectónicos.
 - `EnterWorktree` es una acción interna de permisos — no es un comando manual
 
 ### Setup automático en worktrees (OBLIGATORIO)
-Al detectar que estás trabajando en un worktree con cambios frontend:
-1. Crear symlink de `node_modules` para no duplicar dependencias:
-   ```bash
-   if [ -d "frontend/node_modules" ] && [ ! -L "frontend/node_modules" ]; then
-     echo "Error: frontend/node_modules existe como directorio. Elimínalo antes de continuar."
-     exit 1
-   fi
-   ln -sfn "$(git rev-parse --show-toplevel)/../../../frontend/node_modules" frontend/node_modules
-   ```
-2. Crear symlink de `.env.local` si existe en el repo principal:
-   ```bash
-   [ -f "$(git rev-parse --show-toplevel)/../../../frontend/.env.local" ] && ln -sfn "$(git rev-parse --show-toplevel)/../../../frontend/.env.local" frontend/.env.local
-   ```
-3. Levantar dev server en puerto alternativo (3001, 3002, etc.):
-   ```bash
-   cd frontend && npm run dev -- --port 3001
-   ```
-4. Informar al usuario: "Preview disponible en http://localhost:3001"
+
+Al detectar que estás trabajando en un worktree, ejecutar este setup **ANTES de cualquier otro trabajo**:
+
+```bash
+# 1. Detectar el repo principal (funciona desde cualquier profundidad de worktree)
+MAIN_REPO="$(git rev-parse --git-common-dir | sed 's|/\.git$||')"
+
+# 2. Symlink de node_modules (evita duplicar ~500MB de dependencias)
+if [ -d "$MAIN_REPO/frontend/node_modules" ]; then
+  if [ -d "frontend/node_modules" ] && [ ! -L "frontend/node_modules" ]; then
+    echo "⚠️  frontend/node_modules es un directorio real. Eliminándolo para crear symlink..."
+    rm -rf frontend/node_modules
+  fi
+  ln -sfn "$MAIN_REPO/frontend/node_modules" frontend/node_modules
+  echo "✅ Symlink node_modules → repo principal"
+fi
+
+# 3. Symlink de .env.local (variables de entorno compartidas)
+if [ -f "$MAIN_REPO/frontend/.env.local" ]; then
+  ln -sfn "$MAIN_REPO/frontend/.env.local" frontend/.env.local
+  echo "✅ Symlink .env.local → repo principal"
+fi
+
+# 4. Symlink de backend .env si existe
+if [ -f "$MAIN_REPO/.env" ]; then
+  ln -sfn "$MAIN_REPO/.env" .env
+  echo "✅ Symlink .env → repo principal"
+fi
+```
+
+**Verificación post-setup** (OBLIGATORIO — no continuar si falla):
+```bash
+# Verificar que los symlinks se crearon correctamente
+[ -L "frontend/node_modules" ] && echo "✅ node_modules OK" || echo "❌ node_modules FALTA"
+[ -L "frontend/.env.local" ] && echo "✅ .env.local OK" || echo "⚠️  .env.local no existe (puede ser normal)"
+```
+
+**Dev server** (solo si el usuario lo pide o la tarea requiere preview):
+```bash
+cd frontend && npm run dev -- --port 3001
+# Informar: "Preview disponible en http://localhost:3001"
+```
 
 ## Skills
 
@@ -128,36 +152,104 @@ vía Task tool, y sintetizar sus resultados.
 ### Grafo de dependencias (DAG)
 
 ```text
-[init + branch] → explore → propose → 🚪 → spec + design (paralelo) → 🚪 → tasks → apply → 🚪 → verify → archive → [PR]
+[bootstrap: init + branch + symlinks] → explore → propose → 🚪 → spec + design (paralelo) → 🚪 → tasks → apply → 🚪 → verify → archive → [commit + push + PR a develop]
 ```
+
+**Regla de oro:** Si `git branch --show-current` devuelve `develop` o `main` en cualquier
+punto del pipeline, **DETENERSE INMEDIATAMENTE**. Algo salió mal en el bootstrap.
 
 ### Bootstrap automático (OBLIGATORIO en flujo SDD)
 
-Al iniciar `sdd-new` o `sdd-ff`, ANTES de lanzar cualquier sub-agente, ejecutar estos pasos automáticamente (NO preguntar, NO saltar):
+Al iniciar `sdd-new`, `sdd-ff`, o cualquier comando SDD que inicie un cambio nuevo,
+ejecutar estos pasos **en orden, sin saltar ninguno, sin preguntar**. Si un paso falla,
+**DETENERSE e informar al usuario**. NO continuar con el pipeline hasta que todos pasen.
 
-**Paso 1 — sdd-init (si no existe skill registry):**
+#### Paso 1 — sdd-init (si no existe skill registry)
 1. Verificar si `.atl/skill-registry.md` existe
-2. Si NO existe → lanzar `sdd-init` automáticamente (detecta stack, genera registry, persiste en Engram)
-3. Si SÍ existe → saltar (ya fue inicializado)
+2. Si NO existe → lanzar `sdd-init` automáticamente
+3. Si SÍ existe → saltar
 
-**Paso 2 — Crear branch:**
+#### Paso 2 — Crear branch aislado (CRÍTICO — NO SALTAR)
+
+**Determinar el nombre del branch:**
+- Si el usuario referencia un issue: `feature/issue-{N}-{descripcion-corta}`
+- Si es un fix: `fix/{change-name}`
+- Si es feature: `feature/{change-name}`
+
+**Determinar el contexto actual:**
+
 ```bash
-git checkout develop && git pull origin develop
-git checkout -b feature/{change-name}
+CURRENT_BRANCH=$(git branch --show-current)
+IS_WORKTREE=$(git rev-parse --is-inside-work-tree 2>/dev/null && [ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo "yes" || echo "no")
 ```
 
-**Paso 3 — Si el usuario referencia un issue de GitHub:**
+**Caso A — Estás en el repo principal (no worktree):**
+```bash
+# Guardar el branch actual del usuario para no perderlo
+USER_BRANCH="$CURRENT_BRANCH"
+
+# Crear branch desde develop actualizado
+git fetch origin develop
+git checkout -b {branch-name} origin/develop
+
+echo "✅ Branch '{branch-name}' creado desde develop"
+echo "📌 Branch anterior del usuario: $USER_BRANCH"
+```
+
+**Caso B — Estás en un worktree:**
+```bash
+# En worktrees, el branch ya fue asignado al crear el worktree.
+# Solo verificar que NO estamos en develop o main directamente.
+if [ "$CURRENT_BRANCH" = "develop" ] || [ "$CURRENT_BRANCH" = "main" ]; then
+  echo "❌ ERROR: El worktree está en '$CURRENT_BRANCH'. Crear un branch dedicado:"
+  git checkout -b {branch-name}
+fi
+echo "✅ Worktree en branch: $CURRENT_BRANCH"
+```
+
+**Verificación post-branch (OBLIGATORIO):**
+```bash
+# Confirmar que NO estamos en develop ni main
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "main" ]; then
+  echo "❌ FATAL: Seguimos en '$BRANCH'. El bootstrap falló. DETENERSE."
+  exit 1
+fi
+echo "✅ Branch de trabajo confirmado: $BRANCH"
+```
+
+#### Paso 3 — Setup de symlinks (si es worktree)
+
+Si `IS_WORKTREE` es "yes", ejecutar el **setup automático de worktrees** descrito arriba
+en la sección "Setup automático en worktrees". Esto crea symlinks de node_modules, .env.local, y .env.
+
+#### Paso 4 — Vincular issue de GitHub (si aplica)
+Si el usuario referencia un issue:
 1. Leer el issue completo (`gh issue view {N}` o MCP GitHub)
 2. Usar su contenido como intent del pipeline
-3. Branch: `feature/issue-{N}-{descripcion-corta}`
-4. Al crear PR: incluir `Closes #{N}` en el body
+3. Al crear PR al final: incluir `Closes #{N}` en el body
 
-Después de estos pasos, continuar con el pipeline (explore → propose → ...).
+#### Paso 5 — Confirmar al usuario
 
-Esto garantiza que:
-- Los agentes SIEMPRE tienen el skill registry disponible
-- El pipeline NUNCA toca el branch principal del desarrollador
-- Los issues de GitHub se vinculan automáticamente
+Mostrar un resumen antes de continuar:
+```
+🚀 SDD Bootstrap completo:
+  Branch: {branch-name}
+  Base: develop (commit {short-hash})
+  Worktree: {sí/no}
+  Symlinks: {node_modules ✅, .env.local ✅/⚠️}
+  Issue: #{N} (si aplica)
+  Persistencia: engram
+
+Iniciando pipeline: explore → propose → ...
+```
+
+**Esto garantiza que:**
+- Cada cambio SDD vive en su PROPIO branch aislado
+- El usuario puede probar cada cambio independientemente antes de merge
+- NUNCA se trabaja directamente en develop o main
+- Los worktrees tienen todos los symlinks necesarios
+- El usuario sabe exactamente dónde está parado
 
 ### Human Gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ ejecutar estos pasos **en orden, sin saltar ninguno, sin preguntar**. Si un paso
 
 ```bash
 CURRENT_BRANCH=$(git branch --show-current)
-IS_WORKTREE=$(git rev-parse --is-inside-work-tree 2>/dev/null && [ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo "yes" || echo "no")
+IS_WORKTREE=$(git rev-parse --is-inside-work-tree >/dev/null 2>&1 && [ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo "yes" || echo "no")
 ```
 
 **Caso A — Estás en el repo principal (no worktree):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,37 +51,38 @@ Lee `docs/SDD.md` antes de cambios arquitectónicos.
 Al detectar que estás trabajando en un worktree, ejecutar este setup **ANTES de cualquier otro trabajo**:
 
 ```bash
-# 1. Detectar el repo principal (funciona desde cualquier profundidad de worktree)
+# 1. Detectar paths absolutos (funciona desde cualquier subdirectorio del worktree)
 MAIN_REPO="$(git rev-parse --git-common-dir | sed 's|/\.git$||')"
+WT_ROOT="$(git rev-parse --show-toplevel)"
 
 # 2. Symlink de node_modules (evita duplicar ~500MB de dependencias)
 if [ -d "$MAIN_REPO/frontend/node_modules" ]; then
-  if [ -d "frontend/node_modules" ] && [ ! -L "frontend/node_modules" ]; then
+  if [ -d "$WT_ROOT/frontend/node_modules" ] && [ ! -L "$WT_ROOT/frontend/node_modules" ]; then
     echo "⚠️  frontend/node_modules es un directorio real. Eliminándolo para crear symlink..."
-    rm -rf frontend/node_modules
+    rm -rf "$WT_ROOT/frontend/node_modules"
   fi
-  ln -sfn "$MAIN_REPO/frontend/node_modules" frontend/node_modules
+  ln -sfn "$MAIN_REPO/frontend/node_modules" "$WT_ROOT/frontend/node_modules"
   echo "✅ Symlink node_modules → repo principal"
 fi
 
 # 3. Symlink de .env.local (variables de entorno compartidas)
 if [ -f "$MAIN_REPO/frontend/.env.local" ]; then
-  ln -sfn "$MAIN_REPO/frontend/.env.local" frontend/.env.local
+  ln -sfn "$MAIN_REPO/frontend/.env.local" "$WT_ROOT/frontend/.env.local"
   echo "✅ Symlink .env.local → repo principal"
 fi
 
 # 4. Symlink de backend .env si existe
 if [ -f "$MAIN_REPO/.env" ]; then
-  ln -sfn "$MAIN_REPO/.env" .env
+  ln -sfn "$MAIN_REPO/.env" "$WT_ROOT/.env"
   echo "✅ Symlink .env → repo principal"
 fi
 ```
 
 **Verificación post-setup** (OBLIGATORIO — no continuar si falla):
 ```bash
-# Verificar que los symlinks se crearon correctamente
-[ -L "frontend/node_modules" ] && echo "✅ node_modules OK" || echo "❌ node_modules FALTA"
-[ -L "frontend/.env.local" ] && echo "✅ .env.local OK" || echo "⚠️  .env.local no existe (puede ser normal)"
+WT_ROOT="$(git rev-parse --show-toplevel)"
+[ -L "$WT_ROOT/frontend/node_modules" ] && echo "✅ node_modules OK" || echo "❌ node_modules FALTA"
+[ -L "$WT_ROOT/frontend/.env.local" ] && echo "✅ .env.local OK" || echo "⚠️  .env.local no existe (puede ser normal)"
 ```
 
 **Dev server** (solo si el usuario lo pide o la tarea requiere preview):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ Si el usuario referencia un issue:
 #### Paso 5 — Confirmar al usuario
 
 Mostrar un resumen antes de continuar:
-```
+```text
 🚀 SDD Bootstrap completo:
   Branch: {branch-name}
   Base: develop (commit {short-hash})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ fi
 **Verificación post-setup** (OBLIGATORIO — no continuar si falla):
 ```bash
 WT_ROOT="$(git rev-parse --show-toplevel)"
-[ -L "$WT_ROOT/frontend/node_modules" ] && echo "✅ node_modules OK" || echo "❌ node_modules FALTA"
+[ -L "$WT_ROOT/frontend/node_modules" ] && echo "✅ node_modules OK" || { echo "❌ node_modules FALTA — DETENERSE"; exit 1; }
 [ -L "$WT_ROOT/frontend/.env.local" ] && echo "✅ .env.local OK" || echo "⚠️  .env.local no existe (puede ser normal)"
 ```
 


### PR DESCRIPTION
## Summary
- **Branch aislado por cambio SDD**: el bootstrap ahora detecta repo vs worktree, crea branch desde `origin/develop`, y valida con verificación post-branch que detiene el pipeline si falla
- **Symlinks dinámicos**: usa `git rev-parse --git-common-dir` para resolver el path del repo principal (funciona desde cualquier worktree), agrega symlink de `.env` backend
- **Regla de oro en el DAG**: si en cualquier punto del pipeline el branch es `develop` o `main`, se detiene inmediatamente
- **Resumen de bootstrap visible**: el usuario ve exactamente branch, base, symlinks e issue antes de que el pipeline continúe

## Problema
El orquestador SDD no creaba branches ni configuraba symlinks al iniciar `/sdd-new` o `/sdd-ff`, causando que los desarrollos se hicieran directamente sobre develop/main y que los worktrees no tuvieran acceso a node_modules ni .env.

## Test plan
- [ ] Ejecutar `/sdd-new test-feature` desde el repo principal → debe crear branch `feature/test-feature` desde develop
- [ ] Ejecutar `/sdd-new test-feature` desde un worktree → debe validar branch y crear symlinks
- [ ] Verificar que el pipeline se detiene si el branch es develop o main
- [ ] Verificar que los symlinks de node_modules y .env.local apuntan al repo principal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentación**
  * Mejoradas las instrucciones de bootstrap y setup: verificación obligatoria de enlaces simbólicos (fallo si falta node_modules; advertencia si falta .env local) y manejo seguro de node_modules.
  * Clarificadas y formalizadas las reglas de branching (nomenclatura, protecciones frente a develop/main) y regla de parada inmediata.
  * Ampliado el alcance del bootstrap a más comandos SDD, con pasos ordenados y parada/aviso en fallos.
  * Añadido resumen de confirmación al usuario antes de iniciar el flujo y ajuste: cierre automático de issues movido al final.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->