### PR TITLE
docs(infra): documentar aislamiento de worktrees para agentes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,15 @@ docs/       → Documentación técnica (SDD.md)
 - SIEMPRE paginar listados
 - GitHub Actions: pinear con commit hash (no tags)
 
+## Worktrees y trabajo paralelo
+
+- Los worktrees de Git proveen **aislamiento de branch**, no de filesystem
+- Desde un worktree puedes leer/escribir archivos de cualquier path del sistema (mismos permisos que el repo principal)
+- El `cwd` cambia al root del worktree — usar paths relativos al worktree actual, no al repo principal
+- **NUNCA** usar `cd /ruta/repo/principal && comando` en scripts o skills; usar paths relativos o `$PWD`
+- Los worktrees son ideales para que múltiples agentes trabajen en paralelo sin conflictos de branch
+- No se necesita configuración especial de permisos para worktrees — las mismas reglas de `settings.json` aplican
+
 ## Checklist antes de generar código
 
 - [ ] ¿Considera el multi-tenant?


### PR DESCRIPTION
## Summary\n\n- Documenta en `AGENTS.md` cómo funciona el aislamiento de worktrees en Claude Code\n- Los worktrees proveen aislamiento de **branch** (no de filesystem) — no se necesita config especial de permisos\n- Los prompts de permiso reportados eran por `cd` encadenado en skills SDD (resuelto en PR #104)\n\nCloses #105\n\n## Hallazgos de la investigación\n\n| Aspecto | Resultado |\n|---------|----------|\n| Read/Edit/Write desde worktree | Sin restricciones adicionales |\n| Bash desde worktree | Mismas reglas de allowlist que repo principal |\n| Permisos especiales necesarios | Ninguno |\n| Causa real de los prompts | `cd` encadenado (PR #104) |\n\n## Test plan\n\n- [x] Verificar que la sección se agregó correctamente en AGENTS.md\n- [x] Confirmar que no rompe formato del archivo existente\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)