### PR TITLE
fix(auth): critical security fixes for audit #99

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -726,7 +726,7 @@ class Banner(TenantAwareModel):
 
     message = models.TextField(
         verbose_name="Mensaje",
-        help_text="Texto que se mostrará en el banner. Puede incluir HTML básico.",
+        help_text="Texto plano que se mostrará en el banner. HTML será eliminado automáticamente.",
     )
 
     link_url = models.URLField(
@@ -1014,9 +1014,13 @@ class OTPToken(models.Model):
         """
         Verificar el código OTP.
 
+        Usa secrets.compare_digest para timing-safe comparison (fix #142).
+
         Returns:
             tuple: (success: bool, error_message: str or None)
         """
+        import secrets
+
         from django.utils import timezone
 
         if self.used_at is not None:
@@ -1028,7 +1032,7 @@ class OTPToken(models.Model):
         if self.attempts >= 3:
             return False, "Demasiados intentos fallidos. Solicita un nuevo código"
 
-        if self.code != code:
+        if not secrets.compare_digest(self.code, code):
             self.attempts += 1
             self.save()
             remaining = 3 - self.attempts

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -175,11 +175,12 @@ class RegisterSerializer(serializers.ModelSerializer):
 
         tenant = request.tenant
 
-        # Validar email único por tenant (case-insensitive)
+        # Validar email único por tenant (incluye activos e inactivos para
+        # no revelar si existe una cuenta inactiva — previene account takeover #135)
         email = attrs.get("email", "").lower()
         if User.objects.filter(tenant=tenant, email__iexact=email).exists():
             raise serializers.ValidationError(
-                {"email": "Ya existe un usuario con este email en este centro. Por favor inicia sesión."}
+                {"email": "Ya existe un usuario con este email. Por favor inicia sesión."}
             )
 
         return attrs
@@ -385,10 +386,21 @@ class TenantRegisterSerializer(serializers.Serializer):
 
 
 class BannerSerializer(serializers.ModelSerializer):
-    """Serializer para Banner (información pública)"""
+    """Serializer para Banner (información pública)
+
+    Security: message se sanea con strip_tags para prevenir XSS stored (#137).
+    """
 
     banner_type_display = serializers.CharField(source="get_banner_type_display", read_only=True)
     position_display = serializers.CharField(source="get_position_display", read_only=True)
+
+    def to_representation(self, instance):
+        from django.utils.html import strip_tags
+
+        data = super().to_representation(instance)
+        if data.get("message"):
+            data["message"] = strip_tags(data["message"])
+        return data
 
     class Meta:
         model = Banner

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -60,7 +60,10 @@ def subscription_expired_view(request):
 class RegisterView(generics.CreateAPIView):
     """POST /api/core/auth/register/ - Registro de usuarios
 
-    Si existe un usuario inactivo con el mismo email, lo reactiva automáticamente.
+    Security: NO reactiva usuarios inactivos. Si el email ya existe (activo o
+    inactivo), devuelve error genérico para evitar enumeración. La reactivación
+    se maneja exclusivamente vía ReactivateAccountView + OTP.
+    Ref: #135 (account takeover fix)
     """
 
     queryset = User.objects.all()
@@ -70,58 +73,27 @@ class RegisterView(generics.CreateAPIView):
     serializer_class = RegisterSerializer
 
     def create(self, request, *args, **kwargs):
-        email = request.data.get("email", "").lower()
-        tenant = request.tenant
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
 
-        # Verificar si existe un usuario inactivo con este email
-        try:
-            inactive_user = User.objects.get(email__iexact=email, tenant=tenant, is_active=False)
+        # Enviar email de bienvenida
+        self._send_welcome_email(user)
 
-            # Reactivar usuario existente
-            serializer = self.get_serializer(inactive_user, data=request.data, partial=True)
-            serializer.is_valid(raise_exception=True)
-            user = serializer.save(is_active=True)
+        # Generar tokens
+        refresh = RefreshToken.for_user(user)
 
-            # Enviar email de bienvenida
-            self._send_welcome_email(user)
-
-            # Generar tokens
-            refresh = RefreshToken.for_user(user)
-
-            return Response(
-                {
-                    "user": UserSessionSerializer(user).data,
-                    "tokens": {
-                        "refresh": str(refresh),
-                        "access": str(refresh.access_token),
-                    },
-                    "message": "Cuenta reactivada exitosamente",
+        return Response(
+            {
+                "user": UserSessionSerializer(user).data,
+                "tokens": {
+                    "refresh": str(refresh),
+                    "access": str(refresh.access_token),
                 },
-                status=status.HTTP_200_OK,
-            )
-        except User.DoesNotExist:
-            # No existe usuario inactivo, crear uno nuevo
-            serializer = self.get_serializer(data=request.data)
-            serializer.is_valid(raise_exception=True)
-            user = serializer.save()
-
-            # Enviar email de bienvenida
-            self._send_welcome_email(user)
-
-            # Generar tokens
-            refresh = RefreshToken.for_user(user)
-
-            return Response(
-                {
-                    "user": UserSessionSerializer(user).data,
-                    "tokens": {
-                        "refresh": str(refresh),
-                        "access": str(refresh.access_token),
-                    },
-                    "message": "Usuario creado exitosamente",
-                },
-                status=status.HTTP_201_CREATED,
-            )
+                "message": "Usuario creado exitosamente",
+            },
+            status=status.HTTP_201_CREATED,
+        )
 
     def _send_welcome_email(self, user):
         """Enviar email de bienvenida (sin bloquear el registro si falla)."""
@@ -364,8 +336,10 @@ class PlatformLoginView(APIView):
 
     A diferencia del LoginView normal (que requiere tenant context del middleware),
     este endpoint busca al usuario por email en TODOS los tenants.
-    Está diseñado para el formulario de login de la plataforma (nerbis.com),
-    donde el usuario no tiene un subdominio de tenant.
+
+    Si el email existe en múltiples tenants, se requiere el campo `tenant_slug`
+    para desambiguar. Sin este campo, se devuelve 409 con la lista de tenants.
+    Ref: #136 (cross-tenant mismatch fix)
     """
 
     authentication_classes = []
@@ -378,37 +352,58 @@ class PlatformLoginView(APIView):
 
         email = serializer.validated_data["email"]
         password = serializer.validated_data["password"]
+        tenant_slug = request.data.get("tenant_slug")
 
-        # Buscar usuario por email en TODOS los tenants
-        try:
-            user = User.objects.select_related("tenant").get(email__iexact=email)
-        except User.DoesNotExist:
-            return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
-        except User.MultipleObjectsReturned:
-            # Email existe en múltiples tenants — usar el más reciente
-            user = User.objects.select_related("tenant").filter(email__iexact=email).order_by("-date_joined").first()
+        # Si se especifica tenant_slug, filtrar directamente
+        if tenant_slug:
+            try:
+                user = User.objects.select_related("tenant").get(email__iexact=email, tenant__slug=tenant_slug)
+            except User.DoesNotExist:
+                return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
+        else:
+            # Buscar en todos los tenants
+            try:
+                user = User.objects.select_related("tenant").get(email__iexact=email)
+            except User.DoesNotExist:
+                return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
+            except User.MultipleObjectsReturned:
+                # Verificar password contra todos los candidatos activos
+                candidates = User.objects.select_related("tenant").filter(
+                    email__iexact=email, is_active=True, tenant__is_active=True
+                )
+                matching = [u for u in candidates if u.check_password(password)]
 
-        # Verificar contraseña
-        if not user.check_password(password):
-            return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
+                if not matching:
+                    return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
 
-        # Si el usuario está inactivo
+                if len(matching) == 1:
+                    user = matching[0]
+                else:
+                    # Mismo password en múltiples tenants — exigir selección
+                    return Response(
+                        {
+                            "code": "MULTIPLE_TENANTS",
+                            "message": "Tu email está registrado en varios negocios. Selecciona uno.",
+                            "tenants": [{"slug": u.tenant.slug, "name": u.tenant.name} for u in matching],
+                        },
+                        status=status.HTTP_409_CONFLICT,
+                    )
+
+        # Verificar contraseña (solo si no se verificó arriba en multi-tenant)
+        if not tenant_slug and not hasattr(user, "_password_verified"):
+            if not user.check_password(password):
+                return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
+        elif tenant_slug:
+            if not user.check_password(password):
+                return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        # Si el usuario está inactivo (respuesta genérica — #138 anti-enumeración)
         if not user.is_active:
-            return Response(
-                {
-                    "error": "Tu cuenta fue desactivada",
-                    "code": "ACCOUNT_INACTIVE",
-                    "email": user.email,
-                    "message": "Tu cuenta fue desactivada previamente. ¿Deseas reactivarla?",
-                },
-                status=status.HTTP_403_FORBIDDEN,
-            )
+            return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
 
         # Verificar que el tenant esté activo
         if not user.tenant.is_active:
-            return Response(
-                {"error": "El negocio asociado a esta cuenta no está activo."}, status=status.HTTP_403_FORBIDDEN
-            )
+            return Response({"error": "Credenciales inválidas"}, status=status.HTTP_401_UNAUTHORIZED)
 
         # Generar tokens JWT
         refresh = RefreshToken.for_user(user)
@@ -434,6 +429,10 @@ class PlatformForgotPasswordView(APIView):
 
     Versión cross-tenant de RequestPasswordResetOTPView.
     Busca al usuario por email en TODOS los tenants.
+
+    Si el email existe en múltiples tenants, crea un OTP para CADA usuario
+    (cada uno con código diferente). Así el código identifica al usuario exacto.
+    Ref: #136 (cross-tenant mismatch fix)
     """
 
     authentication_classes = []
@@ -446,28 +445,20 @@ class PlatformForgotPasswordView(APIView):
         if not email:
             return Response({"error": "El email es requerido"}, status=status.HTTP_400_BAD_REQUEST)
 
-        # Buscar usuario en todos los tenants
-        try:
-            user = User.objects.select_related("tenant").get(email__iexact=email)
-        except User.DoesNotExist:
-            # Por seguridad, no revelar si el email existe
-            return Response(
-                {
-                    "message": "Si el email existe, recibirás un código de verificación",
-                    "email": email,
-                }
-            )
-        except User.MultipleObjectsReturned:
-            user = User.objects.select_related("tenant").filter(email__iexact=email).order_by("-date_joined").first()
+        # Buscar todos los usuarios con este email (pueden ser varios tenants)
+        users = User.objects.select_related("tenant").filter(email__iexact=email)
 
-        # Crear OTP
-        otp = OTPToken.create_for_user(user, purpose="password_reset")
+        if users.exists():
+            from notifications.tasks import send_otp_email
 
-        # Enviar email con OTP (async con Celery)
-        from notifications.tasks import send_otp_email
+            for user in users:
+                otp = OTPToken.create_for_user(user, purpose="password_reset")
+                try:
+                    send_otp_email.delay(user.id, otp.code, "password_reset")
+                except Exception:
+                    send_otp_email(user.id, otp.code, "password_reset")
 
-        send_otp_email.delay(user.id, otp.code, "password_reset")
-
+        # Siempre respuesta genérica (anti-enumeración)
         return Response(
             {
                 "message": "Si el email existe, recibirás un código de verificación",
@@ -481,8 +472,8 @@ class PlatformVerifyResetOTPView(APIView):
     POST /api/public/platform-verify-reset-otp/ - Verificar OTP desde la plataforma
 
     Versión cross-tenant de VerifyPasswordResetOTPView.
-    Busca al usuario por email en TODOS los tenants.
-    Retorna user + tenant + tokens para auto-login.
+    Resuelve al usuario correcto vía el OTP (cada usuario/tenant tiene código distinto).
+    Ref: #136 (cross-tenant mismatch fix), #141 (password policy fix)
     """
 
     authentication_classes = []
@@ -499,43 +490,43 @@ class PlatformVerifyResetOTPView(APIView):
                 {"error": "Email, código y nueva contraseña son requeridos"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        # Buscar usuario en todos los tenants
-        try:
-            user = User.objects.select_related("tenant").get(email__iexact=email)
-        except User.DoesNotExist:
-            return Response({"error": "Usuario no encontrado"}, status=status.HTTP_404_NOT_FOUND)
-        except User.MultipleObjectsReturned:
-            user = User.objects.select_related("tenant").filter(email__iexact=email).order_by("-date_joined").first()
+        # Buscar OTPs activos para este email (puede haber varios si multi-tenant)
+        active_otps = OTPToken.objects.select_related("user", "user__tenant").filter(
+            user__email__iexact=email,
+            purpose="password_reset",
+            used_at__isnull=True,
+        )
 
-        # Buscar OTP válido
-        try:
-            otp = OTPToken.objects.get(user=user, purpose="password_reset", used_at__isnull=True)
-        except OTPToken.DoesNotExist:
+        if not active_otps.exists():
+            # Respuesta genérica (anti-enumeración — #138)
             return Response(
-                {"error": "No hay un código de verificación activo. Solicita uno nuevo."},
+                {"error": "Solicitud inválida. Solicita un nuevo código."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Verificar OTP
-        success, error = otp.verify(code)
-        if not success:
-            return Response({"error": error}, status=status.HTTP_400_BAD_REQUEST)
+        # Verificar código contra cada OTP (el código identifica al usuario/tenant)
+        matched_otp = None
+        for otp in active_otps:
+            success, error = otp.verify(code)
+            if success:
+                matched_otp = otp
+                break
 
-        # Validar fortaleza de la nueva contraseña
-        if len(new_password) < 8:
-            return Response(
-                {"error": "La contraseña debe tener al menos 8 caracteres"}, status=status.HTTP_400_BAD_REQUEST
-            )
-        has_upper = any(c.isupper() for c in new_password)
-        has_lower = any(c.islower() for c in new_password)
-        has_digit = any(c.isdigit() for c in new_password)
-        if not (has_upper and has_lower and has_digit):
-            return Response(
-                {"error": "La contraseña debe incluir mayúsculas, minúsculas y números"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if not matched_otp:
+            return Response({"error": error or "Código incorrecto"}, status=status.HTTP_400_BAD_REQUEST)
 
-        # Cambiar contraseña (sin generar tokens — el usuario debe iniciar sesión manualmente)
+        user = matched_otp.user
+
+        # Validar contraseña con AUTH_PASSWORD_VALIDATORS (fix #141)
+        from django.contrib.auth.password_validation import validate_password
+        from django.core.exceptions import ValidationError
+
+        try:
+            validate_password(new_password, user=user)
+        except ValidationError as e:
+            return Response({"error": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Cambiar contraseña
         user.set_password(new_password)
         user.save()
 
@@ -562,6 +553,12 @@ class LogoutView(APIView):
         try:
             refresh_token = request.data.get("refresh")
             token = RefreshToken(refresh_token)
+
+            # Validar que el token pertenece al usuario autenticado (#143)
+            token_user_id = token.get("user_id")
+            if token_user_id != request.user.id:
+                return Response({"error": "Token inválido"}, status=status.HTTP_400_BAD_REQUEST)
+
             token.blacklist()
             return Response({"message": "Logout exitoso"})
         except Exception:
@@ -1157,18 +1154,21 @@ class VerifyPasswordResetOTPView(APIView):
                 {"error": "Email, código y nueva contraseña son requeridos"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        # Buscar usuario
+        # Buscar usuario (respuesta genérica si no existe — anti-enumeración #138)
         try:
             user = User.objects.get(email__iexact=email, tenant=tenant)
         except User.DoesNotExist:
-            return Response({"error": "Usuario no encontrado"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": "Solicitud inválida. Solicita un nuevo código."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Buscar OTP válido
         try:
             otp = OTPToken.objects.get(user=user, purpose="password_reset", used_at__isnull=True)
         except OTPToken.DoesNotExist:
             return Response(
-                {"error": "No hay un código de verificación activo. Solicita uno nuevo."},
+                {"error": "Solicitud inválida. Solicita un nuevo código."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -1177,21 +1177,16 @@ class VerifyPasswordResetOTPView(APIView):
         if not success:
             return Response({"error": error}, status=status.HTTP_400_BAD_REQUEST)
 
-        # Validar fortaleza de la nueva contraseña
-        if len(new_password) < 8:
-            return Response(
-                {"error": "La contraseña debe tener al menos 8 caracteres"}, status=status.HTTP_400_BAD_REQUEST
-            )
-        has_upper = any(c.isupper() for c in new_password)
-        has_lower = any(c.islower() for c in new_password)
-        has_digit = any(c.isdigit() for c in new_password)
-        if not (has_upper and has_lower and has_digit):
-            return Response(
-                {"error": "La contraseña debe incluir mayúsculas, minúsculas y números"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        # Validar contraseña con AUTH_PASSWORD_VALIDATORS (fix #141)
+        from django.contrib.auth.password_validation import validate_password
+        from django.core.exceptions import ValidationError
 
-        # Cambiar contraseña (sin generar tokens — el usuario debe iniciar sesión manualmente)
+        try:
+            validate_password(new_password, user=user)
+        except ValidationError as e:
+            return Response({"error": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Cambiar contraseña
         user.set_password(new_password)
         user.save()
 


### PR DESCRIPTION
## Summary

Fixes **4 critical** and **3 high** vulnerabilities found in the security audit (#99). This is **PR 1 of 4** in the security hardening plan.

### Critical fixes
- **C-1** Account takeover via RegisterView: removed auto-reactivation of inactive users that allowed password override without auth (#135)
- **C-2** Cross-tenant mismatch: PlatformLogin/ForgotPassword/VerifyReset now handle MultipleObjectsReturned securely — login requires tenant selection, forgot-password sends OTP per-user/per-tenant, verify resolves via OTP ownership (#136)
- **C-4** Stored XSS via Banner.message: added `strip_tags` sanitization in BannerSerializer output (#137)

### High fixes
- **A-4** Password policy bypass in reset: replaced ad-hoc validation with `validate_password(user=user)` using AUTH_PASSWORD_VALIDATORS (#141)
- **A-7** LogoutView ownership: validates `token.user_id == request.user.id` before blacklisting (#143)
- **Timing** OTP verification: uses `secrets.compare_digest` for timing-safe comparison (#142)
- **Anti-enumeration** Generic error responses in verify/reset endpoints (#138)

### Files changed
- `backend/core/views.py` — RegisterView, PlatformLoginView, PlatformForgotPasswordView, PlatformVerifyResetOTPView, VerifyPasswordResetOTPView, LogoutView
- `backend/core/serializers.py` — RegisterSerializer validation, BannerSerializer XSS protection
- `backend/core/models.py` — OTPToken.verify timing-safe, Banner.message help_text

## Test plan

- [x] All 55 existing tests pass
- [ ] Manual: register with inactive email returns "Ya existe un usuario" (not reactivation)
- [ ] Manual: platform-login with multi-tenant email returns 409 MULTIPLE_TENANTS
- [ ] Manual: platform-forgot-password with multi-tenant email sends separate OTPs
- [ ] Manual: banner with `<script>` tag returns stripped text
- [ ] Manual: logout with another user's refresh token returns 400

## Remaining PRs

- **PR 2:** Anti-enumeration (A-1), OTP hardening (A-5/A-6)
- **PR 3:** Throttle compuesto Redis (A-2), refresh throttle (A-3), check throttle (A-8)
- **PR 4:** httpOnly cookies (#128), settings hardening, JWT claims (M-1..M-10)

Closes #135, closes #137, closes #141, closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la Versión

* **Correcciones de Seguridad**
  * Implementada comparación segura contra ataques de timing en códigos OTP.
  * Eliminación automática de HTML en mensajes de banners para evitar inyecciones.
  * Validación mejorada de tokens JWT en operaciones de cierre de sesión.

* **Mejoras**
  * Optimización del flujo de inicio de sesión y restablecimiento de contraseña en entornos multi-tenant.
  * Mensajes de error genéricos para mayor seguridad contra enumeración de usuarios.

* **Cambios de Comportamiento**
  * Códigos de respuesta HTTP actualizados en el proceso de registro.
  * Reactivación automática de usuarios eliminada del flujo de registro.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->