### PR TITLE
docs(infra): prohibir cd encadenado en skills y docs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,13 @@
-# Pre-commit hook - se configurará con linters en el paso de CI
-# Por ahora solo valida que el commit pase
-exit 0
+# Validar que skills y docs no usen cd encadenado (issue #106)
+# Excluye líneas de markdown que documentan la regla (contienen backticks o están en tablas)
+VIOLATIONS=$(grep -rEn 'cd [^ ]+ *&&' .claude/skills/ AGENTS.md CLAUDE.md 2>/dev/null | grep -v '`' | grep -v '^\s*#' || true)
+
+if [ -n "$VIOLATIONS" ]; then
+  echo "$VIOLATIONS"
+  echo ""
+  echo "❌ Error: Se detectó 'cd X && Y' en skills o docs."
+  echo "   Usar --prefix, -C, o paths absolutos en lugar de cd encadenado."
+  echo "   Ver AGENTS.md → 'Comandos en skills y documentación' para alternativas."
+  echo ""
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,28 @@ docs/       → Documentación técnica (SDD.md)
 - **Frontend:** ESLint + Next.js build (en PRs a main y develop)
 - **CodeRabbit:** Review automático en cada PR
 - **Release Please:** Versionamiento semántico automático en push a main
-- Correr lint local antes de push: `ruff check backend/` y `cd frontend && npm run lint`
+- Correr lint local antes de push: `ruff check backend/` y `npm run lint --prefix frontend`
+
+## Comandos en skills y documentación (NUNCA usar `cd X && Y`)
+
+Los comandos en skills, hooks y documentación **no deben usar `cd X && Y`** porque
+las allowlists granulares de permisos (`Bash(cd:*)` + `Bash(npm:*)`) no matchean
+comandos encadenados, forzando prompts de permiso innecesarios.
+
+**Usar alternativas sin `cd`:**
+
+| Herramienta | Mal | Bien |
+|-------------|------|------|
+| npm | `cd frontend && npm run lint` | `npm run lint --prefix frontend` |
+| pytest | `cd backend && pytest` | `pytest backend/` |
+| ruff | `cd backend && ruff check .` | `ruff check backend/` |
+| git | `cd "$REPO" && git ...` | `git -C "$REPO" ...` |
+| manage.py | `cd backend && python manage.py X` | `python backend/manage.py X` |
+| general | `cd X && comando` | Usar flag `-C`, `--prefix`, o path absoluto |
+
+**Excepciones válidas:** scripts de shell multi-línea donde `cd` es necesario para
+establecer el directorio de trabajo (ej: setup de worktrees). La regla aplica a
+one-liners encadenados con `&&`.
 
 ## Reglas críticas (NUNCA violar)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Al finalizar el desarrollo (commit hecho, build y lint pasando), evaluar si el c
 
 Cuando aplique:
 ```bash
-cd frontend && npm run dev -- --port 3001 &
+npm run dev --prefix frontend -- --port 3001 &
 # Informar: "Preview disponible en http://localhost:3001 — verifica los cambios en el browser"
 ```
 
@@ -401,8 +401,8 @@ Ambos corren simultáneamente. Esperar a que ambos terminen antes de continuar.
 - **Frontend:** ESLint + Next.js build (en PRs a main y develop)
 - **CodeRabbit:** Review automático en PRs
 - **Release Please:** Versionamiento semántico en push a main
-- Correr lint local antes de push: `ruff check backend/` y `cd frontend && npm run lint`
-- **Aislamiento del panel admin:** correr `cd frontend && npm run test:isolation` antes de push si tocaste `src/app/admin/**`, `src/lib/api/admin-*.ts`, o `src/contexts/AdminAuthContext.tsx`. El script asegura que la superficie superadmin no importe ni referencie código tenant.
+- Correr lint local antes de push: `ruff check backend/` y `npm run lint --prefix frontend`
+- **Aislamiento del panel admin:** correr `npm run test:isolation --prefix frontend` antes de push si tocaste `src/app/admin/**`, `src/lib/api/admin-*.ts`, o `src/contexts/AdminAuthContext.tsx`. El script asegura que la superficie superadmin no importe ni referencie código tenant.
 
 ## Bootstrapping del primer superadministrador
 


### PR DESCRIPTION
## Summary

Closes #106

- Añade sección en `AGENTS.md` con la convención de no usar `cd X && Y` y tabla de alternativas (`--prefix`, `-C`, paths absolutos)
- Corrige 3 ocurrencias restantes de `cd` encadenado en `CLAUDE.md`
- Agrega pre-commit hook que detecta violaciones en `.claude/skills/`, `AGENTS.md` y `CLAUDE.md`

## Test plan

- [x] Pre-commit hook pasa sin falsos positivos (ejemplos en tabla de AGENTS.md no disparan error)
- [x] Pre-commit hook detecta violaciones reales en archivos de skills
- [ ] Verificar que `npm run lint --prefix frontend` funciona igual que `cd frontend && npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)