### PR TITLE
fix(core): align PostgreSQL FK constraints with Django on_delete rules

### DIFF
--- a/backend/core/migrations/0027_fix_tenant_and_user_fk_cascade.py
+++ b/backend/core/migrations/0027_fix_tenant_and_user_fk_cascade.py
@@ -18,7 +18,11 @@ Only runs on PostgreSQL (SQLite does not support ALTER CONSTRAINT).
 See: https://github.com/nerbis-platform/nerbis-platform/issues/88
 """
 
+import logging
+
 from django.db import migrations
+
+logger = logging.getLogger(__name__)
 
 # ── FK → core_tenant (all TenantAwareModel use CASCADE) ─────────────────────
 
@@ -87,7 +91,7 @@ USER_FK_RULES = [
 ]
 
 
-def _find_constraint_name(cursor, table, column, ref_table):
+def _find_constraint_name(cursor, table, column, ref_table, schema="public"):
     """Find the FK constraint name for a given table/column/ref_table combo."""
     cursor.execute(
         """
@@ -97,13 +101,14 @@ def _find_constraint_name(cursor, table, column, ref_table):
             ON tc.constraint_name = kcu.constraint_name
         JOIN information_schema.constraint_column_usage ccu
             ON tc.constraint_name = ccu.constraint_name
-        WHERE tc.table_name = %s
+        WHERE tc.table_schema = %s
+          AND tc.table_name = %s
           AND kcu.column_name = %s
           AND ccu.table_name = %s
           AND tc.constraint_type = 'FOREIGN KEY'
         LIMIT 1
         """,
-        [table, column, ref_table],
+        [schema, table, column, ref_table],
     )
     row = cursor.fetchone()
     return row[0] if row else None
@@ -113,6 +118,12 @@ def _alter_fk(cursor, table, column, ref_table, ref_column, action):
     """Drop and recreate an FK constraint with the desired ON DELETE action."""
     constraint_name = _find_constraint_name(cursor, table, column, ref_table)
     if constraint_name is None:
+        logger.warning(
+            "FK constraint not found: %s.%s → %s (skipping)",
+            table,
+            column,
+            ref_table,
+        )
         return
 
     cursor.execute(f'ALTER TABLE "{table}" DROP CONSTRAINT "{constraint_name}"')

--- a/backend/core/migrations/0027_fix_tenant_and_user_fk_cascade.py
+++ b/backend/core/migrations/0027_fix_tenant_and_user_fk_cascade.py
@@ -1,0 +1,181 @@
+"""
+Fix FK constraints: align PostgreSQL ON DELETE rules with Django on_delete.
+
+Django generates FK constraints with NO ACTION (the PostgreSQL default),
+regardless of the on_delete parameter in the model. This means on_delete
+only works when Django ORM handles the deletion. Direct SQL DELETEs or
+incomplete ORM cascades can leave orphan records or raise IntegrityError.
+
+This migration updates all FK constraints referencing core_tenant and
+core_user to match their Django on_delete declarations:
+
+- on_delete=CASCADE  → ON DELETE CASCADE
+- on_delete=PROTECT  → ON DELETE RESTRICT
+- on_delete=SET_NULL → ON DELETE SET NULL
+
+Only runs on PostgreSQL (SQLite does not support ALTER CONSTRAINT).
+
+See: https://github.com/nerbis-platform/nerbis-platform/issues/88
+"""
+
+from django.db import migrations
+
+# ── FK → core_tenant (all TenantAwareModel use CASCADE) ─────────────────────
+
+TENANT_FK_TABLES = [
+    "billing_subscription",
+    "bookings_appointment",
+    "bookings_businesshours",
+    "bookings_timeoff",
+    "cart_cart",
+    "cart_cartitem",
+    "core_banner",
+    "core_user",
+    "coupons_coupon",
+    "coupons_couponusage",
+    "ecommerce_inventory",
+    "ecommerce_product",
+    "ecommerce_productcategory",
+    "ecommerce_productimage",
+    "marketplace_marketplacecategory",
+    "marketplace_marketplacecontract",
+    "marketplace_marketplaceplan",
+    "notifications_notification",
+    "orders_order",
+    "orders_orderitem",
+    "orders_orderserviceitem",
+    "orders_payment",
+    "promotions_promotion",
+    "promotions_promotionitem",
+    "reviews_review",
+    "reviews_reviewhelpful",
+    "reviews_reviewimage",
+    "services_service",
+    "services_servicecategory",
+    "services_staffmember",
+    "subscriptions_marketplacecategory",
+    "subscriptions_marketplacecontract",
+    "subscriptions_marketplaceplan",
+    "websites_aigenerationlog",
+    "websites_websiteconfig",
+]
+
+# ── FK → core_user (mixed on_delete rules) ──────────────────────────────────
+
+# (table, column, desired_pg_action)
+USER_FK_RULES = [
+    # CASCADE
+    ("bookings_appointment", "customer_id", "CASCADE"),
+    ("cart_cart", "user_id", "CASCADE"),
+    ("core_otptoken", "user_id", "CASCADE"),
+    ("core_passwordsettoken", "user_id", "CASCADE"),
+    ("core_user_groups", "user_id", "CASCADE"),
+    ("core_user_user_permissions", "user_id", "CASCADE"),
+    ("coupons_couponusage", "user_id", "CASCADE"),
+    ("django_admin_log", "user_id", "CASCADE"),
+    ("notifications_notification", "user_id", "CASCADE"),
+    ("reviews_review", "user_id", "CASCADE"),
+    ("reviews_reviewhelpful", "user_id", "CASCADE"),
+    ("services_staffmember", "user_id", "CASCADE"),
+    ("subscriptions_marketplacecontract", "customer_id", "CASCADE"),
+    ("marketplace_marketplacecontract", "customer_id", "CASCADE"),
+    ("token_blacklist_outstandingtoken", "user_id", "CASCADE"),
+    # PROTECT → RESTRICT
+    ("orders_order", "customer_id", "RESTRICT"),
+    # SET_NULL → SET NULL
+    ("reviews_review", "moderated_by_id", "SET NULL"),
+]
+
+
+def _find_constraint_name(cursor, table, column, ref_table):
+    """Find the FK constraint name for a given table/column/ref_table combo."""
+    cursor.execute(
+        """
+        SELECT tc.constraint_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+        JOIN information_schema.constraint_column_usage ccu
+            ON tc.constraint_name = ccu.constraint_name
+        WHERE tc.table_name = %s
+          AND kcu.column_name = %s
+          AND ccu.table_name = %s
+          AND tc.constraint_type = 'FOREIGN KEY'
+        LIMIT 1
+        """,
+        [table, column, ref_table],
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+def _alter_fk(cursor, table, column, ref_table, ref_column, action):
+    """Drop and recreate an FK constraint with the desired ON DELETE action."""
+    constraint_name = _find_constraint_name(cursor, table, column, ref_table)
+    if constraint_name is None:
+        return
+
+    cursor.execute(f'ALTER TABLE "{table}" DROP CONSTRAINT "{constraint_name}"')
+    cursor.execute(
+        f'ALTER TABLE "{table}" '
+        f'ADD CONSTRAINT "{constraint_name}" '
+        f'FOREIGN KEY ("{column}") REFERENCES "{ref_table}" ("{ref_column}") '
+        f"ON DELETE {action} DEFERRABLE INITIALLY DEFERRED"
+    )
+
+
+def forward(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+
+    cursor = schema_editor.connection.cursor()
+
+    # Tenant FKs → CASCADE
+    for table in TENANT_FK_TABLES:
+        _alter_fk(cursor, table, "tenant_id", "core_tenant", "id", "CASCADE")
+
+    # User FKs → mixed rules
+    for table, column, action in USER_FK_RULES:
+        _alter_fk(cursor, table, column, "core_user", "id", action)
+
+
+def reverse(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+
+    cursor = schema_editor.connection.cursor()
+
+    # Revert tenant FKs → NO ACTION
+    for table in TENANT_FK_TABLES:
+        _alter_fk(cursor, table, "tenant_id", "core_tenant", "id", "NO ACTION")
+
+    # Revert user FKs → NO ACTION
+    for table, column, _action in USER_FK_RULES:
+        _alter_fk(cursor, table, column, "core_user", "id", "NO ACTION")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0026_add_has_website_field"),
+        # Depend on latest migration of each app so all tables exist when we run
+        ("billing", "0015_add_trial_annual_ai_fields"),
+        ("bookings", "0004_add_expires_at_to_appointment"),
+        ("cart", "0002_cart_coupon"),
+        ("coupons", "0001_initial"),
+        ("ecommerce", "0002_product_average_rating_product_reviews_count"),
+        ("notifications", "0001_initial"),
+        ("orders", "0002_order_coupon_order_coupon_code_order_discount_amount"),
+        ("promotions", "0001_initial"),
+        ("reviews", "0001_initial"),
+        ("services", "0003_add_rating_fields_to_service_and_category"),
+        (
+            "subscriptions",
+            "0003_rename_subscriptions_tenant__2d28fa_idx_subscriptio_tenant__d827a9_idx_and_more",
+        ),
+        ("websites", "0014_add_published_data"),
+        ("token_blacklist", "0013_alter_blacklistedtoken_options_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]

--- a/backend/core/migrations/0029_fix_tenant_and_user_fk_cascade.py
+++ b/backend/core/migrations/0029_fix_tenant_and_user_fk_cascade.py
@@ -167,7 +167,7 @@ def reverse(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("core", "0026_add_has_website_field"),
+        ("core", "0028_fix_socialaccount_cascade"),
         # Depend on latest migration of each app so all tables exist when we run
         ("billing", "0015_add_trial_annual_ai_fields"),
         ("bookings", "0004_add_expires_at_to_appointment"),

--- a/backend/core/tests_fk_constraints.py
+++ b/backend/core/tests_fk_constraints.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _get_fk_delete_rule(table, column, ref_table):
+def _get_fk_delete_rule(table, column, ref_table, schema="public"):
     """Consulta information_schema para obtener la regla ON DELETE de una FK."""
     with connection.cursor() as cursor:
         cursor.execute(
@@ -29,13 +29,14 @@ def _get_fk_delete_rule(table, column, ref_table):
                 ON tc.constraint_name = kcu.constraint_name
             JOIN information_schema.constraint_column_usage ccu
                 ON tc.constraint_name = ccu.constraint_name
-            WHERE tc.table_name = %s
+            WHERE tc.table_schema = %s
+              AND tc.table_name = %s
               AND kcu.column_name = %s
               AND ccu.table_name = %s
               AND tc.constraint_type = 'FOREIGN KEY'
             LIMIT 1
             """,
-            [table, column, ref_table],
+            [schema, table, column, ref_table],
         )
         row = cursor.fetchone()
         return row[0] if row else None
@@ -71,6 +72,9 @@ TENANT_CASCADE_TABLES = [
     "services_service",
     "services_servicecategory",
     "services_staffmember",
+    "subscriptions_marketplacecategory",
+    "subscriptions_marketplacecontract",
+    "subscriptions_marketplaceplan",
     "websites_aigenerationlog",
     "websites_websiteconfig",
 ]
@@ -100,6 +104,7 @@ USER_FK_EXPECTED = [
     ("reviews_review", "user_id", "CASCADE"),
     ("reviews_reviewhelpful", "user_id", "CASCADE"),
     ("services_staffmember", "user_id", "CASCADE"),
+    ("subscriptions_marketplacecontract", "customer_id", "CASCADE"),
     ("token_blacklist_outstandingtoken", "user_id", "CASCADE"),
     # PROTECT → RESTRICT en PostgreSQL
     ("orders_order", "customer_id", "RESTRICT"),

--- a/backend/core/tests_fk_constraints.py
+++ b/backend/core/tests_fk_constraints.py
@@ -1,0 +1,117 @@
+"""
+Tests para verificar que las FK constraints a nivel PostgreSQL coinciden
+con las reglas on_delete definidas en los modelos Django.
+
+Solo corren en PostgreSQL (se saltan en SQLite).
+
+See: https://github.com/nerbis-platform/nerbis-platform/issues/88
+"""
+
+import pytest
+from django.db import connection
+
+pytestmark = pytest.mark.skipif(
+    connection.vendor != "postgresql",
+    reason="FK constraint rules solo se verifican en PostgreSQL",
+)
+
+
+def _get_fk_delete_rule(table, column, ref_table):
+    """Consulta information_schema para obtener la regla ON DELETE de una FK."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT rc.delete_rule
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.referential_constraints rc
+                ON tc.constraint_name = rc.constraint_name
+            JOIN information_schema.key_column_usage kcu
+                ON tc.constraint_name = kcu.constraint_name
+            JOIN information_schema.constraint_column_usage ccu
+                ON tc.constraint_name = ccu.constraint_name
+            WHERE tc.table_name = %s
+              AND kcu.column_name = %s
+              AND ccu.table_name = %s
+              AND tc.constraint_type = 'FOREIGN KEY'
+            LIMIT 1
+            """,
+            [table, column, ref_table],
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+
+# ── Tests: FK → core_tenant deben ser CASCADE ───────────────────────────────
+
+TENANT_CASCADE_TABLES = [
+    "billing_subscription",
+    "bookings_appointment",
+    "bookings_businesshours",
+    "bookings_timeoff",
+    "cart_cart",
+    "cart_cartitem",
+    "core_banner",
+    "core_user",
+    "coupons_coupon",
+    "coupons_couponusage",
+    "ecommerce_inventory",
+    "ecommerce_product",
+    "ecommerce_productcategory",
+    "ecommerce_productimage",
+    "notifications_notification",
+    "orders_order",
+    "orders_orderitem",
+    "orders_orderserviceitem",
+    "orders_payment",
+    "promotions_promotion",
+    "promotions_promotionitem",
+    "reviews_review",
+    "reviews_reviewhelpful",
+    "reviews_reviewimage",
+    "services_service",
+    "services_servicecategory",
+    "services_staffmember",
+    "websites_aigenerationlog",
+    "websites_websiteconfig",
+]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("table", TENANT_CASCADE_TABLES)
+def test_tenant_fk_is_cascade(table):
+    """Cada FK tenant_id → core_tenant debe tener ON DELETE CASCADE."""
+    rule = _get_fk_delete_rule(table, "tenant_id", "core_tenant")
+    assert rule is not None, f"FK {table}.tenant_id → core_tenant no encontrada"
+    assert rule == "CASCADE", f"{table}.tenant_id tiene ON DELETE {rule}, esperado CASCADE"
+
+
+# ── Tests: FK → core_user deben coincidir con on_delete del modelo ──────────
+
+USER_FK_EXPECTED = [
+    ("bookings_appointment", "customer_id", "CASCADE"),
+    ("cart_cart", "user_id", "CASCADE"),
+    ("core_otptoken", "user_id", "CASCADE"),
+    ("core_passwordsettoken", "user_id", "CASCADE"),
+    ("core_user_groups", "user_id", "CASCADE"),
+    ("core_user_user_permissions", "user_id", "CASCADE"),
+    ("coupons_couponusage", "user_id", "CASCADE"),
+    ("django_admin_log", "user_id", "CASCADE"),
+    ("notifications_notification", "user_id", "CASCADE"),
+    ("reviews_review", "user_id", "CASCADE"),
+    ("reviews_reviewhelpful", "user_id", "CASCADE"),
+    ("services_staffmember", "user_id", "CASCADE"),
+    ("token_blacklist_outstandingtoken", "user_id", "CASCADE"),
+    # PROTECT → RESTRICT en PostgreSQL
+    ("orders_order", "customer_id", "RESTRICT"),
+    # SET_NULL → SET NULL en PostgreSQL
+    ("reviews_review", "moderated_by_id", "SET NULL"),
+]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("table,column,expected_rule", USER_FK_EXPECTED)
+def test_user_fk_matches_django_on_delete(table, column, expected_rule):
+    """Cada FK → core_user debe tener la regla ON DELETE correcta."""
+    rule = _get_fk_delete_rule(table, column, "core_user")
+    assert rule is not None, f"FK {table}.{column} → core_user no encontrada"
+    assert rule == expected_rule, f"{table}.{column} tiene ON DELETE {rule}, esperado {expected_rule}"


### PR DESCRIPTION
## Summary

- Adds migration `0027_fix_tenant_and_user_fk_cascade` that updates all FK constraints at the PostgreSQL level to match Django model `on_delete` declarations
- **35 FK → `core_tenant`**: `NO ACTION` → `ON DELETE CASCADE`
- **15 FK → `core_user`**: `NO ACTION` → `ON DELETE CASCADE`
- **1 FK `orders_order.customer_id`**: `NO ACTION` → `ON DELETE RESTRICT` (matches `models.PROTECT`)
- **1 FK `reviews_review.moderated_by_id`**: `NO ACTION` → `ON DELETE SET NULL` (matches `models.SET_NULL`)
- Migration is PostgreSQL-only (no-op on SQLite), idempotent, and includes reverse SQL
- Adds 44 parametrized pytest tests that verify FK constraints match Django models

## Why

Django generates FK constraints with `NO ACTION` (PostgreSQL default) regardless of `on_delete` in the model. This means cascade/protect/set_null only works through the ORM. Direct SQL operations or incomplete ORM cascades can leave orphan records or raise `IntegrityError`.

## Test plan

- [x] Migration tested against PostgreSQL in Docker — all 52 FK constraints updated correctly
- [x] 44/44 parametrized tests passing against fresh test DB
- [x] Reverse migration included (reverts to NO ACTION)
- [x] Ruff lint + format clean

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de la versión

* **Correcciones de errores**
  * Se corrigieron las restricciones de clave externa de la base de datos para asegurar el comportamiento correcto de eliminación en cascada entre tablas de inquilino y usuario, mejorando la integridad de datos del sistema.

* **Cambios en la base de datos**
  * Se aplicaron actualizaciones en las reglas de eliminación (CASCADE, RESTRICT, SET NULL) y restricciones diferibles para optimizar la gestión de referencias entre tablas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->