### PR TITLE
chore(infra): add claude code local settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,10 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+# Claude Code local settings (personal, not for repo)
+.claude/settings.local.json
+.claude/worktrees/
+
 # Cursor
 #  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` and `.claude/worktrees/` to `.gitignore`
- Prevents accidental commit of personal Claude Code permissions (e.g. `bypassPermissions` mode)

## Test plan
- [x] Verify `.claude/settings.local.json` is not tracked by git
- [x] Verify `.claude/worktrees/` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)