### PR TITLE
feat(websites): add ::selection with brand color

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -242,6 +242,12 @@
   h1, h2, h3, h4, h5, h6 {
     font-family: var(--font-heading);
   }
+
+  /* Signature NERBIS — brand selection color */
+  ::selection {
+    background-color: var(--primary);
+    color: var(--primary-foreground);
+  }
 }
 
 @layer utilities {

--- a/frontend/src/styles/published-website.css
+++ b/frontend/src/styles/published-website.css
@@ -40,6 +40,12 @@
   --glow-sm: 0 0 12px color-mix(in srgb, var(--primary), transparent 80%);
 }
 
+/* Brand selection color — signature NERBIS */
+.published-website ::selection {
+  background-color: var(--primary);
+  color: #fff;
+}
+
 /* ═══════════════════════════════════════════════════
    2. KEYFRAME ANIMATIONS
    ═══════════════════════════════════════════════════ */

--- a/frontend/src/styles/published-website.css
+++ b/frontend/src/styles/published-website.css
@@ -43,7 +43,7 @@
 /* Brand selection color — signature NERBIS */
 .published-website ::selection {
   background-color: var(--primary);
-  color: #fff;
+  color: var(--primary-foreground, #fff);
 }
 
 /* ═══════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Add `::selection` CSS pseudo-element with brand primary color across the platform
- `globals.css`: applies `--primary` / `--primary-foreground` to all text selection in dashboard/app (respects light/dark mode)
- `published-website.css`: scoped under `.published-website`, uses tenant's dynamic `--primary` so each published site gets its own brand selection color

## Test plan
- [ ] Select text anywhere in the dashboard — highlight should be Dusty Rose (#D4A5A5) instead of browser default blue
- [ ] Toggle dark mode — selection should change to Light Rose (#E8B4B4)
- [ ] Visit a published tenant website and select text — highlight should match the tenant's primary color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* **Actualizado el estilo visual de texto seleccionado** — Mejorada la experiencia visual cuando los usuarios destacan texto en la aplicación y el sitio web publicado, utilizando los colores del tema primario para una consistencia visual mejorada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->