### PR TITLE
docs(infra): symlink all .env* files in worktree setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,23 @@ if [ -d "$MAIN_REPO/frontend/node_modules" ]; then
   echo "✅ Symlink node_modules → repo principal"
 fi
 
-# 3. Symlink de .env.local (variables de entorno compartidas)
-if [ -f "$MAIN_REPO/frontend/.env.local" ]; then
-  ln -sfn "$MAIN_REPO/frontend/.env.local" "$WT_ROOT/frontend/.env.local"
-  echo "✅ Symlink .env.local → repo principal"
-fi
+# 3. Symlink de TODOS los .env* del frontend (feature flags, API URLs, etc.)
+for envfile in "$MAIN_REPO"/frontend/.env*; do
+  [ -f "$envfile" ] || continue
+  fname="$(basename "$envfile")"
+  ln -sfn "$envfile" "$WT_ROOT/frontend/$fname"
+  echo "✅ Symlink frontend/$fname → repo principal"
+done
 
-# 4. Symlink de backend .env si existe
+# 4. Symlink de TODOS los .env* del backend
+for envfile in "$MAIN_REPO"/backend/.env*; do
+  [ -f "$envfile" ] || continue
+  fname="$(basename "$envfile")"
+  ln -sfn "$envfile" "$WT_ROOT/backend/$fname"
+  echo "✅ Symlink backend/$fname → repo principal"
+done
+
+# 5. Symlink de .env raíz si existe
 if [ -f "$MAIN_REPO/.env" ]; then
   ln -sfn "$MAIN_REPO/.env" "$WT_ROOT/.env"
   echo "✅ Symlink .env → repo principal"
@@ -82,7 +92,9 @@ fi
 ```bash
 WT_ROOT="$(git rev-parse --show-toplevel)"
 [ -L "$WT_ROOT/frontend/node_modules" ] && echo "✅ node_modules OK" || { echo "❌ node_modules FALTA — DETENERSE"; exit 1; }
-[ -L "$WT_ROOT/frontend/.env.local" ] && echo "✅ .env.local OK" || echo "⚠️  .env.local no existe (puede ser normal)"
+[ -L "$WT_ROOT/frontend/.env.local" ] && echo "✅ frontend/.env.local OK" || echo "⚠️  frontend/.env.local no existe (puede ser normal)"
+[ -L "$WT_ROOT/frontend/.env.development" ] && echo "✅ frontend/.env.development OK" || echo "⚠️  frontend/.env.development no existe"
+[ -L "$WT_ROOT/backend/.env" ] && echo "✅ backend/.env OK" || echo "⚠️  backend/.env no existe"
 ```
 
 **Dev server automático post-desarrollo** (OBLIGATORIO cuando el cambio toca UI):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,18 @@ fi
 for envfile in "$MAIN_REPO"/frontend/.env*; do
   [ -f "$envfile" ] || continue
   fname="$(basename "$envfile")"
-  ln -sfn "$envfile" "$WT_ROOT/frontend/$fname"
+  dest="$WT_ROOT/frontend/$fname"
+  # Skip if dest already points to the correct target
+  if [ -L "$dest" ] && [ "$(readlink "$dest")" = "$envfile" ]; then
+    echo "✅ Symlink frontend/$fname ya existe (correcto)"
+    continue
+  fi
+  # Backup if dest is a real file or a symlink to a different target
+  if [ -e "$dest" ] || [ -L "$dest" ]; then
+    echo "⚠️  frontend/$fname existe — backup a frontend/${fname}.bak"
+    mv "$dest" "${dest}.bak"
+  fi
+  ln -sfn "$envfile" "$dest"
   echo "✅ Symlink frontend/$fname → repo principal"
 done
 
@@ -77,7 +88,16 @@ done
 for envfile in "$MAIN_REPO"/backend/.env*; do
   [ -f "$envfile" ] || continue
   fname="$(basename "$envfile")"
-  ln -sfn "$envfile" "$WT_ROOT/backend/$fname"
+  dest="$WT_ROOT/backend/$fname"
+  if [ -L "$dest" ] && [ "$(readlink "$dest")" = "$envfile" ]; then
+    echo "✅ Symlink backend/$fname ya existe (correcto)"
+    continue
+  fi
+  if [ -e "$dest" ] || [ -L "$dest" ]; then
+    echo "⚠️  backend/$fname existe — backup a backend/${fname}.bak"
+    mv "$dest" "${dest}.bak"
+  fi
+  ln -sfn "$envfile" "$dest"
   echo "✅ Symlink backend/$fname → repo principal"
 done
 
@@ -92,9 +112,16 @@ fi
 ```bash
 WT_ROOT="$(git rev-parse --show-toplevel)"
 [ -L "$WT_ROOT/frontend/node_modules" ] && echo "✅ node_modules OK" || { echo "❌ node_modules FALTA — DETENERSE"; exit 1; }
-[ -L "$WT_ROOT/frontend/.env.local" ] && echo "✅ frontend/.env.local OK" || echo "⚠️  frontend/.env.local no existe (puede ser normal)"
-[ -L "$WT_ROOT/frontend/.env.development" ] && echo "✅ frontend/.env.development OK" || echo "⚠️  frontend/.env.development no existe"
-[ -L "$WT_ROOT/backend/.env" ] && echo "✅ backend/.env OK" || echo "⚠️  backend/.env no existe"
+for envfile in "$WT_ROOT"/frontend/.env*; do
+  [ -e "$envfile" ] || [ -L "$envfile" ] || continue
+  fname="$(basename "$envfile")"
+  [ -L "$envfile" ] && echo "✅ frontend/$fname OK" || echo "⚠️  frontend/$fname no es symlink"
+done
+for envfile in "$WT_ROOT"/backend/.env*; do
+  [ -e "$envfile" ] || [ -L "$envfile" ] || continue
+  fname="$(basename "$envfile")"
+  [ -L "$envfile" ] && echo "✅ backend/$fname OK" || echo "⚠️  backend/$fname no es symlink"
+done
 ```
 
 **Dev server automático post-desarrollo** (OBLIGATORIO cuando el cambio toca UI):


### PR DESCRIPTION
## Summary
- Updated worktree setup script in `CLAUDE.md` to symlink **all** `.env*` files (not just `.env.local`)
- Uses loops for both `frontend/.env*` and `backend/.env*` files
- Fixes the recurring issue where feature flags and configs are missing when SDD creates new worktrees (git doesn't copy `.gitignore`d files)

## Problem
Every time a new worktree was created, `.env.local`, `.env.development`, and other env files were missing because git worktrees don't copy `.gitignore`d files. This caused:
- Feature flags not working (e.g., social login buttons not showing)
- API URLs missing
- Database configs missing

## Test plan
- [ ] Create a new worktree and verify all `.env*` files are symlinked
- [ ] Verify `frontend/.env.local` and `frontend/.env.development` exist in worktree
- [ ] Verify `backend/.env` exists in worktree
- [ ] Start dev server in worktree and confirm feature flags work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentación**
  * Se actualizaron las instrucciones de configuración del worktree para soportar múltiples archivos de variables de entorno mediante vinculación basada en comodines.
  * Se mejoró el proceso de verificación posterior a la instalación para validar correctamente los archivos de configuración requeridos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->