### PR TITLE
fix(core): add CASCADE delete rule to socialaccount foreign keys

### DIFF
--- a/backend/core/migrations/0028_fix_socialaccount_cascade.py
+++ b/backend/core/migrations/0028_fix_socialaccount_cascade.py
@@ -1,8 +1,8 @@
-# Fix CASCADE delete rules on core_socialaccount foreign keys.
-# The original migration created the FKs with NO ACTION (Django default when
-# on_delete is not CASCADE at the DB level). This caused IntegrityError when
-# deleting a User or Tenant that had linked social accounts.
-# See: https://github.com/nerbis-platform/nerbis-platform/issues/53
+# Corrige las reglas de eliminación CASCADE en las claves foráneas de core_socialaccount.
+# La migración original creó las FK con NO ACTION (comportamiento por defecto de Django
+# a nivel de base de datos). Esto causaba IntegrityError al eliminar un Usuario o Tenant
+# que tuviera cuentas sociales vinculadas.
+# Ver: https://github.com/nerbis-platform/nerbis-platform/issues/53
 
 from django.db import migrations
 
@@ -16,14 +16,14 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             sql=[
-                # Fix user FK: NO ACTION -> CASCADE
+                # Corregir FK de usuario: NO ACTION -> CASCADE
                 "ALTER TABLE core_socialaccount "
                 "DROP CONSTRAINT IF EXISTS core_socialaccount_user_id_4da0b336_fk_core_user_id;",
                 "ALTER TABLE core_socialaccount "
                 "ADD CONSTRAINT core_socialaccount_user_id_4da0b336_fk_core_user_id "
                 "FOREIGN KEY (user_id) REFERENCES core_user(id) "
                 "ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;",
-                # Fix tenant FK: NO ACTION -> CASCADE
+                # Corregir FK de tenant: NO ACTION -> CASCADE
                 "ALTER TABLE core_socialaccount "
                 "DROP CONSTRAINT IF EXISTS core_socialaccount_tenant_id_52e8c00a_fk_core_tenant_id;",
                 "ALTER TABLE core_socialaccount "
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
                 "ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;",
             ],
             reverse_sql=[
-                # Reverse: restore NO ACTION (Django default)
+                # Reverso: restaurar NO ACTION (comportamiento por defecto de Django)
                 "ALTER TABLE core_socialaccount "
                 "DROP CONSTRAINT IF EXISTS core_socialaccount_user_id_4da0b336_fk_core_user_id;",
                 "ALTER TABLE core_socialaccount "

--- a/backend/core/migrations/0028_fix_socialaccount_cascade.py
+++ b/backend/core/migrations/0028_fix_socialaccount_cascade.py
@@ -1,0 +1,50 @@
+# Fix CASCADE delete rules on core_socialaccount foreign keys.
+# The original migration created the FKs with NO ACTION (Django default when
+# on_delete is not CASCADE at the DB level). This caused IntegrityError when
+# deleting a User or Tenant that had linked social accounts.
+# See: https://github.com/nerbis-platform/nerbis-platform/issues/53
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0027_social_account"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                # Fix user FK: NO ACTION -> CASCADE
+                "ALTER TABLE core_socialaccount "
+                "DROP CONSTRAINT IF EXISTS core_socialaccount_user_id_4da0b336_fk_core_user_id;",
+                "ALTER TABLE core_socialaccount "
+                "ADD CONSTRAINT core_socialaccount_user_id_4da0b336_fk_core_user_id "
+                "FOREIGN KEY (user_id) REFERENCES core_user(id) "
+                "ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;",
+                # Fix tenant FK: NO ACTION -> CASCADE
+                "ALTER TABLE core_socialaccount "
+                "DROP CONSTRAINT IF EXISTS core_socialaccount_tenant_id_52e8c00a_fk_core_tenant_id;",
+                "ALTER TABLE core_socialaccount "
+                "ADD CONSTRAINT core_socialaccount_tenant_id_52e8c00a_fk_core_tenant_id "
+                "FOREIGN KEY (tenant_id) REFERENCES core_tenant(id) "
+                "ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;",
+            ],
+            reverse_sql=[
+                # Reverse: restore NO ACTION (Django default)
+                "ALTER TABLE core_socialaccount "
+                "DROP CONSTRAINT IF EXISTS core_socialaccount_user_id_4da0b336_fk_core_user_id;",
+                "ALTER TABLE core_socialaccount "
+                "ADD CONSTRAINT core_socialaccount_user_id_4da0b336_fk_core_user_id "
+                "FOREIGN KEY (user_id) REFERENCES core_user(id) "
+                "DEFERRABLE INITIALLY DEFERRED;",
+                "ALTER TABLE core_socialaccount "
+                "DROP CONSTRAINT IF EXISTS core_socialaccount_tenant_id_52e8c00a_fk_core_tenant_id;",
+                "ALTER TABLE core_socialaccount "
+                "ADD CONSTRAINT core_socialaccount_tenant_id_52e8c00a_fk_core_tenant_id "
+                "FOREIGN KEY (tenant_id) REFERENCES core_tenant(id) "
+                "DEFERRABLE INITIALLY DEFERRED;",
+            ],
+        ),
+    ]

--- a/backend/core/tests/test_cascade_delete.py
+++ b/backend/core/tests/test_cascade_delete.py
@@ -1,0 +1,55 @@
+# backend/core/tests/test_cascade_delete.py
+# Regression test for https://github.com/nerbis-platform/nerbis-platform/issues/53
+# Verifies that deleting a User or Tenant with linked SocialAccounts
+# does not raise IntegrityError.
+
+from core.models import SocialAccount, User
+from core.test_base import TenantAwareTestCase
+
+
+class SocialAccountCascadeDeleteTest(TenantAwareTestCase):
+    """Test: eliminar usuario/tenant con social accounts no produce IntegrityError."""
+
+    def test_delete_user_cascades_to_social_account(self):
+        """Al eliminar un usuario, sus social accounts se eliminan automáticamente."""
+        user = User.objects.create_user(
+            email="social@test.com",
+            password="Social123!",
+            username="social_user",
+            tenant=self.tenant,
+            role="customer",
+        )
+        SocialAccount.objects.create(
+            tenant=self.tenant,
+            user=user,
+            provider="google",
+            provider_uid="google-uid-123",
+            email="social@gmail.com",
+            extra_data={"name": "Social User"},
+        )
+        user_id = user.id
+        self.assertEqual(SocialAccount.objects.filter(user_id=user_id).count(), 1)
+
+        # Esto causaba IntegrityError antes del fix
+        user.delete()
+
+        self.assertEqual(SocialAccount.objects.filter(user_id=user_id).count(), 0)
+
+    def test_delete_tenant_cascades_to_social_accounts(self):
+        """Al eliminar un tenant, todos sus social accounts se eliminan."""
+        tenant_2, admin_2 = self.create_second_tenant()
+        SocialAccount.objects.create(
+            tenant=tenant_2,
+            user=admin_2,
+            provider="google",
+            provider_uid="google-uid-456",
+            email="admin@gmail.com",
+            extra_data={},
+        )
+        tenant_2_id = tenant_2.id
+        self.assertEqual(SocialAccount.objects.filter(tenant_id=tenant_2_id).count(), 1)
+
+        # Esto causaba IntegrityError antes del fix
+        tenant_2.delete()
+
+        self.assertEqual(SocialAccount.objects.filter(tenant_id=tenant_2_id).count(), 0)


### PR DESCRIPTION
## Summary

- Adds migration `0028_fix_socialaccount_cascade` with `RunSQL` to alter both FK constraints (`user_id`, `tenant_id`) on `core_socialaccount` from `NO ACTION` to `ON DELETE CASCADE` at the PostgreSQL level
- Adds regression tests (`test_cascade_delete.py`) verifying that deleting a User or Tenant with linked SocialAccounts no longer raises `IntegrityError`

## Context

Django's `on_delete=models.CASCADE` only enforces cascade deletes at the ORM level (Python), not at the database constraint level. The original migration created the FKs with PostgreSQL's default `NO ACTION`, so deleting via the admin (which bypasses the ORM in some cases) caused:

```
IntegrityError: update or delete on table "core_user" violates foreign key constraint
"core_socialaccount_user_id_4da0b336_fk_core_user_id" on table "core_socialaccount"
```

## Test plan

- [x] `test_delete_user_cascades_to_social_account` — verifies user deletion cascades
- [x] `test_delete_tenant_cascades_to_social_accounts` — verifies tenant deletion cascades
- [ ] Manual: delete a user with social account from `/admin/core/user/`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lanzamiento

* **Bug Fixes**
  * Se corrigió un problema en el que los registros de cuentas sociales vinculados a un usuario o a un inquilino no se eliminaban automáticamente, evitando errores de integridad al borrar usuarios o inquilinos.

* **Tests**
  * Se añadió una prueba de regresión que verifica la eliminación en cascada correcta de las cuentas sociales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->