### PR TITLE
feat(infra): agregar limpieza de branch en sdd-archive tras merge del PR

### DIFF
--- a/.claude/skills/sdd-archive/SKILL.md
+++ b/.claude/skills/sdd-archive/SKILL.md
@@ -6,7 +6,7 @@ description: >
 license: MIT
 metadata:
   author: nerbis-platform
-  version: "1.0"
+  version: "1.1"
 ---
 
 ## Purpose
@@ -140,11 +140,73 @@ mem_save(
 ### NERBIS Actions
 - SDD.md update needed: {Yes — sections X, Y / No}
 - PR suggestion: {branch name} → develop
+- Branch cleanup: {Pending — will execute after PR merge / Skipped}
 
 ### SDD Cycle Complete
 The change has been fully planned, implemented, verified, and archived.
 Ready for the next change.
 ```
+
+### Step 8: Branch Cleanup (post-merge)
+
+**This step runs AFTER the PR has been merged to `develop`.** If the PR has not been created or merged yet, include the cleanup instructions in the summary and skip execution.
+
+**8.1 — Human Gate (MANDATORY)**
+
+Before executing any cleanup, ask the user for confirmation:
+```text
+🧹 Branch cleanup ready. This will:
+  - Delete remote branch: origin/{branch-name}
+  - Delete local branch: {branch-name}
+  - {If worktree: Remove worktree at {worktree-path}}
+  - Switch to develop (updated)
+
+Proceed with cleanup? (y/n)
+```
+
+Do NOT proceed without explicit user approval.
+
+**8.2 — Detect context**
+
+```bash
+BRANCH_NAME=$(git branch --show-current)
+IS_WORKTREE=$([ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo "yes" || echo "no")
+WT_PATH=$(git rev-parse --show-toplevel)
+```
+
+**8.3 — Execute cleanup**
+
+```bash
+# Switch to develop first (required before deleting the current branch)
+git checkout develop
+git pull origin develop
+
+# Delete remote branch (may already be deleted if "Automatically delete head branches" is enabled)
+git push origin --delete {branch-name} 2>/dev/null || echo "Remote branch already deleted (auto-delete may be enabled)"
+
+# Delete local branch (use -d for safe delete — fails if not fully merged)
+git branch -d {branch-name}
+```
+
+**8.4 — Worktree cleanup (if applicable)**
+
+If `IS_WORKTREE` was "yes":
+```bash
+# From the MAIN repo (not from inside the worktree)
+MAIN_REPO="$(git rev-parse --git-common-dir | sed 's|/\.git$||')"
+git -C "$MAIN_REPO" worktree remove {worktree-path}
+```
+
+**8.5 — Verify cleanup**
+
+```bash
+# Confirm branch is gone
+git branch | grep -q "{branch-name}" && echo "⚠️ Local branch still exists" || echo "✅ Local branch deleted"
+git ls-remote --heads origin {branch-name} | grep -q "{branch-name}" && echo "⚠️ Remote branch still exists" || echo "✅ Remote branch deleted"
+echo "✅ On branch: $(git branch --show-current)"
+```
+
+> **Tip:** Consider enabling "Automatically delete head branches" in the GitHub repository settings (Settings → General → Pull Requests) to handle remote branch deletion automatically on merge.
 
 ## Rules
 
@@ -155,4 +217,6 @@ Ready for the next change.
 - The archive is an AUDIT TRAIL — never delete or modify archived changes
 - ALWAYS suggest SDD.md updates for architectural changes
 - ALWAYS suggest PR creation to develop
+- ALWAYS ask for user confirmation (Human Gate) before deleting branches or worktrees
+- Use `git branch -d` (safe delete) — NEVER use `-D` (force delete) unless the user explicitly requests it
 - After the summary above, ALWAYS append a structured envelope: `{ status, executive_summary, artifacts: [{name, store, ref}], next_recommended: [...], risks: [...] }`

--- a/.claude/skills/sdd-archive/SKILL.md
+++ b/.claude/skills/sdd-archive/SKILL.md
@@ -166,12 +166,26 @@ Proceed with cleanup? (y/n)
 
 Do NOT proceed without explicit user approval.
 
-**8.2 — Detect context**
+**8.2 — Detect and validate context**
 
 ```bash
 BRANCH_NAME=$(git branch --show-current)
 IS_WORKTREE=$([ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo "yes" || echo "no")
 WT_PATH=$(git rev-parse --show-toplevel)
+
+# Guard: abort if BRANCH_NAME is empty (detached HEAD)
+if [ -z "$BRANCH_NAME" ]; then
+  echo "❌ Cannot determine current branch (detached HEAD?). Aborting cleanup."
+  exit 1
+fi
+
+# Guard: never delete protected branches
+case "$BRANCH_NAME" in
+  main|master|develop|release/*|hotfix/*)
+    echo "❌ Refusing to delete protected branch '$BRANCH_NAME'. Aborting cleanup."
+    exit 1
+    ;;
+esac
 ```
 
 **8.3 — Execute cleanup**

--- a/.claude/skills/sdd-archive/SKILL.md
+++ b/.claude/skills/sdd-archive/SKILL.md
@@ -201,8 +201,12 @@ fi
 git checkout develop
 git pull origin develop
 
-# Delete remote branch (may already be deleted if "Automatically delete head branches" is enabled)
-git push origin --delete "$BRANCH_NAME" 2>/dev/null || echo "Remote branch already deleted (auto-delete may be enabled)"
+# Delete remote branch (check if it exists first to avoid hiding real errors)
+if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+  git push origin --delete "$BRANCH_NAME" || echo "⚠️ Failed to delete remote branch (check permissions/network)"
+else
+  echo "✅ Remote branch already deleted (auto-delete may be enabled)"
+fi
 
 # Delete local branch (use -d for safe delete — fails if not fully merged)
 git branch -d "$BRANCH_NAME"
@@ -210,16 +214,22 @@ git branch -d "$BRANCH_NAME"
 
 **8.4 — Worktree cleanup (if applicable)**
 
-If `IS_WORKTREE` was "yes":
 ```bash
-# From the MAIN repo (not from inside the worktree)
-MAIN_REPO="$(git rev-parse --git-common-dir | sed 's|/\.git$||')"
-git -C "$MAIN_REPO" worktree remove "$WT_PATH"
+if [ "$IS_WORKTREE" = "yes" ]; then
+  # From the MAIN repo (not from inside the worktree)
+  MAIN_REPO="$(git rev-parse --show-toplevel 2>/dev/null || git rev-parse --git-common-dir | sed 's|/\.git$||')"
+  git -C "$MAIN_REPO" worktree remove "$WT_PATH"
+else
+  echo "ℹ️ Not a worktree, skipping worktree cleanup"
+fi
 ```
 
 **8.5 — Verify cleanup**
 
 ```bash
+# Ensure we're in a valid git directory (not in a deleted worktree)
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
 # Confirm branch is gone
 git branch | grep -q "$BRANCH_NAME" && echo "⚠️ Local branch still exists" || echo "✅ Local branch deleted"
 git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME" && echo "⚠️ Remote branch still exists" || echo "✅ Remote branch deleted"

--- a/.claude/skills/sdd-archive/SKILL.md
+++ b/.claude/skills/sdd-archive/SKILL.md
@@ -177,15 +177,21 @@ WT_PATH=$(git rev-parse --show-toplevel)
 **8.3 — Execute cleanup**
 
 ```bash
+# Verify working tree is clean before switching
+if ! git diff-index --quiet HEAD --; then
+  echo "⚠️ You have uncommitted changes. Please commit or stash them before cleanup."
+  exit 1
+fi
+
 # Switch to develop first (required before deleting the current branch)
 git checkout develop
 git pull origin develop
 
 # Delete remote branch (may already be deleted if "Automatically delete head branches" is enabled)
-git push origin --delete {branch-name} 2>/dev/null || echo "Remote branch already deleted (auto-delete may be enabled)"
+git push origin --delete "$BRANCH_NAME" 2>/dev/null || echo "Remote branch already deleted (auto-delete may be enabled)"
 
 # Delete local branch (use -d for safe delete — fails if not fully merged)
-git branch -d {branch-name}
+git branch -d "$BRANCH_NAME"
 ```
 
 **8.4 — Worktree cleanup (if applicable)**
@@ -194,15 +200,15 @@ If `IS_WORKTREE` was "yes":
 ```bash
 # From the MAIN repo (not from inside the worktree)
 MAIN_REPO="$(git rev-parse --git-common-dir | sed 's|/\.git$||')"
-git -C "$MAIN_REPO" worktree remove {worktree-path}
+git -C "$MAIN_REPO" worktree remove "$WT_PATH"
 ```
 
 **8.5 — Verify cleanup**
 
 ```bash
 # Confirm branch is gone
-git branch | grep -q "{branch-name}" && echo "⚠️ Local branch still exists" || echo "✅ Local branch deleted"
-git ls-remote --heads origin {branch-name} | grep -q "{branch-name}" && echo "⚠️ Remote branch still exists" || echo "✅ Remote branch deleted"
+git branch | grep -q "$BRANCH_NAME" && echo "⚠️ Local branch still exists" || echo "✅ Local branch deleted"
+git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME" && echo "⚠️ Remote branch still exists" || echo "✅ Remote branch deleted"
 echo "✅ On branch: $(git branch --show-current)"
 ```
 


### PR DESCRIPTION
## Summary

- Agrega **Step 8: Branch Cleanup (post-merge)** al skill `sdd-archive` para eliminar branches huérfanas tras el merge del PR
- Incluye Human Gate obligatorio antes de ejecutar cualquier borrado
- Soporta limpieza de worktrees cuando aplica
- Agrega reglas de seguridad (`-d` safe delete, nunca `-D`)

## Cambios

| Archivo | Cambio |
|---------|--------|
| `.claude/skills/sdd-archive/SKILL.md` | Step 8 completo + 2 reglas nuevas + version bump 1.0 → 1.1 |

## Detalle del Step 8

1. **8.1 — Human Gate**: Pide confirmación al usuario antes de borrar
2. **8.2 — Detect context**: Detecta branch actual y si estamos en worktree
3. **8.3 — Execute cleanup**: Switch a develop, delete remote, delete local
4. **8.4 — Worktree cleanup**: `git worktree remove` si aplica
5. **8.5 — Verify cleanup**: Confirma que branch fue eliminada

## Test plan

- [ ] Verificar que el markdown del skill es válido y bien formado
- [ ] Validar que los comandos bash del skill son sintácticamente correctos
- [ ] Test funcional: ejecutar `/sdd-archive` en un cambio completado y verificar que Step 8 aparece con Human Gate
- [ ] Test worktree: ejecutar desde un worktree y verificar que ofrece limpiar el worktree

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Funcionalidades**
  * Paso de limpieza de ramas post-fusión con confirmación humana obligatoria antes de cualquier eliminación.
  * Detección y manejo de contextos de worktree, incluida la eliminación de worktrees cuando procede.
  * Verificación posterior que confirma la ausencia de la rama en local y remoto y muestra la rama actual.

* **Documentación**
  * Plantilla de salida actualizada para indicar si la limpieza se ejecutará o se omitirá; reglas globales exigen eliminación segura (no forzada) salvo petición explícita.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->