### PR TITLE
fix(infra): husky hooks support for git worktrees

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,9 @@
+# Resolve node_modules from main repo when running in a worktree
+if [ ! -d "node_modules" ]; then
+  MAIN_ROOT="$(git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.git$||')"
+  if [ -d "$MAIN_ROOT/node_modules" ]; then
+    export PATH="$MAIN_ROOT/node_modules/.bin:$PATH"
+  fi
+fi
+
 npx --no -- commitlint --edit ${1}


### PR DESCRIPTION
## Summary
- Fix `commit-msg` hook to resolve `node_modules` from the main repo when running inside a git worktree
- Uses `git rev-parse --git-common-dir` to find the main repo root and adds its `node_modules/.bin` to PATH
- Allows `commitlint` to work in worktrees without `npm install` or symlinks

## Context
`core.hooksPath` was corrupted (`--version/_` instead of `.husky`), breaking hooks everywhere. The relative path `.husky` works across worktrees since git resolves it from the working directory root.

## Test plan
- [x] Verified `commitlint` rejects invalid messages in worktree
- [x] Verified `commitlint` accepts valid conventional commit messages in worktree
- [x] Verify hooks work in main repo (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)