### PR TITLE
feat(profile): social providers en Mi Perfil + admin NERBIS

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -12,7 +12,7 @@ from unfold.forms import AdminPasswordChangeForm, UserChangeForm
 from unfold.forms import UserCreationForm as UnfoldUserCreationForm
 from unfold.widgets import UnfoldAdminTextareaWidget
 
-from .models import Banner, Tenant, TenantConfig, TenantWebsite, User
+from .models import Banner, SocialAccount, Tenant, TenantConfig, TenantWebsite, User
 
 
 class CustomUserCreationForm(UnfoldUserCreationForm):
@@ -963,6 +963,48 @@ class TenantWebsiteAdmin(UnfoldModelAdmin):
     )
 
 
+class AuthMethodFilter(admin.SimpleListFilter):
+    """Filtrar usuarios por método de autenticación."""
+
+    title = "Método de acceso"
+    parameter_name = "auth_method"
+
+    def lookups(self, request, model_admin):
+        return [
+            ("email_only", "Solo email"),
+            ("social_only", "Solo social"),
+            ("both", "Email + Social"),
+        ]
+
+    def queryset(self, request, queryset):
+        has_social = queryset.filter(social_accounts__isnull=False).distinct()
+        no_social = queryset.exclude(pk__in=has_social)
+
+        if self.value() == "email_only":
+            return no_social
+        if self.value() == "social_only":
+            # Usuarios sin password usable (solo social)
+            return has_social.exclude(password__startswith="pbkdf2_")
+        if self.value() == "both":
+            # Usuarios con password Y social
+            return has_social.filter(password__startswith="pbkdf2_")
+        return queryset
+
+
+class SocialAccountInline(admin.TabularInline):
+    """Cuentas sociales vinculadas al usuario."""
+
+    model = SocialAccount
+    extra = 0
+    fields = ["provider", "email", "provider_uid", "created_at"]
+    readonly_fields = ["provider", "email", "provider_uid", "created_at"]
+    can_delete = True
+    show_change_link = False
+
+    verbose_name = "Cuenta social"
+    verbose_name_plural = "Cuentas sociales vinculadas"
+
+
 @admin.register(User, site=nerbis_admin_site)
 class UserAdmin(UnfoldModelAdmin, BaseUserAdmin):
     """
@@ -978,6 +1020,8 @@ class UserAdmin(UnfoldModelAdmin, BaseUserAdmin):
     form = UserChangeForm
     add_form = CustomUserCreationForm
     change_password_form = AdminPasswordChangeForm
+
+    inlines = [SocialAccountInline]
 
     def has_module_permission(self, request):
         """Permitir ver el módulo Users"""
@@ -999,6 +1043,7 @@ class UserAdmin(UnfoldModelAdmin, BaseUserAdmin):
         "full_name_display",
         "tenant",
         "role_badge",
+        "auth_method_display",
         "is_active",
         "created_at",
     ]
@@ -1011,8 +1056,8 @@ class UserAdmin(UnfoldModelAdmin, BaseUserAdmin):
     def get_list_filter(self, request):
         """Mostrar más filtros solo a superusuarios"""
         if request.user.is_superuser:
-            return ["role", "is_active", "is_staff", "tenant", "created_at"]
-        return ["role", "is_active"]
+            return ["role", "is_active", "is_staff", "tenant", AuthMethodFilter, "created_at"]
+        return ["role", "is_active", AuthMethodFilter]
 
     def get_list_display_links(self, request, list_display):
         """
@@ -1348,6 +1393,31 @@ class UserAdmin(UnfoldModelAdmin, BaseUserAdmin):
 
     role_badge.short_description = "Rol"
 
+    @admin.display(description="Acceso")
+    def auth_method_display(self, obj):
+        """Indicador visual del método de autenticación."""
+        has_password = obj.has_usable_password()
+        social_accounts = obj.social_accounts.all()
+        providers = [sa.get_provider_display() for sa in social_accounts]
+
+        parts = []
+        if has_password:
+            parts.append(
+                '<span style="background-color: #6366f1; color: white; padding: 2px 8px; '
+                'border-radius: 3px; font-size: 11px;">Email</span>'
+            )
+        for provider in providers:
+            colors = {"Google": "#4285F4", "Apple": "#000000", "Facebook": "#1877F2"}
+            color = colors.get(provider, "#6b7280")
+            parts.append(
+                f'<span style="background-color: {color}; color: white; padding: 2px 8px; '
+                f'border-radius: 3px; font-size: 11px;">{provider}</span>'
+            )
+
+        if not parts:
+            return format_html('<span style="color: #9ca3af;">—</span>')
+        return format_html(" ".join(parts))
+
     def assigned_services_display(self, obj):
         """Mostrar servicios asignados al staff (solo lectura)"""
         if not hasattr(obj, "staff_profile"):
@@ -1393,6 +1463,85 @@ class UserAdmin(UnfoldModelAdmin, BaseUserAdmin):
         return format_html("".join(html_parts))
 
     assigned_services_display.short_description = "Servicios que puedo realizar"
+
+
+@admin.register(SocialAccount, site=nerbis_admin_site)
+class SocialAccountAdmin(UnfoldModelAdmin):
+    """
+    Panel de administración para Cuentas Sociales.
+    Permite ver y gestionar las vinculaciones sociales de los usuarios.
+    """
+
+    list_display = ["user", "provider_badge", "email", "tenant", "created_at"]
+    list_filter = ["provider", "tenant"]
+    search_fields = ["user__email", "user__first_name", "user__last_name", "email"]
+    search_help_text = "Buscar por email del usuario o email del proveedor"
+    readonly_fields = ["provider_uid", "extra_data", "created_at", "updated_at"]
+    ordering = ["-created_at"]
+    actions = ["disconnect_social_accounts"]
+
+    fieldsets = (
+        (
+            "Vinculación",
+            {"fields": ("user", "tenant", "provider", "email", "provider_uid")},
+        ),
+        (
+            "Datos adicionales",
+            {
+                "fields": ("extra_data", "created_at", "updated_at"),
+                "classes": ("collapse",),
+            },
+        ),
+    )
+
+    @admin.display(description="Proveedor")
+    def provider_badge(self, obj):
+        """Badge visual con color del proveedor."""
+        colors = {"google": "#4285F4", "apple": "#000000", "facebook": "#1877F2"}
+        color = colors.get(obj.provider, "#6b7280")
+        return format_html(
+            '<span style="background-color: {}; color: white; padding: 3px 10px; border-radius: 3px;">{}</span>',
+            color,
+            obj.get_provider_display(),
+        )
+
+    @admin.action(description="Desvincular cuentas sociales seleccionadas")
+    def disconnect_social_accounts(self, request, queryset):
+        """Elimina las vinculaciones seleccionadas verificando que el usuario no pierda acceso."""
+        disconnected = 0
+        skipped = 0
+        for social_account in queryset:
+            user = social_account.user
+            has_password = user.has_usable_password()
+            other_social = (
+                SocialAccount.objects.filter(user=user, tenant=user.tenant).exclude(pk=social_account.pk).count()
+            )
+            if not has_password and other_social == 0:
+                skipped += 1
+                continue
+            social_account.delete()
+            disconnected += 1
+
+        if disconnected:
+            self.message_user(request, f"{disconnected} cuenta(s) desvinculada(s) correctamente.")
+        if skipped:
+            self.message_user(
+                request,
+                f"{skipped} cuenta(s) omitida(s) porque es el único método de acceso del usuario.",
+                level="warning",
+            )
+
+    def has_add_permission(self, request):
+        """Las cuentas sociales se crean por OAuth, no manualmente."""
+        return False
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        if hasattr(request.user, "tenant") and request.user.tenant:
+            return qs.filter(tenant=request.user.tenant)
+        return qs.none()
 
 
 @admin.register(Banner, site=nerbis_admin_site)

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -3,7 +3,7 @@
 from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers
 
-from .models import Banner, Tenant, User
+from .models import Banner, SocialAccount, Tenant, User
 
 
 class TenantSerializer(serializers.ModelSerializer):
@@ -65,12 +65,23 @@ class TenantSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "slug"]
 
 
+class SocialAccountSerializer(serializers.ModelSerializer):
+    """Serializer para cuentas sociales vinculadas."""
+
+    class Meta:
+        model = SocialAccount
+        fields = ["id", "provider", "email", "created_at"]
+        read_only_fields = fields
+
+
 class UserSerializer(serializers.ModelSerializer):
     """Serializer para User (información completa)"""
 
     tenant_name = serializers.CharField(source="tenant.name", read_only=True)
     role_display = serializers.CharField(source="get_role_display", read_only=True)
     full_name = serializers.SerializerMethodField()
+    has_password = serializers.SerializerMethodField()
+    social_accounts = SocialAccountSerializer(many=True, read_only=True)
 
     class Meta:
         model = User
@@ -89,11 +100,16 @@ class UserSerializer(serializers.ModelSerializer):
             "role_display",
             "is_active",
             "date_joined",
+            "has_password",
+            "social_accounts",
         ]
         read_only_fields = ["id", "tenant", "date_joined"]
 
     def get_full_name(self, obj) -> str:
         return obj.get_full_name() or obj.username
+
+    def get_has_password(self, obj) -> bool:
+        return obj.has_usable_password()
 
 
 class UserPublicSerializer(serializers.ModelSerializer):

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -25,8 +25,11 @@ urlpatterns = [
     # OTP - Reactivación de cuenta
     path("auth/request-reactivation/", views.RequestReactivationOTPView.as_view(), name="request_reactivation"),
     path("auth/verify-reactivation/", views.VerifyReactivationOTPView.as_view(), name="verify_reactivation"),
-    # Social Auth (link/ must come before <str:provider>/ to avoid matching "link" as provider)
+    # Social Auth (link/ and disconnect/ must come before <str:provider>/ to avoid matching as provider)
     path("auth/social/link/", views.SocialLinkView.as_view(), name="social_link"),
+    path(
+        "auth/social/disconnect/<str:provider>/", views.SocialAccountDisconnectView.as_view(), name="social_disconnect"
+    ),
     path("auth/social/<str:provider>/", views.SocialLoginView.as_view(), name="social_login"),
     # Banners
     path("banners/", views.ActiveBannersView.as_view(), name="active_banners"),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1735,6 +1735,55 @@ class SocialLinkView(APIView):
         return Response(_build_social_auth_response(user, tenant))
 
 
+class SocialAccountDisconnectView(APIView):
+    """
+    DELETE /api/auth/social/<provider>/ — Desvincular cuenta social.
+
+    Solo permite desvincular si el usuario tiene contraseña u otra cuenta social,
+    para evitar que quede sin forma de acceder.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        responses={
+            200: OpenApiResponse(description="Cuenta social desvinculada"),
+            400: OpenApiResponse(description="No se puede desvincular (único método de acceso)"),
+            404: OpenApiResponse(description="No hay cuenta vinculada para este proveedor"),
+        },
+        parameters=[
+            OpenApiParameter(name="provider", location="path", type=str, enum=["google", "apple", "facebook"]),
+        ],
+    )
+    def delete(self, request, provider):
+        if provider not in ("google", "apple", "facebook"):
+            return Response({"error": "Proveedor no válido"}, status=status.HTTP_400_BAD_REQUEST)
+
+        user = request.user
+        social_account = SocialAccount.objects.filter(user=user, tenant=user.tenant, provider=provider).first()
+
+        if not social_account:
+            return Response(
+                {"error": f"No tienes una cuenta de {provider} vinculada"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Verificar que el usuario no quede sin forma de acceder
+        has_password = user.has_usable_password()
+        other_social_count = (
+            SocialAccount.objects.filter(user=user, tenant=user.tenant).exclude(id=social_account.id).count()
+        )
+
+        if not has_password and other_social_count == 0:
+            return Response(
+                {"error": "No puedes desvincular tu único método de acceso. Establece una contraseña primero."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        social_account.delete()
+        return Response({"message": f"Cuenta de {provider} desvinculada correctamente"})
+
+
 class PlatformSocialLoginView(APIView):
     """
     POST /api/public/platform-social-login/ — Social login cross-tenant.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: ['lucide-react'],
+  },
   images: {
     remotePatterns: [
       // Desarrollo: localhost

--- a/frontend/src/app/dashboard/DashboardShell.tsx
+++ b/frontend/src/app/dashboard/DashboardShell.tsx
@@ -18,7 +18,8 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
   // Rutas con layout limpio (sin Header/Footer de tienda)
   const isBuilderRoute = pathname.startsWith('/dashboard/website-builder');
   const isSetupRoute = pathname === '/dashboard/setup';
-  const isCleanLayout = isBuilderRoute || isSetupRoute;
+  const isProfileRoute = pathname === '/dashboard/profile';
+  const isCleanLayout = isBuilderRoute || isSetupRoute || isProfileRoute;
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -31,18 +32,19 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
       router.push('/login?redirect=/dashboard');
       return;
     }
-    // Redirect to setup if modules not configured (except if already on setup)
-    if (tenant && !tenant.modules_configured && !isSetupRoute) {
+    // Redirect to setup if modules not configured (except if already on setup or profile)
+    if (tenant && !tenant.modules_configured && !isSetupRoute && !isProfileRoute) {
       router.push('/dashboard/setup');
     } else if (
       tenant?.has_website &&
       tenant.website_status !== 'published' &&
       !isBuilderRoute &&
-      !isSetupRoute
+      !isSetupRoute &&
+      !isProfileRoute
     ) {
       router.push('/dashboard/website-builder');
     }
-  }, [mounted, isAuthenticated, isLoading, tenant, isSetupRoute, isBuilderRoute, router]);
+  }, [mounted, isAuthenticated, isLoading, tenant, isSetupRoute, isBuilderRoute, isProfileRoute, router]);
 
   // Layout limpio para Setup y Website Builder
   if (isCleanLayout) {

--- a/frontend/src/app/dashboard/profile/page.tsx
+++ b/frontend/src/app/dashboard/profile/page.tsx
@@ -3,25 +3,29 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
 import { useAuth } from '@/contexts/AuthContext';
-import { updateUserProfile, changePassword, deleteAccount } from '@/lib/api/user';
+import { updateUserProfile, changePassword, deleteAccount, getUserProfile, disconnectSocialAccount } from '@/lib/api/user';
 import { useToast } from '@/hooks/use-toast';
+import type { SocialProvider } from '@/types';
+import Image from 'next/image';
 import {
   ArrowLeft,
-  User,
-  Mail,
   Lock,
   Trash2,
   Save,
-  AlertTriangle,
   Eye,
-  EyeOff
+  EyeOff,
+  Check,
+  X,
+  KeyRound,
+  LogOut,
+  UserCircle,
 } from 'lucide-react';
 import Link from 'next/link';
 import {
@@ -36,6 +40,67 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 
+// ─── Estilos hoisted (evita recreación en cada render) ──────────────
+const navyBg = { background: '#1C3B57' } as const;
+const navyText = { color: '#1C3B57' } as const;
+const navyIconBg = { background: 'rgba(28, 59, 87, 0.06)' } as const;
+const bodyText = { color: '#374151' } as const;
+const tealCta = { color: '#0D9488', background: 'rgba(13, 148, 136, 0.08)' } as const;
+
+// ─── SVG Icons para providers sociales (hoisted como constantes) ────
+
+const googleIcon = (
+  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+  </svg>
+);
+
+const appleIcon = (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+  </svg>
+);
+
+const facebookIcon = (
+  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" fill="#1877F2" />
+  </svg>
+);
+
+const PROVIDER_CONFIG: Record<SocialProvider, { name: string; icon: React.ReactElement }> = {
+  google: { name: 'Google', icon: googleIcon },
+  apple: { name: 'Apple', icon: appleIcon },
+  facebook: { name: 'Facebook', icon: facebookIcon },
+};
+
+// ─── Componente reutilizable: toggle de visibilidad de contraseña ───
+
+function PasswordToggle({
+  show,
+  onToggle,
+}: {
+  show: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      onClick={onToggle}
+      className="absolute right-1 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+      aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+    >
+      {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+    </Button>
+  );
+}
+
+// ─── Página principal ───────────────────────────────────────────────
+
 export default function ProfilePage() {
   const { user, logout, setUser } = useAuth();
   const router = useRouter();
@@ -43,10 +108,15 @@ export default function ProfilePage() {
   const queryClient = useQueryClient();
   const [mounted, setMounted] = useState(false);
 
-  // Efecto para manejar hidratación
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
+
+    // theme-color para navegadores mobile
+    const meta = document.createElement('meta');
+    meta.name = 'theme-color';
+    meta.content = '#fafbfc';
+    document.head.appendChild(meta);
+    return () => { document.head.removeChild(meta); };
   }, []);
 
   // Estado para el formulario de perfil
@@ -56,17 +126,16 @@ export default function ProfilePage() {
     phone: '',
   });
 
-  // Actualizar profileData cuando user cambie
   useEffect(() => {
     if (user) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setProfileData({
         first_name: user.first_name || '',
         last_name: user.last_name || '',
         phone: user.phone || '',
       });
     }
-  }, [user]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- usamos primitives para evitar re-renders innecesarios
+  }, [user?.first_name, user?.last_name, user?.phone]);
 
   // Estado para el formulario de cambio de contraseña
   const [passwordData, setPasswordData] = useState({
@@ -75,75 +144,62 @@ export default function ProfilePage() {
     new_password2: '',
   });
 
-  // Estados para mostrar/ocultar contraseñas
   const [showOldPassword, setShowOldPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-
-  // Estado para eliminar cuenta
   const [deletePassword, setDeletePassword] = useState('');
   const [showDeletePassword, setShowDeletePassword] = useState(false);
 
-  // Mutación para actualizar perfil
+  // Query para obtener perfil completo (incluye social_accounts y has_password)
+  const { data: profile } = useQuery({
+    queryKey: ['user-profile'],
+    queryFn: getUserProfile,
+    enabled: mounted,
+  });
+
   const updateProfileMutation = useMutation({
     mutationFn: updateUserProfile,
     onSuccess: (data) => {
       setUser(data);
       queryClient.invalidateQueries({ queryKey: ['user'] });
-      toast({
-        title: 'Perfil actualizado',
-        description: 'Tus datos han sido actualizados correctamente',
-      });
+      toast({ title: 'Perfil actualizado', description: 'Tus datos han sido actualizados correctamente' });
     },
     onError: (error: Error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive',
-      });
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
     },
   });
 
-  // Mutación para cambiar contraseña
   const changePasswordMutation = useMutation({
     mutationFn: changePassword,
     onSuccess: () => {
-      setPasswordData({
-        current_password: '',
-        new_password: '',
-        new_password2: '',
-      });
-      toast({
-        title: 'Contraseña actualizada',
-        description: 'Tu contraseña ha sido cambiada correctamente',
-      });
+      setPasswordData({ current_password: '', new_password: '', new_password2: '' });
+      toast({ title: 'Contraseña actualizada', description: 'Tu contraseña ha sido cambiada correctamente' });
     },
     onError: (error: Error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive',
-      });
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
     },
   });
 
-  // Mutación para eliminar cuenta
   const deleteAccountMutation = useMutation({
     mutationFn: deleteAccount,
     onSuccess: () => {
-      toast({
-        title: 'Cuenta eliminada',
-        description: 'Tu cuenta ha sido eliminada correctamente',
-      });
+      toast({ title: 'Cuenta eliminada', description: 'Tu cuenta ha sido eliminada correctamente' });
       logout();
       router.push('/');
     },
     onError: (error: Error) => {
-      toast({
-        title: 'Error',
-        description: error.message,
-        variant: 'destructive',
-      });
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: disconnectSocialAccount,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['user-profile'] });
+      toast({ title: 'Cuenta desvinculada', description: data.message });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
     },
   });
 
@@ -154,277 +210,374 @@ export default function ProfilePage() {
 
   const handlePasswordSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
     if (passwordData.new_password !== passwordData.new_password2) {
-      toast({
-        title: 'Error',
-        description: 'Las contraseñas no coinciden',
-        variant: 'destructive',
-      });
+      toast({ title: 'Error', description: 'Las contraseñas no coinciden', variant: 'destructive' });
       return;
     }
-
     if (passwordData.new_password.length < 8) {
-      toast({
-        title: 'Error',
-        description: 'La contraseña debe tener al menos 8 caracteres',
-        variant: 'destructive',
-      });
+      toast({ title: 'Error', description: 'La contraseña debe tener al menos 8 caracteres', variant: 'destructive' });
       return;
     }
-
     changePasswordMutation.mutate(passwordData);
   };
 
   const handleDeleteAccount = () => {
     if (!deletePassword) {
-      toast({
-        title: 'Error',
-        description: 'Debes ingresar tu contraseña para confirmar',
-        variant: 'destructive',
-      });
+      toast({ title: 'Error', description: 'Debes ingresar tu contraseña para confirmar', variant: 'destructive' });
       return;
     }
     deleteAccountMutation.mutate(deletePassword);
   };
 
+  const firstName = user?.first_name || '';
+
   return (
-    <div className="max-w-4xl">
-      <div className="mb-8">
-          <Button variant="ghost" size="sm" asChild className="mb-4">
-            <Link href="/dashboard">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Volver al panel
-            </Link>
-          </Button>
-          <h1 className="text-3xl font-bold mb-2">Mi Perfil</h1>
-          <p className="text-muted-foreground">
-            Administra tu información personal y configuración de cuenta
-          </p>
+    <>
+      <style jsx global>{`
+        html, body { background: #fafbfc !important; }
+      `}</style>
+
+      <div className="min-h-screen bg-[#fafbfc]">
+        {/* Skip link — accesibilidad */}
+        <a
+          href="#profile-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-white focus:text-[#1C3B57] focus:rounded-md focus:shadow-md focus:text-sm focus:font-medium"
+        >
+          Ir al contenido
+        </a>
+
+        {/* Header — identidad NERBIS */}
+        <div className="bg-white border-b border-gray-100">
+          <div className="max-w-3xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Image
+                src="/Isotipo_color_NERBIS.png"
+                alt="Nerbis"
+                width={36}
+                height={36}
+              />
+              <span
+                className="text-[0.85rem] font-semibold tracking-wide"
+                style={navyText}
+              >
+                NERBIS
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                asChild
+                className="text-xs text-gray-500 hover:text-[#1C3B57]"
+              >
+                <Link href="/dashboard">
+                  <ArrowLeft className="w-3.5 h-3.5" aria-hidden="true" />
+                  <span className="hidden sm:inline">Volver</span>
+                </Link>
+              </Button>
+              <div className="w-px h-4 bg-gray-200" aria-hidden="true" />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => logout()}
+                className="text-xs text-gray-400 hover:text-red-500 hover:bg-red-50"
+              >
+                <LogOut className="w-3.5 h-3.5" aria-hidden="true" />
+                Salir
+              </Button>
+            </div>
+          </div>
         </div>
 
-        <div className="space-y-6">
-          {/* Información de cuenta */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <User className="h-5 w-5" />
-                Información de Cuenta
-              </CardTitle>
-              <CardDescription>
-                Información básica de tu cuenta que no puede ser modificada
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-start gap-3 p-3 rounded-lg bg-muted/50">
-                <Mail className="h-5 w-5 text-muted-foreground mt-0.5" />
-                <div className="flex-1">
-                  <Label className="text-xs text-muted-foreground">Correo electrónico</Label>
-                  <p className="font-medium text-sm">
-                    {!mounted ? 'Cargando...' : user?.email}
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        <main id="profile-content" className="w-full max-w-3xl mx-auto px-4 sm:px-6 py-10">
+          {/* Page header */}
+          <div className="mb-10 profile-fade-up text-center">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4" style={navyIconBg}>
+              <UserCircle className="w-8 h-8" style={navyText} aria-hidden="true" />
+            </div>
+            <h1
+              className="text-[2rem] sm:text-[2.4rem] leading-[1.15] tracking-[-0.025em] mb-2 text-pretty"
+              style={navyText}
+            >
+              <span style={{ fontWeight: 300 }}>
+                {firstName ? `${firstName}, ` : ''}tu
+              </span>{' '}
+              <span style={{ fontWeight: 600 }}>cuenta</span>
+            </h1>
+            <p className="text-sm text-gray-400">
+              Administra tu información personal y seguridad
+            </p>
+          </div>
 
-          {/* Información personal */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <User className="h-5 w-5" />
-                Información Personal
-              </CardTitle>
-              <CardDescription>
-                Actualiza tu información personal
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handleProfileSubmit} className="space-y-4">
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="grid gap-2">
-                    <Label htmlFor="first_name">Nombre</Label>
+          {/* ── Métodos de acceso ── */}
+          <section className="mb-8 profile-fade-up profile-delay-1">
+            <h2 className="text-[0.7rem] text-gray-400 font-medium tracking-wide uppercase mb-3">
+              Métodos de acceso
+            </h2>
+            <div className="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
+              {/* Email + Contraseña */}
+              <div className="flex items-center justify-between px-4 py-3.5 hover:bg-gray-50/50 transition-colors">
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 bg-gray-50">
+                    <KeyRound className="w-4.5 h-4.5 text-gray-400" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <p className="text-[0.85rem] font-medium" style={bodyText}>Email y contraseña</p>
+                    <p className="text-xs text-gray-400 truncate">{!mounted ? 'Cargando\u2026' : user?.email}</p>
+                  </div>
+                </div>
+                {profile?.has_password ? (
+                  <Badge variant="outline" className="gap-1 text-[0.68rem] text-emerald-600 border-emerald-200 bg-emerald-50">
+                    <Check className="h-3 w-3" aria-hidden="true" />
+                    Activo
+                  </Badge>
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => router.push('/forgot-password')}
+                    className="text-xs font-medium"
+                    style={tealCta}
+                  >
+                    Crear contraseña
+                  </Button>
+                )}
+              </div>
+
+              {/* Providers sociales */}
+              {(['google', 'apple', 'facebook'] as SocialProvider[]).map((provider) => {
+                const config = PROVIDER_CONFIG[provider];
+                const linked = profile?.social_accounts?.find((sa) => sa.provider === provider);
+                const canDisconnect = (profile?.has_password) || ((profile?.social_accounts?.length ?? 0) > 1);
+
+                return (
+                  <div key={provider} className="flex items-center justify-between px-4 py-3.5 hover:bg-gray-50/50 transition-colors">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 bg-gray-50">
+                        {config.icon}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-[0.85rem] font-medium" style={bodyText}>{config.name}</p>
+                        <p className="text-xs text-gray-400 truncate">
+                          {linked ? linked.email : 'Disponible para vincular'}
+                        </p>
+                      </div>
+                    </div>
+                    {linked ? (
+                      <div className="flex items-center gap-2 shrink-0">
+                        <Badge variant="outline" className="gap-1 text-[0.68rem] text-emerald-600 border-emerald-200 bg-emerald-50">
+                          <Check className="h-3 w-3" aria-hidden="true" />
+                          Vinculado
+                        </Badge>
+                        {canDisconnect && (
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                className="text-gray-300 hover:text-red-500 hover:bg-red-50"
+                                aria-label={`Desvincular ${config.name}`}
+                              >
+                                <X className="h-3.5 w-3.5" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Desvincular {config.name}</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  Ya no podrás iniciar sesión con {config.name}. Puedes volver a vincularla iniciando sesión con esa cuenta.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() => disconnectMutation.mutate(provider)}
+                                  disabled={disconnectMutation.isPending}
+                                >
+                                  {disconnectMutation.isPending ? 'Desvinculando\u2026' : 'Desvincular'}
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-xs text-gray-400">Vincula desde el login</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            {!profile?.has_password && (
+              <p className="text-xs text-gray-400 mt-2 px-1">
+                Crea una contraseña para acceder también por email, sin depender de redes sociales.
+              </p>
+            )}
+          </section>
+
+          {/* ── Información personal ── */}
+          <section className="mb-8 profile-fade-up profile-delay-2">
+            <h2 className="text-[0.7rem] text-gray-400 font-medium tracking-wide uppercase mb-3">
+              Información personal
+            </h2>
+            <div className="rounded-xl border border-gray-200 bg-white">
+              <form onSubmit={handleProfileSubmit} className="px-4 py-5 space-y-4">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="first_name" className="text-xs text-gray-500">Nombre</Label>
                     <Input
                       id="first_name"
+                      name="first_name"
                       value={profileData.first_name}
-                      onChange={(e) =>
-                        setProfileData({ ...profileData, first_name: e.target.value })
-                      }
+                      onChange={(e) => setProfileData(prev => ({ ...prev, first_name: e.target.value }))}
                       required
+                      autoComplete="given-name"
+                      spellCheck={false}
+                      className="h-10"
                     />
                   </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="last_name">Apellido</Label>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="last_name" className="text-xs text-gray-500">Apellido</Label>
                     <Input
                       id="last_name"
+                      name="last_name"
                       value={profileData.last_name}
-                      onChange={(e) =>
-                        setProfileData({ ...profileData, last_name: e.target.value })
-                      }
+                      onChange={(e) => setProfileData(prev => ({ ...prev, last_name: e.target.value }))}
                       required
+                      autoComplete="family-name"
+                      spellCheck={false}
+                      className="h-10"
                     />
                   </div>
                 </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="phone">Teléfono</Label>
+                <div className="grid gap-1.5">
+                  <Label htmlFor="phone" className="text-xs text-gray-500">Teléfono</Label>
                   <Input
                     id="phone"
+                    name="phone"
                     type="tel"
+                    inputMode="tel"
                     value={profileData.phone}
-                    onChange={(e) =>
-                      setProfileData({ ...profileData, phone: e.target.value })
-                    }
+                    onChange={(e) => setProfileData(prev => ({ ...prev, phone: e.target.value }))}
+                    autoComplete="tel"
+                    className="h-10"
                   />
                 </div>
-                <Button
-                  type="submit"
-                  disabled={updateProfileMutation.isPending}
-                  className="w-full md:w-auto"
-                >
-                  <Save className="h-4 w-4 mr-2" />
-                  {updateProfileMutation.isPending ? 'Guardando...' : 'Guardar cambios'}
-                </Button>
+                <div className="flex justify-end pt-1">
+                  <Button
+                    type="submit"
+                    disabled={updateProfileMutation.isPending}
+                    className="rounded-lg text-[0.82rem] hover:shadow-md active:scale-[0.98]"
+                    style={navyBg}
+                  >
+                    <Save className="h-3.5 w-3.5" aria-hidden="true" />
+                    {updateProfileMutation.isPending ? 'Guardando\u2026' : 'Guardar cambios'}
+                  </Button>
+                </div>
               </form>
-            </CardContent>
-          </Card>
+            </div>
+          </section>
 
-          {/* Cambiar contraseña */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Lock className="h-5 w-5" />
-                Cambiar Contraseña
-              </CardTitle>
-              <CardDescription>
-                Actualiza tu contraseña para mantener tu cuenta segura
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handlePasswordSubmit} className="space-y-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="current_password">Contraseña actual</Label>
-                  <div className="relative">
-                    <Input
-                      id="current_password"
-                      type={showOldPassword ? "text" : "password"}
-                      value={passwordData.current_password}
-                      onChange={(e) =>
-                        setPasswordData({ ...passwordData, current_password: e.target.value })
-                      }
-                      required
-                      className="pr-10"
-                    />
+          {/* ── Cambiar contraseña (solo si tiene password) ── */}
+          {profile?.has_password && (
+            <section className="mb-8 profile-fade-up profile-delay-3">
+              <h2 className="text-[0.7rem] text-gray-400 font-medium tracking-wide uppercase mb-3">
+                Cambiar contraseña
+              </h2>
+              <div className="rounded-xl border border-gray-200 bg-white">
+                <form onSubmit={handlePasswordSubmit} className="px-4 py-5 space-y-4">
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="current_password" className="text-xs text-gray-500">Contraseña actual</Label>
+                    <div className="relative">
+                      <Input
+                        id="current_password"
+                        name="current_password"
+                        type={showOldPassword ? 'text' : 'password'}
+                        value={passwordData.current_password}
+                        onChange={(e) => setPasswordData(prev => ({ ...prev, current_password: e.target.value }))}
+                        required
+                        autoComplete="current-password"
+                        className="h-10 pr-10"
+                      />
+                      <PasswordToggle show={showOldPassword} onToggle={() => setShowOldPassword(v => !v)} />
+                    </div>
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="new_password" className="text-xs text-gray-500">Nueva contraseña</Label>
+                    <div className="relative">
+                      <Input
+                        id="new_password"
+                        name="new_password"
+                        type={showNewPassword ? 'text' : 'password'}
+                        value={passwordData.new_password}
+                        onChange={(e) => setPasswordData(prev => ({ ...prev, new_password: e.target.value }))}
+                        required
+                        minLength={8}
+                        autoComplete="new-password"
+                        className="h-10 pr-10"
+                      />
+                      <PasswordToggle show={showNewPassword} onToggle={() => setShowNewPassword(v => !v)} />
+                    </div>
+                    <p className="text-[0.7rem] text-gray-400">Mínimo 8 caracteres</p>
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="new_password2" className="text-xs text-gray-500">Confirmar nueva contraseña</Label>
+                    <div className="relative">
+                      <Input
+                        id="new_password2"
+                        name="new_password2"
+                        type={showConfirmPassword ? 'text' : 'password'}
+                        value={passwordData.new_password2}
+                        onChange={(e) => setPasswordData(prev => ({ ...prev, new_password2: e.target.value }))}
+                        required
+                        minLength={8}
+                        autoComplete="new-password"
+                        className="h-10 pr-10"
+                      />
+                      <PasswordToggle show={showConfirmPassword} onToggle={() => setShowConfirmPassword(v => !v)} />
+                    </div>
+                  </div>
+                  <div className="flex justify-end pt-1">
                     <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setShowOldPassword(!showOldPassword)}
-                      className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 text-muted-foreground hover:text-foreground"
+                      type="submit"
+                      disabled={changePasswordMutation.isPending}
+                      className="rounded-lg text-[0.82rem] hover:shadow-md active:scale-[0.98]"
+                      style={navyBg}
                     >
-                      {showOldPassword ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
+                      <Lock className="h-3.5 w-3.5" aria-hidden="true" />
+                      {changePasswordMutation.isPending ? 'Actualizando\u2026' : 'Cambiar contraseña'}
                     </Button>
                   </div>
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="new_password">Nueva contraseña</Label>
-                  <div className="relative">
-                    <Input
-                      id="new_password"
-                      type={showNewPassword ? "text" : "password"}
-                      value={passwordData.new_password}
-                      onChange={(e) =>
-                        setPasswordData({ ...passwordData, new_password: e.target.value })
-                      }
-                      required
-                      minLength={8}
-                      className="pr-10"
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setShowNewPassword(!showNewPassword)}
-                      className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 text-muted-foreground hover:text-foreground"
-                    >
-                      {showNewPassword ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    Mínimo 8 caracteres
-                  </p>
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="new_password2">Confirmar nueva contraseña</Label>
-                  <div className="relative">
-                    <Input
-                      id="new_password2"
-                      type={showConfirmPassword ? "text" : "password"}
-                      value={passwordData.new_password2}
-                      onChange={(e) =>
-                        setPasswordData({ ...passwordData, new_password2: e.target.value })
-                      }
-                      required
-                      minLength={8}
-                      className="pr-10"
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                      className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 text-muted-foreground hover:text-foreground"
-                    >
-                      {showConfirmPassword ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-                <Button
-                  type="submit"
-                  disabled={changePasswordMutation.isPending}
-                  className="w-full md:w-auto"
-                >
-                  <Lock className="h-4 w-4 mr-2" />
-                  {changePasswordMutation.isPending ? 'Actualizando...' : 'Cambiar contraseña'}
-                </Button>
-              </form>
-            </CardContent>
-          </Card>
+                </form>
+              </div>
+            </section>
+          )}
 
-          {/* Zona de peligro */}
-          <Card className="border-destructive">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-destructive">
-                <AlertTriangle className="h-5 w-5" />
-                Zona de Peligro
-              </CardTitle>
-              <CardDescription>
-                Acciones irreversibles que afectan tu cuenta
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <div>
-                  <h4 className="font-semibold mb-2">Eliminar cuenta</h4>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    Una vez que elimines tu cuenta, no hay vuelta atrás. Por favor, está
-                    seguro antes de continuar.
-                  </p>
+          {/* ── Zona de peligro ── */}
+          <section className="mb-16 profile-fade-up profile-delay-4">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="h-px flex-1 bg-gray-200" />
+              <span className="text-[0.7rem] text-red-400/70 font-medium tracking-wide uppercase">
+                Zona de peligro
+              </span>
+              <div className="h-px flex-1 bg-gray-200" />
+            </div>
+            <div className="rounded-xl border border-red-100 bg-white">
+              <div className="px-4 py-5">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                  <div>
+                    <p className="text-[0.85rem] font-medium text-gray-700 mb-1">Eliminar cuenta</p>
+                    <p className="text-xs text-gray-400 leading-relaxed">
+                      Se eliminarán todos tus datos de forma irreversible.
+                    </p>
+                  </div>
                   <AlertDialog>
                     <AlertDialogTrigger asChild>
-                      <Button variant="destructive">
-                        <Trash2 className="h-4 w-4 mr-2" />
+                      <Button
+                        variant="outline"
+                        className="border-red-200 text-red-500 hover:bg-red-50 hover:border-red-300 text-[0.82rem] shrink-0"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
                         Eliminar mi cuenta
                       </Button>
                     </AlertDialogTrigger>
@@ -437,31 +590,21 @@ export default function ProfilePage() {
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <div className="py-4">
-                        <Label htmlFor="delete_password" className="mb-2 block">
+                        <Label htmlFor="delete_password" className="mb-2 block text-[0.82rem]">
                           Ingresa tu contraseña para confirmar
                         </Label>
                         <div className="relative">
                           <Input
                             id="delete_password"
-                            type={showDeletePassword ? "text" : "password"}
-                            placeholder="Tu contraseña"
+                            name="delete_password"
+                            type={showDeletePassword ? 'text' : 'password'}
+                            placeholder="Tu contraseña\u2026"
                             value={deletePassword}
                             onChange={(e) => setDeletePassword(e.target.value)}
+                            autoComplete="current-password"
                             className="pr-10"
                           />
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => setShowDeletePassword(!showDeletePassword)}
-                            className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 text-muted-foreground hover:text-foreground"
-                          >
-                            {showDeletePassword ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
-                          </Button>
+                          <PasswordToggle show={showDeletePassword} onToggle={() => setShowDeletePassword(v => !v)} />
                         </div>
                       </div>
                       <AlertDialogFooter>
@@ -473,16 +616,17 @@ export default function ProfilePage() {
                           className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                           disabled={deleteAccountMutation.isPending}
                         >
-                          {deleteAccountMutation.isPending ? 'Eliminando...' : 'Sí, eliminar mi cuenta'}
+                          {deleteAccountMutation.isPending ? 'Eliminando\u2026' : 'Sí, eliminar mi cuenta'}
                         </AlertDialogAction>
                       </AlertDialogFooter>
                     </AlertDialogContent>
                   </AlertDialog>
                 </div>
               </div>
-            </CardContent>
-          </Card>
-        </div>
-    </div>
+            </div>
+          </section>
+        </main>
+      </div>
+    </>
   );
 }

--- a/frontend/src/app/dashboard/setup/page.tsx
+++ b/frontend/src/app/dashboard/setup/page.tsx
@@ -23,8 +23,10 @@ import {
   Loader2,
   Check,
   Lock,
+  UserCircle,
 } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { toast } from 'sonner';
 
 // ─── Module definitions ──────────────────────────────────────
@@ -285,17 +287,28 @@ export default function SetupPage() {
                 NERBIS
               </span>
             </div>
-            <span className="text-[0.72rem] text-gray-400 font-medium tracking-wide">
+            <span className="text-[0.72rem] text-gray-400 font-medium tracking-wide" role="status" aria-label="Paso 1 de 2">
               PASO 1 DE 2
             </span>
-            <button
-              type="button"
-              onClick={() => logout('/register-business')}
-              className="flex items-center gap-1.5 text-[0.72rem] text-gray-400 hover:text-red-400 transition-colors cursor-pointer"
-            >
-              <LogOut className="w-3.5 h-3.5" />
-              Salir
-            </button>
+            <div className="flex items-center gap-1.5">
+              <Link
+                href="/dashboard/profile"
+                className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[0.72rem] text-gray-500 hover:text-[#1C3B57] hover:bg-gray-50 transition-colors"
+                aria-label="Mi Perfil"
+              >
+                <UserCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                <span className="hidden sm:inline">Mi Perfil</span>
+              </Link>
+              <div className="w-px h-4 bg-gray-200" aria-hidden="true" />
+              <button
+                type="button"
+                onClick={() => logout('/register-business')}
+                className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[0.72rem] text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
+              >
+                <LogOut className="w-3.5 h-3.5" aria-hidden="true" />
+                Salir
+              </button>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -422,6 +422,37 @@
   animation-play-state: paused;
 }
 
+/* Profile page — animaciones */
+@keyframes profile-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.profile-fade-up {
+  animation: profile-fade-up 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.profile-delay-1 { animation-delay: 0.06s; opacity: 0; }
+.profile-delay-2 { animation-delay: 0.12s; opacity: 0; }
+.profile-delay-3 { animation-delay: 0.18s; opacity: 0; }
+.profile-delay-4 { animation-delay: 0.24s; opacity: 0; }
+.profile-delay-5 { animation-delay: 0.30s; opacity: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .profile-fade-up {
+    animation: none;
+    opacity: 1;
+  }
+  .profile-delay-1,
+  .profile-delay-2,
+  .profile-delay-3,
+  .profile-delay-4,
+  .profile-delay-5 {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 /* ── Auth: Reduced motion support ────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   [data-auth-animated] {

--- a/frontend/src/lib/api/user.ts
+++ b/frontend/src/lib/api/user.ts
@@ -1,7 +1,7 @@
 // src/lib/api/user.ts
 
 import { apiClient } from './client';
-import { User } from '@/types';
+import { SocialProvider, User } from '@/types';
 
 /**
  * Obtener perfil del usuario actual
@@ -34,6 +34,16 @@ export async function changePassword(passwordData: {
   const { data } = await apiClient.post<{ message: string }>(
     '/auth/change-password/',
     passwordData
+  );
+  return data;
+}
+
+/**
+ * Desvincular cuenta social
+ */
+export async function disconnectSocialAccount(provider: SocialProvider): Promise<{ message: string }> {
+  const { data } = await apiClient.delete<{ message: string }>(
+    `/auth/social/disconnect/${provider}/`
   );
   return data;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -65,9 +65,17 @@ export interface User {
   date_joined: string;
   auth_provider?: string;
   has_password?: boolean;
+  social_accounts?: SocialAccountInfo[];
 }
 
 export type SocialProvider = 'google' | 'apple' | 'facebook';
+
+export interface SocialAccountInfo {
+  id: number;
+  provider: SocialProvider;
+  email: string;
+  created_at: string;
+}
 
 // ===================================
 // AUTH


### PR DESCRIPTION
## Summary

- Rediseño completo de `/dashboard/profile` con identidad NERBIS (header, colores, tipografía, animaciones)
- Sección "Métodos de acceso" mostrando email+contraseña y providers sociales (Google, Apple, Facebook) con estado vinculado/no vinculado
- Endpoint `DELETE /auth/social/disconnect/<provider>/` con validación de seguridad (no permite dejar al usuario sin acceso)
- Gestión de `SocialAccount` desde Django Admin: modelo independiente + inline en UserAdmin + filtros + acción bulk de desvinculación

## Changes

### Backend
- `core/serializers.py`: `SocialAccountSerializer` + campos `has_password` y `social_accounts` en `UserSerializer`
- `core/views.py`: `SocialAccountDisconnectView` con validación de seguridad
- `core/urls.py`: ruta `auth/social/disconnect/<provider>/`
- `core/admin.py`: `SocialAccountAdmin`, `SocialAccountInline`, `AuthMethodFilter`, columna "Acceso" con badges, acción bulk de desvinculación

### Frontend
- `profile/page.tsx`: rediseño completo con identidad NERBIS, componente `PasswordToggle` reutilizable, copy mejorado
- `DashboardShell.tsx`: profile usa layout limpio (sin Header/Footer de tienda)
- `setup/page.tsx`: link "Mi Perfil" en header de onboarding
- `globals.css`: animaciones profile con `prefers-reduced-motion`
- `next.config.ts`: `optimizePackageImports` para lucide-react
- `types/index.ts`: `SocialAccountInfo` + campos en `User`
- `lib/api/user.ts`: función `disconnectSocialAccount`

## Closes

- Closes #60 — mostrar providers sociales en Mi Perfil
- Partially addresses #79 — gestión de cuentas desde admin NERBIS

## Test plan

- [ ] Login con email → ver "Email y contraseña: Activo" en perfil
- [ ] Login con Facebook → ver "Facebook: Vinculado" con email
- [ ] Login con Google (misma cuenta) → ver ambos vinculados
- [ ] Desvincular Facebook → confirmar dialog → badge desaparece
- [ ] Intentar desvincular último método → backend rechaza con error
- [ ] Perfil accesible desde setup (link "Mi Perfil" en header)
- [ ] Django Admin: ver SocialAccount en lista y como inline en User
- [ ] Django Admin: filtrar por "Método de acceso" (solo email, solo social, ambos)
- [ ] Django Admin: acción bulk "Desvincular" respeta validación de seguridad
- [ ] Verificar accesibilidad: Tab navigation, focus rings, screen reader labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la Versión

* **Nuevas Características**
  * Los usuarios pueden desconectar cuentas sociales vinculadas (Google, Apple, Facebook) desde su perfil.
  * Panel de métodos de acceso mejorado que muestra el estado de autenticación por contraseña y cuentas vinculadas.
  * Interfaz de perfil rediseñada con mejor gestión y visualización de métodos de autenticación.
  * Acceso directo al perfil desde la página de configuración.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->