### PR TITLE
fix(frontend): use nerbis teal for loading spinners

### DIFF
--- a/frontend/src/app/(tenant)/(shop)/plans/[slug]/[planSlug]/page.tsx
+++ b/frontend/src/app/(tenant)/(shop)/plans/[slug]/[planSlug]/page.tsx
@@ -72,7 +72,7 @@ export default function PlanDetailPage({ params }: PageProps) {
     return (
       <div className="container mx-auto px-4 py-12">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-auth-accent mx-auto mb-4"></div>
           <p className="text-muted-foreground">Cargando plan...</p>
         </div>
       </div>

--- a/frontend/src/app/(tenant)/(shop)/plans/[slug]/page.tsx
+++ b/frontend/src/app/(tenant)/(shop)/plans/[slug]/page.tsx
@@ -50,7 +50,7 @@ export default function CategoryPlansPage({ params }: PageProps) {
     return (
       <div className="container mx-auto px-4 py-12">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-auth-accent mx-auto mb-4"></div>
           <p className="text-muted-foreground">Cargando planes...</p>
         </div>
       </div>

--- a/frontend/src/app/(tenant)/(shop)/plans/page.tsx
+++ b/frontend/src/app/(tenant)/(shop)/plans/page.tsx
@@ -34,7 +34,7 @@ export default function PlansPage() {
     return (
       <div className="container mx-auto px-4 py-12">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-auth-accent mx-auto mb-4"></div>
           <p className="text-muted-foreground">Cargando servicios...</p>
         </div>
       </div>

--- a/frontend/src/app/(tenant)/checkout/page.tsx
+++ b/frontend/src/app/(tenant)/checkout/page.tsx
@@ -147,7 +147,7 @@ export default function CheckoutPage() {
         <main className="container py-8">
           <Card className="max-w-md mx-auto text-center py-12">
             <CardContent>
-              <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-primary" />
+              <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-auth-accent" />
               <h2 className="text-xl font-semibold mb-2">Cargando...</h2>
             </CardContent>
           </Card>
@@ -309,7 +309,7 @@ export default function CheckoutPage() {
         <main className="container py-8">
           <Card className="max-w-md mx-auto text-center py-12">
             <CardContent>
-              <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-primary" />
+              <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-auth-accent" />
               <h2 className="text-xl font-semibold mb-2">Sincronizando tu carrito...</h2>
               <p className="text-muted-foreground">
                 Estamos preparando tu pedido, por favor espera.

--- a/frontend/src/app/(tenant)/checkout/success/page.tsx
+++ b/frontend/src/app/(tenant)/checkout/success/page.tsx
@@ -73,7 +73,7 @@ export default function CheckoutSuccessPage() {
   return (
     <Suspense fallback={
       <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <Loader2 className="h-8 w-8 animate-spin text-auth-accent" />
       </div>
     }>
       <CheckoutSuccessContent />

--- a/frontend/src/app/(tenant)/dashboard/contracts/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/contracts/page.tsx
@@ -100,7 +100,7 @@ export default function ContractsPage() {
     return (
       <div className="container mx-auto px-4 py-12">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-auth-accent mx-auto mb-4"></div>
           <p className="text-muted-foreground">Cargando contratos...</p>
         </div>
       </div>

--- a/frontend/src/components/common/PageGuard.tsx
+++ b/frontend/src/components/common/PageGuard.tsx
@@ -23,7 +23,7 @@ export function PageGuard({ page, children }: PageGuardProps) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4" />
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-auth-accent mx-auto mb-4" />
           <p className="text-muted-foreground">Cargando...</p>
         </div>
       </div>

--- a/frontend/src/contexts/TenantContext.tsx
+++ b/frontend/src/contexts/TenantContext.tsx
@@ -156,7 +156,7 @@ export function TenantProvider({ children }: TenantProviderProps) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-auth-accent mx-auto mb-4"></div>
           <p className="text-muted-foreground">Cargando...</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaced `border-primary` / `text-primary` (rose gold `#D4A5A5`) with `border-auth-accent` / `text-auth-accent` (teal `#0D9488`) in all loading spinners
- Affected files: TenantContext, PageGuard, checkout, plans, contracts
- Ensures loading states are visually consistent with the NERBIS identity rebrand

Closes #129

## Test plan
- [ ] Verify loading spinner on tenant page load shows teal color
- [ ] Verify checkout loading state shows teal spinner
- [ ] Verify plans/services loading states show teal spinner
- [ ] Verify contracts loading state shows teal spinner
- [ ] Verify PageGuard loading state shows teal spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)