### PR TITLE
feat(frontend): migrate reactivate page to AuthSplitScreenV2

### DIFF
--- a/frontend/src/app/(tenant)/(auth)/reactivate/page.tsx
+++ b/frontend/src/app/(tenant)/(auth)/reactivate/page.tsx
@@ -2,210 +2,24 @@
 
 'use client';
 
-import { useState, useRef, useEffect, Suspense } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
-import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { toast } from 'sonner';
-import { Loader2, ArrowLeft, UserCheck } from 'lucide-react';
-import { verifyReactivationOTP } from '@/lib/api/auth';
-import { useAuth } from '@/contexts/AuthContext';
+import { Suspense } from 'react';
+import { Loader2 } from 'lucide-react';
+import AuthSplitScreenV2 from '@/components/auth/AuthSplitScreenV2';
 
-const reactivateSchema = z.object({
-  code: z.string().length(6, 'El código debe tener 6 dígitos'),
-});
-
-type ReactivateFormValues = z.infer<typeof reactivateSchema>;
-
-function ReactivateForm() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const email = searchParams.get('email') || '';
-  const { setUser } = useAuth();
-  const [isLoading, setIsLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  const [otpDigits, setOtpDigits] = useState(['', '', '', '', '', '']);
-  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
-
-  const form = useForm<ReactivateFormValues>({
-    resolver: zodResolver(reactivateSchema),
-    defaultValues: {
-      code: '',
-    },
-  });
-
-  // Redirect if no email
-  useEffect(() => {
-    if (!email) {
-      router.push('/login');
-    }
-  }, [email, router]);
-
-  // Handle OTP input
-  const handleOtpChange = (index: number, value: string) => {
-    if (value.length > 1) {
-      // Handle paste
-      const digits = value.slice(0, 6).split('');
-      const newOtpDigits = [...otpDigits];
-      digits.forEach((digit, i) => {
-        if (index + i < 6) {
-          newOtpDigits[index + i] = digit;
-        }
-      });
-      setOtpDigits(newOtpDigits);
-      form.setValue('code', newOtpDigits.join(''));
-
-      // Focus last filled input or next empty
-      const nextIndex = Math.min(index + digits.length, 5);
-      inputRefs.current[nextIndex]?.focus();
-    } else {
-      const newOtpDigits = [...otpDigits];
-      newOtpDigits[index] = value;
-      setOtpDigits(newOtpDigits);
-      form.setValue('code', newOtpDigits.join(''));
-
-      // Auto-focus next input
-      if (value && index < 5) {
-        inputRefs.current[index + 1]?.focus();
-      }
-    }
-  };
-
-  const handleOtpKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Backspace' && !otpDigits[index] && index > 0) {
-      inputRefs.current[index - 1]?.focus();
-    }
-  };
-
-  const onSubmit = async (data: ReactivateFormValues) => {
-    try {
-      setIsLoading(true);
-      const response = await verifyReactivationOTP(email, data.code);
-      setUser(response.user);
-      setSuccess(true);
-      toast.success('¡Cuenta reactivada exitosamente!');
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Error al reactivar cuenta';
-      toast.error(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  if (success) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-stone-50 dark:bg-stone-950 p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="space-y-1 text-center">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50">
-              <UserCheck className="h-8 w-8 text-emerald-600" />
-            </div>
-            <CardTitle className="text-2xl font-semibold tracking-[-0.03em]">¡Bienvenido de vuelta!</CardTitle>
-            <CardDescription>
-              Tu cuenta ha sido reactivada exitosamente
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button onClick={() => router.push('/')} className="w-full">
-              Ir al inicio
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-stone-50 dark:bg-stone-950 p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-semibold tracking-[-0.03em] text-center">
-            Reactivar cuenta
-          </CardTitle>
-          <CardDescription className="text-center">
-            Ingresa el código de 6 dígitos enviado a{' '}
-            <span className="font-medium text-foreground">{email}</span>
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-              {/* OTP Input */}
-              <FormField
-                control={form.control}
-                name="code"
-                render={() => (
-                  <FormItem>
-                    <FormLabel className="text-center block">Código de verificación</FormLabel>
-                    <FormControl>
-                      <div className="flex justify-center gap-2">
-                        {otpDigits.map((digit, index) => (
-                          <Input
-                            key={index}
-                            ref={(el) => { inputRefs.current[index] = el; }}
-                            type="text"
-                            inputMode="numeric"
-                            maxLength={6}
-                            value={digit}
-                            onChange={(e) => handleOtpChange(index, e.target.value.replace(/\D/g, ''))}
-                            onKeyDown={(e) => handleOtpKeyDown(index, e)}
-                            className="w-12 h-12 text-center text-xl font-semibold"
-                            disabled={isLoading}
-                          />
-                        ))}
-                      </div>
-                    </FormControl>
-                    <FormMessage className="text-center" />
-                  </FormItem>
-                )}
-              />
-
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Verificando...
-                  </>
-                ) : (
-                  'Reactivar mi cuenta'
-                )}
-              </Button>
-            </form>
-          </Form>
-
-          <p className="mt-4 text-sm text-muted-foreground text-center">
-            El código expira en 10 minutos. Si no lo ves en tu bandeja de entrada, revisa la carpeta de spam.
-          </p>
-
-          <div className="mt-4 text-center">
-            <Link
-              href="/login"
-              className="inline-flex items-center text-sm text-muted-foreground hover:text-primary"
-            >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Volver a iniciar sesión
-            </Link>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
+function ReactivatePageInner() {
+  return <AuthSplitScreenV2 initialMode="reactivate" />;
 }
 
 export default function ReactivatePage() {
   return (
-    <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center bg-stone-50 dark:bg-stone-950 p-4">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      </div>
-    }>
-      <ReactivateForm />
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-stone-400" />
+        </div>
+      }
+    >
+      <ReactivatePageInner />
     </Suspense>
   );
 }

--- a/frontend/src/components/auth/AuthSplitScreenV2.tsx
+++ b/frontend/src/components/auth/AuthSplitScreenV2.tsx
@@ -150,7 +150,7 @@ export default function AuthSplitScreenV2({
       )}
 
       {mode === 'reactivate' && (
-        <ReactivateForm onGoToLogin={goToLogin} />
+        <ReactivateForm />
       )}
     </>
   );

--- a/frontend/src/components/auth/AuthSplitScreenV2.tsx
+++ b/frontend/src/components/auth/AuthSplitScreenV2.tsx
@@ -10,6 +10,7 @@ import { MobileBrandHeader } from './MobileBrandHeader';
 import { LoginForm } from './LoginForm';
 import { RegisterForm } from './RegisterForm';
 import { ForgotPasswordForm } from './ForgotPasswordForm';
+import { ReactivateForm } from './ReactivateForm';
 import { useReducedMotion } from './hooks';
 import type { AuthMode, AuthPrefill } from './types';
 
@@ -44,6 +45,7 @@ export default function AuthSplitScreenV2({
       login: 'Formulario de inicio de sesión',
       register: 'Formulario de registro',
       forgot: 'Recuperar contraseña',
+      reactivate: 'Reactivar cuenta',
     };
     setAnnouncement(labels[m]);
   }, []);
@@ -145,6 +147,10 @@ export default function AuthSplitScreenV2({
 
       {mode === 'forgot' && (
         <ForgotPasswordForm onGoToLogin={goToLogin} />
+      )}
+
+      {mode === 'reactivate' && (
+        <ReactivateForm onGoToLogin={goToLogin} />
       )}
     </>
   );

--- a/frontend/src/components/auth/ReactivateForm.tsx
+++ b/frontend/src/components/auth/ReactivateForm.tsx
@@ -25,13 +25,9 @@ import { LABEL_CLASS, LABEL_STYLE } from './constants';
 
 // ─── Props ──────────────────────────────────────────────────────
 
-interface ReactivateFormComponentProps {
-  onGoToLogin: () => void;
-}
-
 // ─── Component ──────────────────────────────────────────────────
 
-export function ReactivateForm({ onGoToLogin }: ReactivateFormComponentProps) {
+export function ReactivateForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const email = searchParams.get('email') || '';
@@ -189,7 +185,7 @@ export function ReactivateForm({ onGoToLogin }: ReactivateFormComponentProps) {
       <div className="mt-6 pt-5 border-t border-[var(--auth-border)] text-center">
         <button
           type="button"
-          onClick={onGoToLogin}
+          onClick={() => router.push('/login')}
           className="inline-flex items-center text-[0.78rem] transition-colors cursor-pointer hover:text-[var(--auth-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--auth-accent)] focus-visible:ring-offset-2 rounded-sm"
           style={{
             color: 'var(--auth-text-muted)',

--- a/frontend/src/components/auth/ReactivateForm.tsx
+++ b/frontend/src/components/auth/ReactivateForm.tsx
@@ -1,0 +1,205 @@
+// src/components/auth/ReactivateForm.tsx
+// Account reactivation form: OTP verification -> success.
+
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { ArrowLeft, UserCheck } from 'lucide-react';
+import { toast } from 'sonner';
+import { verifyReactivationOTP } from '@/lib/api/auth';
+import { useAuth } from '@/contexts/AuthContext';
+import { reactivateSchema, type ReactivateFormValues } from './schemas';
+import { useAuthForm } from './hooks/useAuthForm';
+import { OtpInput } from './OtpInput';
+import { SubmitButton } from './SubmitButton';
+import { LABEL_CLASS, LABEL_STYLE } from './constants';
+
+// ─── Props ──────────────────────────────────────────────────────
+
+interface ReactivateFormComponentProps {
+  onGoToLogin: () => void;
+}
+
+// ─── Component ──────────────────────────────────────────────────
+
+export function ReactivateForm({ onGoToLogin }: ReactivateFormComponentProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const email = searchParams.get('email') || '';
+  const { setUser } = useAuth();
+  const [success, setSuccess] = useState(false);
+
+  // Redirect if no email
+  useEffect(() => {
+    if (!email) {
+      router.push('/login');
+    }
+  }, [email, router]);
+
+  const handleSubmit = useCallback(
+    async (data: ReactivateFormValues) => {
+      const response = await verifyReactivationOTP(email, data.code);
+      setUser(response.user);
+      setSuccess(true);
+      toast.success('¡Cuenta reactivada exitosamente!');
+    },
+    [email, setUser],
+  );
+
+  const formHook = useAuthForm<ReactivateFormValues>({
+    schema: reactivateSchema,
+    defaultValues: { code: '' },
+    onSubmit: handleSubmit,
+  });
+
+  // ── Success state
+  if (success) {
+    return (
+      <div className="text-center" role="status" data-auth-animated>
+        <div
+          className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full"
+          style={{ background: 'var(--auth-accent-bg, #E2F3F1)' }}
+        >
+          <UserCheck
+            className="h-7 w-7"
+            style={{ color: 'var(--auth-success)' }}
+          />
+        </div>
+
+        <h2
+          className="text-[1.5rem] tracking-[-0.03em] mb-2"
+          style={{
+            color: 'var(--auth-primary)',
+            fontWeight: 600,
+            fontFamily: 'var(--auth-font-heading)',
+          }}
+        >
+          ¡Bienvenido de vuelta!
+        </h2>
+
+        <p
+          className="text-[0.85rem] mb-8"
+          style={{
+            color: 'var(--auth-text-muted)',
+            fontFamily: 'var(--auth-font-body)',
+          }}
+        >
+          Tu cuenta ha sido reactivada exitosamente.
+        </p>
+
+        <SubmitButton
+          isLoading={false}
+          type="button"
+          onClick={() => router.push('/')}
+        >
+          Ir al inicio
+        </SubmitButton>
+      </div>
+    );
+  }
+
+  return (
+    <section aria-label="Reactivar cuenta">
+      <div className="mb-6">
+        <h2
+          className="text-[1.5rem] tracking-[-0.03em] mb-2"
+          style={{
+            color: 'var(--auth-primary)',
+            fontWeight: 600,
+            fontFamily: 'var(--auth-font-heading)',
+          }}
+        >
+          Reactivar cuenta
+        </h2>
+        <p
+          className="text-[0.85rem] leading-relaxed"
+          style={{
+            color: 'var(--auth-text-muted)',
+            fontFamily: 'var(--auth-font-body)',
+          }}
+        >
+          Ingresa el código de 6 dígitos enviado a{' '}
+          <span
+            className="font-medium"
+            style={{ color: 'var(--auth-primary)' }}
+          >
+            {email}
+          </span>
+        </p>
+      </div>
+
+      <Form {...formHook.form}>
+        <form
+          onSubmit={formHook.handleSubmit}
+          className="space-y-5"
+          data-auth-animated
+        >
+          <FormField
+            control={formHook.form.control}
+            name="code"
+            render={() => (
+              <FormItem>
+                <FormLabel className={LABEL_CLASS} style={LABEL_STYLE}>
+                  Código de verificación
+                </FormLabel>
+                <FormControl>
+                  <OtpInput
+                    value={formHook.form.watch('code') || ''}
+                    onChange={(code) =>
+                      formHook.form.setValue('code', code, {
+                        shouldValidate: true,
+                      })
+                    }
+                    disabled={formHook.isLoading}
+                  />
+                </FormControl>
+                <FormMessage role="alert" aria-live="polite" />
+              </FormItem>
+            )}
+          />
+
+          <SubmitButton
+            isLoading={formHook.isLoading}
+            loadingLabel="Verificando..."
+          >
+            Reactivar mi cuenta
+          </SubmitButton>
+        </form>
+      </Form>
+
+      <p
+        className="mt-4 text-[0.75rem] leading-relaxed text-center"
+        style={{
+          color: 'var(--auth-text-placeholder)',
+          fontFamily: 'var(--auth-font-body)',
+        }}
+      >
+        El código expira en 10 minutos. Si no lo ves en tu bandeja de entrada, revisa la carpeta de spam.
+      </p>
+
+      <div className="mt-6 pt-5 border-t border-[var(--auth-border)] text-center">
+        <button
+          type="button"
+          onClick={onGoToLogin}
+          className="inline-flex items-center text-[0.78rem] transition-colors cursor-pointer hover:text-[var(--auth-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--auth-accent)] focus-visible:ring-offset-2 rounded-sm"
+          style={{
+            color: 'var(--auth-text-muted)',
+            fontFamily: 'var(--auth-font-body)',
+          }}
+        >
+          <ArrowLeft className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+          Volver a iniciar sesión
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/auth/index.ts
+++ b/frontend/src/components/auth/index.ts
@@ -7,6 +7,7 @@ export { RegisterForm } from './RegisterForm';
 export { RegisterStep1 } from './RegisterStep1';
 export { RegisterStep2 } from './RegisterStep2';
 export { ForgotPasswordForm } from './ForgotPasswordForm';
+export { ReactivateForm } from './ReactivateForm';
 
 // ─── Shared UI Components ────────────────────────────────────────
 export { PasswordField } from './PasswordField';
@@ -57,6 +58,7 @@ export {
   registerBusinessSchema,
   forgotEmailSchema,
   forgotResetSchema,
+  reactivateSchema,
   passwordRules,
 } from './schemas';
 export type {
@@ -64,6 +66,7 @@ export type {
   RegisterBusinessFormValues,
   ForgotEmailFormValues,
   ForgotResetFormValues,
+  ReactivateFormValues,
 } from './schemas';
 
 // ─── Constants ───────────────────────────────────────────────────

--- a/frontend/src/components/auth/schemas.ts
+++ b/frontend/src/components/auth/schemas.ts
@@ -75,3 +75,11 @@ export const forgotResetSchema = z
   });
 
 export type ForgotResetFormValues = z.infer<typeof forgotResetSchema>;
+
+// ─── Reactivate Account ──────────────────────────────────────
+
+export const reactivateSchema = z.object({
+  code: z.string().length(6, 'El código debe tener 6 dígitos').regex(/^\d+$/, 'El código solo debe contener números'),
+});
+
+export type ReactivateFormValues = z.infer<typeof reactivateSchema>;

--- a/frontend/src/components/auth/types.ts
+++ b/frontend/src/components/auth/types.ts
@@ -10,7 +10,7 @@ import type {
 
 // ─── Core Auth Types ────────────────────────────────────────────
 
-export type AuthMode = 'login' | 'register' | 'forgot';
+export type AuthMode = 'login' | 'register' | 'forgot' | 'reactivate';
 export type ForgotStep = 'email' | 'reset' | 'success';
 export type RegisterStep = 1 | 2;
 


### PR DESCRIPTION
## Descripción

Migra la página de reactivación de cuenta (`/reactivate`) para usar el layout compartido `AuthSplitScreenV2`, reemplazando el diseño standalone con `Card` centrada. Esto unifica la experiencia visual de todos los flujos de autenticación (login, registro, recuperar contraseña, reactivar).

## Tipo de cambio

- [x] Feature (nueva funcionalidad sin breaking changes)

## Módulo(s) afectado(s)

- [x] Frontend

## Cambios realizados

- Crear `ReactivateForm` como componente modular usando design tokens compartidos (`--auth-*`), `OtpInput`, `SubmitButton` y `useAuthForm` hook
- Agregar `'reactivate'` como modo en `AuthMode` y en el orquestador `AuthSplitScreenV2`
- Agregar `reactivateSchema` a los esquemas Zod compartidos
- Simplificar `reactivate/page.tsx` de ~210 líneas a ~25 líneas

## Test plan

- [x] Layout split-screen se ve igual que `/login` y `/forgot-password`
- [x] OTP inputs: auto-avance, backspace y paste funcionan correctamente
- [x] "Volver a iniciar sesión" navega a `/login`
- [x] `/reactivate` sin `?email=` redirige a `/login`
- [x] Responsive: desktop, tablet y mobile verificados
- [x] ESLint + Next.js build pasan sin errores

## Checklist

- [x] Código sigue las convenciones del proyecto
- [x] No hay secretos hardcodeados
- [x] CI pasa (lint + build)
- [x] Probado visualmente en browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)