### PR TITLE
chore(infra): sync con develop automático en bootstrap SDD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,20 @@ punto del pipeline, **DETENERSE INMEDIATAMENTE**. Algo salió mal en el bootstra
 
 ### Bootstrap automático (OBLIGATORIO en flujo SDD)
 
-Al iniciar `sdd-new`, `sdd-ff`, o cualquier comando SDD que inicie un cambio nuevo,
+Al iniciar `sdd-new`, `sdd-ff`, `sdd-continue`, o cualquier comando SDD que inicie o retome un cambio,
 ejecutar estos pasos **en orden, sin saltar ninguno, sin preguntar**. Si un paso falla,
 **DETENERSE e informar al usuario**. NO continuar con el pipeline hasta que todos pasen.
+
+#### Paso 0 — Sincronizar con develop (SIEMPRE — NO SALTAR)
+
+Antes de cualquier otra acción, asegurar que el ambiente local tiene los últimos cambios de develop:
+
+```bash
+git fetch origin develop
+echo "✅ Fetch de develop completado ($(git rev-parse --short origin/develop))"
+```
+
+Esto garantiza que al crear branches o hacer rebase, se usa el develop más reciente de GitHub.
 
 #### Paso 1 — sdd-init (si no existe skill registry)
 1. Verificar si `.atl/skill-registry.md` existe


### PR DESCRIPTION
## Summary
- Agrega **Paso 0 — Sincronizar con develop** como primera acción obligatoria del bootstrap SDD
- Garantiza que `sdd-new`, `sdd-ff`, `sdd-continue` y cualquier comando SDD ejecuten `git fetch origin develop` antes de crear branches o hacer rebase
- También se expandió el allowlist local de permisos (`.claude/settings.local.json`) para reducir prompts innecesarios — este archivo no se commitea ya que es local

## Test plan
- [ ] Ejecutar `sdd-new` y verificar que el Paso 0 se ejecuta antes del Paso 1
- [ ] Confirmar que `sdd-continue` también hace fetch de develop al iniciar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentación**
  * Se actualizó la documentación del flujo de desarrollo para ampliar los comandos que inician la secuencia de bootstrap e incorporar un nuevo paso de sincronización automática con la rama develop, mejorando la consistencia del proceso.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->