### PR TITLE
fix(frontend): auditar uso del token --destructive en botones y badges

### DIFF
--- a/frontend/src/app/(tenant)/(shop)/products/[id]/page.tsx
+++ b/frontend/src/app/(tenant)/(shop)/products/[id]/page.tsx
@@ -164,7 +164,7 @@ export default function ProductDetailPage() {
                 <Badge className="absolute top-4 right-4">Destacado</Badge>
               )}
               {hasDiscount && (
-                <Badge variant="destructive" className="absolute top-4 left-4">
+                <Badge className="absolute top-4 left-4">
                   Oferta
                 </Badge>
               )}

--- a/frontend/src/app/(tenant)/dashboard/appointments/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/appointments/page.tsx
@@ -261,7 +261,7 @@ export default function AppointmentsPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>No, mantener cita</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              variant="destructive"
               onClick={() => cancelingId && cancelMutation.mutate(cancelingId)}
               disabled={cancelMutation.isPending}
             >

--- a/frontend/src/app/(tenant)/dashboard/contracts/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/contracts/page.tsx
@@ -246,7 +246,7 @@ export default function ContractsPage() {
             <AlertDialogCancel>No, mantener</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleCancelContract}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              variant="destructive"
             >
               Sí, cancelar contrato
             </AlertDialogAction>

--- a/frontend/src/app/(tenant)/dashboard/products/categories/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/products/categories/page.tsx
@@ -457,7 +457,7 @@ export default function CategoriesPage() {
               onClick={() =>
                 deleteDialog.category && deleteMutation.mutate(deleteDialog.category.id)
               }
-              className="bg-destructive hover:bg-destructive/90"
+              variant="destructive"
             >
               {deleteMutation.isPending ? 'Eliminando...' : 'Eliminar'}
             </AlertDialogAction>

--- a/frontend/src/app/(tenant)/dashboard/products/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/products/page.tsx
@@ -243,7 +243,7 @@ export default function ProductsPage() {
                   )}
                   {!product.is_active && (
                     <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
-                      <Badge variant="destructive">Inactivo</Badge>
+                      <Badge variant="secondary">Inactivo</Badge>
                     </div>
                   )}
                   {product.is_featured && product.is_active && (
@@ -360,7 +360,7 @@ export default function ProductsPage() {
             <AlertDialogCancel>Cancelar</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => deleteDialog.product && deleteMutation.mutate(deleteDialog.product.id)}
-              className="bg-destructive hover:bg-destructive/90"
+              variant="destructive"
             >
               {deleteMutation.isPending ? 'Eliminando...' : 'Eliminar'}
             </AlertDialogAction>

--- a/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
@@ -341,7 +341,7 @@ export default function SettingsTeamPage() {
                           {ROLE_CONFIG[member.role].label}
                         </Badge>
                         {!member.is_active && (
-                          <Badge variant="destructive" className="text-[0.65rem] py-0 px-1.5">
+                          <Badge variant="secondary" className="text-[0.65rem] py-0 px-1.5">
                             Inactivo
                           </Badge>
                         )}
@@ -463,7 +463,7 @@ export default function SettingsTeamPage() {
                   });
                 }
               }}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              variant="destructive"
               disabled={
                 disconnectMutation.isPending ||
                 (!disconnectDialog.member?.has_password &&
@@ -508,7 +508,7 @@ export default function SettingsTeamPage() {
                   reset2faMutation.mutate(reset2faDialog.member.id);
                 }
               }}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              variant="destructive"
               disabled={reset2faMutation.isPending}
             >
               {reset2faMutation.isPending ? 'Reseteando...' : 'Resetear 2FA'}

--- a/frontend/src/app/(tenant)/dashboard/staff/appointments/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/staff/appointments/page.tsx
@@ -379,7 +379,7 @@ export default function StaffAppointmentsPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>No, mantener</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              variant="destructive"
               onClick={() => cancelingId && cancelMutation.mutate(cancelingId)}
               disabled={cancelMutation.isPending}
             >

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -91,7 +91,6 @@ export function Header() {
                 <ShoppingCart className="h-5 w-5 md:h-6 md:w-6" />
                 {itemsCount > 0 && (
                   <Badge
-                    variant="destructive"
                     className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 text-xs"
                   >
                     {itemsCount}

--- a/frontend/src/components/products/ProductCard.tsx
+++ b/frontend/src/components/products/ProductCard.tsx
@@ -64,7 +64,7 @@ export function ProductCard({ product }: ProductCardProps) {
             <Badge className="absolute top-2 right-2">Destacado</Badge>
           )}
           {hasDiscount && (
-            <Badge variant="destructive" className="absolute top-2 left-2">
+            <Badge className="absolute top-2 left-2">
               Oferta
             </Badge>
           )}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
@@ -116,12 +117,14 @@ function AlertDialogDescription({
 
 function AlertDialogAction({
   className,
+  variant,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  VariantProps<typeof buttonVariants>) {
   return (
     <AlertDialogPrimitive.Action
       data-slot="alert-dialog-action"
-      className={cn(buttonVariants(), className)}
+      className={cn(buttonVariants({ variant }), className)}
       {...props}
     />
   )


### PR DESCRIPTION
Cierra #100

> Reemplaza PR #133 (cerrado por conflictos con develop tras la reorganización a route group `(tenant)`).

## Objetivo

Auditar y corregir el uso del token CSS `--destructive` en la UI. Se usaba indistintamente para **acciones destructivas** (eliminar cuenta, borrar producto) y para **estados informativos** (badge "Oferta", contador del carrito, "Inactivo") — mezclando semánticas bajo el mismo color rojo.

## Cambios

### 1. `AlertDialogAction` acepta prop `variant`
Se agregó soporte para `VariantProps<typeof buttonVariants>` en `alert-dialog.tsx`. Ya no es necesario pasar clases inline.

### 2. 7 dialogs de confirmación estandarizados
Reemplazadas las clases inline `bg-destructive text-destructive-foreground hover:bg-destructive/90` por `variant="destructive"`:
- `(tenant)/dashboard/appointments/page.tsx` — cancelar cita
- `(tenant)/dashboard/contracts/page.tsx` — cancelar contrato
- `(tenant)/dashboard/staff/appointments/page.tsx` — cancelar cita (staff)
- `(tenant)/dashboard/products/page.tsx` — eliminar producto
- `(tenant)/dashboard/products/categories/page.tsx` — eliminar categoría
- `(tenant)/dashboard/settings/team/page.tsx` — desvincular cuenta social + resetear 2FA

### 3. Badges con semántica corregida
| Elemento | Antes | Después | Razón |
|----------|-------|---------|-------|
| "Oferta" (ProductCard, product detail) | `destructive` | `default` | Promocional, no negativo |
| "Inactivo" (productos + team) | `destructive` | `secondary` | Estado neutral |
| Cart count (Header) | `destructive` | `default` | Informativo |

## Test plan

- [ ] Verificar que los botones rojos siguen siendo rojos en los 7 dialogs de confirmación
- [ ] Verificar que el badge "Oferta" ahora usa color primary (rosa dusty) en lugar de rojo
- [ ] Verificar que el contador del carrito ahora es primary en lugar de rojo
- [ ] Verificar que el badge "Inactivo" (productos y miembros de equipo) ahora es gris/secondary
- [ ] Verificar que badges de estados negativos reales (cita cancelada, pedido cancelado) siguen siendo rojos
- [ ] CI pasa: ESLint + Next.js build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refinado el estilo visual de botones destructivos en diálogos de confirmación.
  * Actualizado el estilo de insignias de estado e indicadores en interfaces de administración.
  * Mejorada la consistencia en la presentación de elementos visuales mediante variantes de componentes unificadas.

* **Refactor**
  * Refactorizado el sistema de estilos de componentes para utilizar variantes integradas en lugar de clases personalizadas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->