### PR TITLE
chore(infra): elimina cd encadenado en skills sdd-*

### DIFF
--- a/.claude/skills/_shared/openspec-convention.md
+++ b/.claude/skills/_shared/openspec-convention.md
@@ -91,12 +91,12 @@ rules:
     tdd: false
     test_command: "pytest backend/"
     lint_backend: "ruff check backend/"
-    lint_frontend: "cd frontend && npm run lint"
+    lint_frontend: "npm run lint --prefix frontend"
   verify:
     test_command: "pytest backend/"
-    build_command: "cd frontend && npm run build"
+    build_command: "npm run build --prefix frontend"
     lint_backend: "ruff check backend/"
-    lint_frontend: "cd frontend && npm run lint"
+    lint_frontend: "npm run lint --prefix frontend"
     coverage_threshold: 0
   archive:
     - Warn before merging destructive deltas

--- a/.claude/skills/sdd-apply/SKILL.md
+++ b/.claude/skills/sdd-apply/SKILL.md
@@ -125,7 +125,7 @@ ruff check backend/
 
 **Frontend changes:**
 ```bash
-cd frontend && npm run lint
+npm run lint --prefix frontend
 ```
 
 Fix any issues before proceeding to the next batch.

--- a/.claude/skills/sdd-archive/SKILL.md
+++ b/.claude/skills/sdd-archive/SKILL.md
@@ -227,13 +227,13 @@ fi
 **8.5 — Verify cleanup**
 
 ```bash
-# Ensure we're in a valid git directory (not in a deleted worktree)
-cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+# Resolve a valid git directory (not the deleted worktree)
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 
 # Confirm branch is gone
-git branch | grep -q "$BRANCH_NAME" && echo "⚠️ Local branch still exists" || echo "✅ Local branch deleted"
-git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME" && echo "⚠️ Remote branch still exists" || echo "✅ Remote branch deleted"
-echo "✅ On branch: $(git branch --show-current)"
+git -C "$REPO_ROOT" branch | grep -q "$BRANCH_NAME" && echo "⚠️ Local branch still exists" || echo "✅ Local branch deleted"
+git -C "$REPO_ROOT" ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME" && echo "⚠️ Remote branch still exists" || echo "✅ Remote branch deleted"
+echo "✅ On branch: $(git -C "$REPO_ROOT" branch --show-current)"
 ```
 
 > **Tip:** Consider enabling "Automatically delete head branches" in the GitHub repository settings (Settings → General → Pull Requests) to handle remote branch deletion automatically on merge.

--- a/.claude/skills/sdd-init/SKILL.md
+++ b/.claude/skills/sdd-init/SKILL.md
@@ -52,7 +52,7 @@ Read the project to understand:
 - Routes in `frontend/src/app/`
 - Context providers: AuthContext, CartContext, TenantContext, WebsiteContentContext
 - Components: shadcn/ui
-- Lint: ESLint (`cd frontend && npm run lint`)
+- Lint: ESLint (`npm run lint --prefix frontend`)
 
 **Infrastructure:**
 - CI: GitHub Actions (backend + frontend pipelines)

--- a/.claude/skills/sdd-tasks/SKILL.md
+++ b/.claude/skills/sdd-tasks/SKILL.md
@@ -103,7 +103,7 @@ From the design document, identify:
 ## Phase 5: Cleanup & Lint
 
 - [ ] 5.1 Run `ruff check backend/` and fix issues
-- [ ] 5.2 Run `cd frontend && npm run lint` and fix issues
+- [ ] 5.2 Run `npm run lint --prefix frontend` and fix issues
 - [ ] 5.3 {Update docs/comments if needed}
 ```
 
@@ -139,7 +139,7 @@ Phase 4: Testing
 
 Phase 5: Cleanup & Lint
   └─ ruff check backend/
-  └─ cd frontend && npm run lint
+  └─ npm run lint --prefix frontend
   └─ NEVER modify existing Django migrations
 ```
 

--- a/.claude/skills/sdd-verify/SKILL.md
+++ b/.claude/skills/sdd-verify/SKILL.md
@@ -137,12 +137,12 @@ pytest backend/
 
 **Frontend lint:**
 ```bash
-cd frontend && npm run lint
+npm run lint --prefix frontend
 ```
 
 **Frontend build:**
 ```bash
-cd frontend && npm run build
+npm run build --prefix frontend
 ```
 
 Capture exit codes, errors, and results for each.


### PR DESCRIPTION
## Contexto

Los agentes SDD (`sdd-apply`, `sdd-verify`, `sdd-tasks`, `sdd-init`, `sdd-archive`, `_shared/openspec-convention.md`) contenían comandos con `cd frontend && npm run ...` que disparaban prompts de permiso en Claude Code aunque las reglas `Bash(cd:*)` y `Bash(npm:*)` estuvieran en la allowlist. El matcher evalúa el comando completo como una unidad y `cd X && Y` no encaja con ninguna regla individual.

## Cambios

- `cd frontend && npm run lint` → `npm run lint --prefix frontend`
- `cd frontend && npm run build` → `npm run build --prefix frontend`
- En `sdd-archive`: `cd "$(git rev-parse --show-toplevel)"` → variable `REPO_ROOT` + `git -C "$REPO_ROOT" ...` (evita `cd` con command substitution).

## Impacto

- Los subagentes SDD dejan de pedir permiso por esos comandos.
- Matchean directamente con `Bash(npm:*)` y `Bash(git:*)` ya permitidas.
- Sin cambios funcionales — los comandos hacen exactamente lo mismo.

## Test plan

- [ ] Correr `sdd-verify` y confirmar que no pide permiso por lint/build de frontend
- [ ] Correr `sdd-apply` y confirmar lo mismo
- [ ] Verificar que `sdd-archive` sigue funcionando tras eliminar un worktree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Chores**
  * Actualizada la configuración y documentación de los comandos de compilación y verificación del frontend para optimizar la ejecución de tareas.

* **Refactor**
  * Mejorada la forma en que se ejecutan los scripts npm y se capturan las rutas del repositorio en los procesos de verificación, manteniendo la funcionalidad existente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->