### PR TITLE
fix(email): usar footer NERBIS limpio en templates OTP

### DIFF
--- a/backend/notifications/templates/emails/_nerbis_clean_footer.html
+++ b/backend/notifications/templates/emails/_nerbis_clean_footer.html
@@ -1,0 +1,4 @@
+<div class="footer">
+    <img src="cid:nerbis-logo" alt="NERBIS" width="36" height="36" style="display: block; margin: 0 auto 8px; border-radius: 6px;">
+    <p style="font-weight: 700; color: #1C3B57; font-size: 13px; margin: 0;">NERBIS</p>
+</div>

--- a/backend/notifications/templates/emails/base.html
+++ b/backend/notifications/templates/emails/base.html
@@ -115,9 +115,13 @@
                 {% if tenant_phone %}{{ tenant_phone }}{% endif %}
             </p>
             {% endif %}
+            {% if social_facebook or social_instagram %}
             <p style="margin-top: 12px;">
-                <a href="#">Facebook</a> | <a href="#">Instagram</a>
+                {% if social_facebook %}<a href="{{ social_facebook }}">Facebook</a>{% endif %}
+                {% if social_facebook and social_instagram %} | {% endif %}
+                {% if social_instagram %}<a href="{{ social_instagram }}">Instagram</a>{% endif %}
             </p>
+            {% endif %}
         </div>
         {% endblock %}
     </div>

--- a/backend/notifications/templates/emails/otp_account_reactivation.html
+++ b/backend/notifications/templates/emails/otp_account_reactivation.html
@@ -17,3 +17,10 @@
     <a href="{{ frontend_url }}/ayuda" style="color: #0D9488; text-decoration: none; font-weight: 500;">¿Necesitas ayuda?</a>
 </p>
 {% endblock %}
+
+{% block footer %}
+<div class="footer">
+    <img src="cid:nerbis-logo" alt="NERBIS" width="36" height="36" style="display: block; margin: 0 auto 8px; border-radius: 6px;">
+    <p style="font-weight: 700; color: #1C3B57; font-size: 13px; margin: 0;">NERBIS</p>
+</div>
+{% endblock %}

--- a/backend/notifications/templates/emails/otp_account_reactivation.html
+++ b/backend/notifications/templates/emails/otp_account_reactivation.html
@@ -19,8 +19,5 @@
 {% endblock %}
 
 {% block footer %}
-<div class="footer">
-    <img src="cid:nerbis-logo" alt="NERBIS" width="36" height="36" style="display: block; margin: 0 auto 8px; border-radius: 6px;">
-    <p style="font-weight: 700; color: #1C3B57; font-size: 13px; margin: 0;">NERBIS</p>
-</div>
+{% include "emails/_nerbis_clean_footer.html" %}
 {% endblock %}

--- a/backend/notifications/templates/emails/otp_password_reset.html
+++ b/backend/notifications/templates/emails/otp_password_reset.html
@@ -17,3 +17,10 @@
     <a href="{{ frontend_url }}/ayuda" style="color: #0D9488; text-decoration: none; font-weight: 500;">¿Necesitas ayuda?</a>
 </p>
 {% endblock %}
+
+{% block footer %}
+<div class="footer">
+    <img src="cid:nerbis-logo" alt="NERBIS" width="36" height="36" style="display: block; margin: 0 auto 8px; border-radius: 6px;">
+    <p style="font-weight: 700; color: #1C3B57; font-size: 13px; margin: 0;">NERBIS</p>
+</div>
+{% endblock %}

--- a/backend/notifications/templates/emails/otp_password_reset.html
+++ b/backend/notifications/templates/emails/otp_password_reset.html
@@ -19,8 +19,5 @@
 {% endblock %}
 
 {% block footer %}
-<div class="footer">
-    <img src="cid:nerbis-logo" alt="NERBIS" width="36" height="36" style="display: block; margin: 0 auto 8px; border-radius: 6px;">
-    <p style="font-weight: 700; color: #1C3B57; font-size: 13px; margin: 0;">NERBIS</p>
-</div>
+{% include "emails/_nerbis_clean_footer.html" %}
 {% endblock %}

--- a/backend/notifications/templates/emails/welcome.html
+++ b/backend/notifications/templates/emails/welcome.html
@@ -7,7 +7,7 @@
 {% block content %}
 <h2 style="text-align: center; margin-bottom: 24px;">¡Bienvenido a NERBIS!</h2>
 
-<p style="text-align: center;">Hola{{ user.first_name|yesno:",," }}{% if user.first_name %} {{ user.first_name }}{% endif %}, tu cuenta <strong style="color: #1C3B57;">{{ tenant_name }}</strong> está lista.</p>
+<p style="text-align: center;">Hola{% if user.first_name %} {{ user.first_name }}{% endif %}, tu cuenta <strong style="color: #1C3B57;">{{ tenant_name }}</strong> está lista.</p>
 
 <!--[if mso]>
 <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ frontend_url }}/dashboard" style="height:48px;v-text-anchor:middle;width:180px;" arcsize="50%" fillcolor="#0D9488" stroke="f">

--- a/backend/notifications/templates/emails/welcome.html
+++ b/backend/notifications/templates/emails/welcome.html
@@ -30,8 +30,5 @@
 {% endblock %}
 
 {% block footer %}
-<div class="footer">
-    <img src="cid:nerbis-logo" alt="NERBIS" width="36" height="36" style="display: block; margin: 0 auto 8px; border-radius: 6px;">
-    <p style="font-weight: 700; color: #1C3B57; font-size: 13px; margin: 0;">NERBIS</p>
-</div>
+{% include "emails/_nerbis_clean_footer.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Los templates OTP (`otp_password_reset.html` y `otp_account_reactivation.html`) heredaban el footer de `base.html` con datos del tenant (dirección, email, teléfono, redes sociales) que no corresponden para emails transaccionales de código OTP
- Ahora sobreescriben `{% block footer %}` con el footer limpio de NERBIS (logo + nombre), alineado con `welcome.html`

## Test plan
- [ ] Verificar que el email OTP de password reset muestra solo el footer NERBIS (sin datos del tenant)
- [ ] Verificar que el email OTP de reactivación muestra solo el footer NERBIS (sin datos del tenant)
- [ ] Verificar que el email de bienvenida sigue mostrando su footer NERBIS correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lanzamiento

* **Correcciones de Errores**
  * Los enlaces de redes sociales en los correos electrónicos ahora funcionan correctamente cuando se proporcionan credenciales sociales válidas.

* **Mejoras**
  * Se implementó un pie de página consistente y mejorado en todas las plantillas de notificación por correo electrónico, incluyendo el logo y enlaces sociales estandarizados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->