### PR TITLE
refactor(core): migrate auth tokens from localStorage to httpOnly cookies

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -293,7 +293,7 @@ LOGGING = {
 REST_FRAMEWORK = {
     # Autenticación
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "core.authentication.CookieJWTAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
     # Permisos por defecto
@@ -349,6 +349,17 @@ SIMPLE_JWT = {
     "USER_ID_FIELD": "id",
     "USER_ID_CLAIM": "user_id",
 }
+
+# ===================================
+# JWT COOKIE CONFIGURATION
+# ===================================
+JWT_AUTH_COOKIE = "access_token"
+JWT_AUTH_REFRESH_COOKIE = "refresh_token"
+JWT_AUTH_COOKIE_HTTP_ONLY = True
+JWT_AUTH_COOKIE_SECURE = not DEBUG  # True en producción (HTTPS)
+JWT_AUTH_COOKIE_SAMESITE = "Lax"
+JWT_AUTH_COOKIE_PATH = "/"
+JWT_AUTH_REFRESH_COOKIE_PATH = "/api/auth/"  # Refresh cookie solo se envía a endpoints de auth
 
 # ===================================
 # DRF SPECTACULAR (Documentación)

--- a/backend/core/authentication.py
+++ b/backend/core/authentication.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """
+    Autenticación JWT que busca el token en:
+    1. Cookie httpOnly (access_token)
+    2. Header Authorization (Bearer) — fallback para compatibilidad
+    """
+
+    def authenticate(self, request):
+        # Intentar primero con la cookie
+        cookie_name = getattr(settings, "JWT_AUTH_COOKIE", "access_token")
+        raw_token = request.COOKIES.get(cookie_name)
+
+        if raw_token is not None:
+            validated_token = self.get_validated_token(raw_token)
+            return self.get_user(validated_token), validated_token
+
+        # Fallback al header Authorization (comportamiento original)
+        return super().authenticate(request)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,7 +1,6 @@
 # backend/core/urls.py
 
 from django.urls import path
-from rest_framework_simplejwt.views import TokenRefreshView
 
 from . import views
 
@@ -12,7 +11,7 @@ urlpatterns = [
     path("auth/register/", views.RegisterView.as_view(), name="register"),
     path("auth/login/", views.LoginView.as_view(), name="login"),
     path("auth/logout/", views.LogoutView.as_view(), name="logout"),
-    path("auth/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("auth/refresh/", views.CookieTokenRefreshView.as_view(), name="token_refresh"),
     path("auth/me/", views.CurrentUserView.as_view(), name="current_user"),
     path("auth/profile/", views.ProfileView.as_view(), name="profile"),
     path("auth/change-password/", views.ChangePasswordView.as_view(), name="change_password"),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from django.conf import settings
+from django.db.models import Q
 from django.shortcuts import render
 from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, inline_serializer
@@ -29,7 +31,42 @@ from .serializers import (
 from .throttles import LoginThrottle, OTPRequestThrottle, OTPVerifyThrottle, PasswordResetThrottle, RegisterThrottle
 
 logger = logging.getLogger(__name__)
-from django.db.models import Q
+
+
+def set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> Response:
+    """Set httpOnly cookies for JWT tokens on a DRF Response."""
+    response.set_cookie(
+        key=settings.JWT_AUTH_COOKIE,
+        value=access_token,
+        httponly=settings.JWT_AUTH_COOKIE_HTTP_ONLY,
+        secure=settings.JWT_AUTH_COOKIE_SECURE,
+        samesite=settings.JWT_AUTH_COOKIE_SAMESITE,
+        path=settings.JWT_AUTH_COOKIE_PATH,
+        max_age=int(settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"].total_seconds()),
+    )
+    response.set_cookie(
+        key=settings.JWT_AUTH_REFRESH_COOKIE,
+        value=refresh_token,
+        httponly=settings.JWT_AUTH_COOKIE_HTTP_ONLY,
+        secure=settings.JWT_AUTH_COOKIE_SECURE,
+        samesite=settings.JWT_AUTH_COOKIE_SAMESITE,
+        path=settings.JWT_AUTH_REFRESH_COOKIE_PATH,
+        max_age=int(settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"].total_seconds()),
+    )
+    return response
+
+
+def clear_auth_cookies(response: Response) -> Response:
+    """Clear JWT auth cookies from a DRF Response."""
+    response.delete_cookie(
+        key=settings.JWT_AUTH_COOKIE,
+        path=settings.JWT_AUTH_COOKIE_PATH,
+    )
+    response.delete_cookie(
+        key=settings.JWT_AUTH_REFRESH_COOKIE,
+        path=settings.JWT_AUTH_REFRESH_COOKIE_PATH,
+    )
+    return response
 
 # ===================================
 # VISTA DE SUSCRIPCION EXPIRADA
@@ -88,17 +125,14 @@ class RegisterView(generics.CreateAPIView):
             # Generar tokens
             refresh = RefreshToken.for_user(user)
 
-            return Response(
+            response = Response(
                 {
                     "user": UserSessionSerializer(user).data,
-                    "tokens": {
-                        "refresh": str(refresh),
-                        "access": str(refresh.access_token),
-                    },
                     "message": "Cuenta reactivada exitosamente",
                 },
                 status=status.HTTP_200_OK,
             )
+            return set_auth_cookies(response, str(refresh.access_token), str(refresh))
         except User.DoesNotExist:
             # No existe usuario inactivo, crear uno nuevo
             serializer = self.get_serializer(data=request.data)
@@ -111,17 +145,14 @@ class RegisterView(generics.CreateAPIView):
             # Generar tokens
             refresh = RefreshToken.for_user(user)
 
-            return Response(
+            response = Response(
                 {
                     "user": UserSessionSerializer(user).data,
-                    "tokens": {
-                        "refresh": str(refresh),
-                        "access": str(refresh.access_token),
-                    },
                     "message": "Usuario creado exitosamente",
                 },
                 status=status.HTTP_201_CREATED,
             )
+            return set_auth_cookies(response, str(refresh.access_token), str(refresh))
 
     def _send_welcome_email(self, user):
         """Enviar email de bienvenida (sin bloquear el registro si falla)."""
@@ -245,18 +276,15 @@ class TenantRegisterView(generics.CreateAPIView):
         # Generar tokens
         refresh = RefreshToken.for_user(user)
 
-        return Response(
+        response = Response(
             {
                 "user": UserSessionSerializer(user).data,
                 "tenant": TenantSerializer(user.tenant).data,
-                "tokens": {
-                    "refresh": str(refresh),
-                    "access": str(refresh.access_token),
-                },
                 "message": "Negocio creado exitosamente. Bienvenido a NERBIS!",
             },
             status=status.HTTP_201_CREATED,
         )
+        return set_auth_cookies(response, str(refresh.access_token), str(refresh))
 
     def _send_welcome_email(self, user):
         """Enviar email de bienvenida (sin bloquear el registro si falla)."""
@@ -346,16 +374,13 @@ class LoginView(APIView):
         refresh["tenant_slug"] = user.tenant.slug
         refresh["role"] = user.role
 
-        return Response(
+        response = Response(
             {
                 "user": UserSessionSerializer(user).data,
                 "tenant": TenantSerializer(tenant).data,
-                "tokens": {
-                    "refresh": str(refresh),
-                    "access": str(refresh.access_token),
-                },
             }
         )
+        return set_auth_cookies(response, str(refresh.access_token), str(refresh))
 
 
 class PlatformLoginView(APIView):
@@ -416,16 +441,13 @@ class PlatformLoginView(APIView):
         refresh["tenant_slug"] = user.tenant.slug
         refresh["role"] = user.role
 
-        return Response(
+        response = Response(
             {
                 "user": UserSessionSerializer(user).data,
                 "tenant": TenantSerializer(user.tenant).data,
-                "tokens": {
-                    "refresh": str(refresh),
-                    "access": str(refresh.access_token),
-                },
             }
         )
+        return set_auth_cookies(response, str(refresh.access_token), str(refresh))
 
 
 class PlatformForgotPasswordView(APIView):
@@ -552,7 +574,7 @@ class LogoutView(APIView):
     permission_classes = [IsAuthenticated]
 
     @extend_schema(
-        request=inline_serializer(name="LogoutRequest", fields={"refresh": drf_serializers.CharField()}),
+        request=inline_serializer(name="LogoutRequest", fields={}),
         responses={
             200: inline_serializer(name="LogoutResponse", fields={"message": drf_serializers.CharField()}),
             400: OpenApiResponse(description="Token inválido"),
@@ -560,12 +582,16 @@ class LogoutView(APIView):
     )
     def post(self, request):
         try:
-            refresh_token = request.data.get("refresh")
-            token = RefreshToken(refresh_token)
-            token.blacklist()
-            return Response({"message": "Logout exitoso"})
+            # Leer refresh token de la cookie httpOnly
+            refresh_token = request.COOKIES.get(settings.JWT_AUTH_REFRESH_COOKIE)
+            if refresh_token:
+                token = RefreshToken(refresh_token)
+                token.blacklist()
         except Exception:
-            return Response({"error": "Token inválido"}, status=status.HTTP_400_BAD_REQUEST)
+            pass  # Si el token ya expiró o es inválido, continuar con la limpieza
+
+        response = Response({"message": "Logout exitoso"})
+        return clear_auth_cookies(response)
 
 
 class CurrentUserView(APIView):
@@ -777,16 +803,13 @@ class SetPasswordView(APIView):
         refresh["tenant_slug"] = user.tenant.slug
         refresh["role"] = user.role
 
-        return Response(
+        response = Response(
             {
                 "message": "Contraseña establecida exitosamente",
                 "user": UserSessionSerializer(user).data,
-                "tokens": {
-                    "refresh": str(refresh),
-                    "access": str(refresh.access_token),
-                },
             }
         )
+        return set_auth_cookies(response, str(refresh.access_token), str(refresh))
 
 
 # Vistas de testing (mantener)
@@ -969,17 +992,14 @@ class ReactivateAccountView(APIView):
         refresh["tenant_slug"] = user.tenant.slug
         refresh["role"] = user.role
 
-        return Response(
+        response = Response(
             {
                 "user": UserSessionSerializer(user).data,
-                "tokens": {
-                    "refresh": str(refresh),
-                    "access": str(refresh.access_token),
-                },
                 "message": "Cuenta reactivada exitosamente",
             },
             status=status.HTTP_200_OK,
         )
+        return set_auth_cookies(response, str(refresh.access_token), str(refresh))
 
 
 class ActiveBannersView(generics.ListAPIView):
@@ -1345,16 +1365,13 @@ class VerifyReactivationOTPView(APIView):
         refresh["tenant_slug"] = user.tenant.slug
         refresh["role"] = user.role
 
-        return Response(
+        response = Response(
             {
                 "message": "Cuenta reactivada exitosamente",
                 "user": UserSessionSerializer(user).data,
-                "tokens": {
-                    "refresh": str(refresh),
-                    "access": str(refresh.access_token),
-                },
             }
         )
+        return set_auth_cookies(response, str(refresh.access_token), str(refresh))
 
 
 # ===================================
@@ -1569,3 +1586,38 @@ def get_tenant_website_content(request):
         response_data["template_slug"] = config.template.slug
 
     return Response(response_data)
+
+
+class CookieTokenRefreshView(APIView):
+    """POST /api/auth/refresh/ — Refresh access token using httpOnly cookie."""
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        refresh_token = request.COOKIES.get(settings.JWT_AUTH_REFRESH_COOKIE)
+        if not refresh_token:
+            return Response(
+                {"error": "No refresh token provided"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        try:
+            from rest_framework_simplejwt.serializers import TokenRefreshSerializer
+
+            # TokenRefreshSerializer maneja rotación y blacklist automáticamente
+            serializer = TokenRefreshSerializer(data={"refresh": refresh_token})
+            serializer.is_valid(raise_exception=True)
+
+            new_access = serializer.validated_data["access"]
+            new_refresh = serializer.validated_data.get("refresh", refresh_token)
+
+            response = Response({"detail": "Token refreshed"})
+            return set_auth_cookies(response, new_access, new_refresh)
+
+        except Exception:
+            response = Response(
+                {"error": "Token inválido o expirado"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+            return clear_auth_cookies(response)

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -36,13 +36,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const refreshedRef = useRef(false);
 
-  // Auto-refresh: obtener datos frescos del servidor al cargar la app
+  // Auto-refresh: verificar sesión con el servidor al cargar la app.
+  // Las cookies httpOnly se envían automáticamente — si hay sesión válida,
+  // /auth/me/ responde con el usuario; si no, responde 401.
   useEffect(() => {
     if (refreshedRef.current) return;
     if (typeof window === 'undefined') return;
 
-    const token = localStorage.getItem('access_token');
-    if (!token) return;
+    // Si no hay user en localStorage, probablemente no hay sesión
+    const storedUser = authApi.getStoredUser();
+    if (!storedUser) return;
 
     refreshedRef.current = true;
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -51,12 +54,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     authApi.getCurrentUser()
       .then((freshUser) => {
         setUser(freshUser);
-        // Actualizar tenant desde localStorage (se actualiza en getCurrentUser)
         setTenant(getStoredTenant());
       })
       .catch(() => {
-        // Si falla (token expirado, etc), no hacer nada.
-        // El interceptor de 401 se encarga de limpiar la sesión.
+        // Si falla (cookie expirada, etc), limpiar estado local
+        setUser(null);
+        setTenant(null);
+        localStorage.removeItem('user');
+        localStorage.removeItem('tenant');
       })
       .finally(() => {
         setIsLoading(false);

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -6,13 +6,12 @@ import { AuthResponse, LoginCredentials, RegisterData, RegisterTenantData, User,
 /**
  * Platform Login (cross-tenant — busca al usuario en todos los tenants)
  * Usado desde el formulario de login de la plataforma NERBIS
+ * Los tokens se setean como cookies httpOnly por el backend.
  */
 export async function platformLogin(credentials: { email: string; password: string }): Promise<AuthResponse> {
   const { data } = await apiClient.post<AuthResponse>('/public/platform-login/', credentials);
 
   if (typeof window !== 'undefined') {
-    localStorage.setItem('access_token', data.tokens.access);
-    localStorage.setItem('refresh_token', data.tokens.refresh);
     localStorage.setItem('user', JSON.stringify(data.user));
     if (data.tenant) {
       localStorage.setItem('tenant', JSON.stringify(data.tenant));
@@ -31,8 +30,6 @@ export async function register(data: RegisterData): Promise<AuthResponse> {
   const response = await apiClient.post<AuthResponse>('/auth/register/', data);
 
   if (typeof window !== 'undefined') {
-    localStorage.setItem('access_token', response.data.tokens.access);
-    localStorage.setItem('refresh_token', response.data.tokens.refresh);
     localStorage.setItem('user', JSON.stringify(response.data.user));
     if (response.data.tenant) {
       localStorage.setItem('tenant', JSON.stringify(response.data.tenant));
@@ -43,21 +40,16 @@ export async function register(data: RegisterData): Promise<AuthResponse> {
 }
 
 /**
- * Logout — invalida refresh token en backend + limpia localStorage
+ * Logout — el backend lee el refresh token de la cookie httpOnly,
+ * lo blacklistea, y borra las cookies.
  */
 export async function logout(): Promise<void> {
+  try {
+    await apiClient.post('/auth/logout/');
+  } catch {
+    // Si falla (token ya expiró, etc), continuar con limpieza local
+  }
   if (typeof window !== 'undefined') {
-    const refreshToken = localStorage.getItem('refresh_token');
-    // Invalidar token en backend (blacklist)
-    if (refreshToken) {
-      try {
-        await apiClient.post('/auth/logout/', { refresh: refreshToken });
-      } catch {
-        // Si falla (token ya expiró, etc), continuar con limpieza local
-      }
-    }
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('refresh_token');
     localStorage.removeItem('user');
     localStorage.removeItem('tenant');
   }
@@ -77,14 +69,6 @@ export async function getCurrentUser(): Promise<User> {
   }
 
   return data.user;
-}
-
-/**
- * Check if user is authenticated
- */
-export function isAuthenticated(): boolean {
-  if (typeof window === 'undefined') return false;
-  return !!localStorage.getItem('access_token');
 }
 
 /**
@@ -147,8 +131,6 @@ export async function registerTenant(data: RegisterTenantData): Promise<AuthResp
   const response = await apiClient.post<AuthResponse>('/public/register-tenant/', data);
 
   if (typeof window !== 'undefined') {
-    localStorage.setItem('access_token', response.data.tokens.access);
-    localStorage.setItem('refresh_token', response.data.tokens.refresh);
     localStorage.setItem('user', JSON.stringify(response.data.user));
     if (response.data.tenant) {
       localStorage.setItem('tenant', JSON.stringify(response.data.tenant));
@@ -242,8 +224,6 @@ export async function verifyReactivationOTP(email: string, code: string): Promis
   const { data } = await apiClient.post<AuthResponse>('/auth/verify-reactivation/', { email, code });
 
   if (typeof window !== 'undefined') {
-    localStorage.setItem('access_token', data.tokens.access);
-    localStorage.setItem('refresh_token', data.tokens.refresh);
     localStorage.setItem('user', JSON.stringify(data.user));
     if (data.tenant) {
       localStorage.setItem('tenant', JSON.stringify(data.tenant));

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -37,29 +37,23 @@ function getTenantSlug(): string {
 
 /**
  * Cliente Axios configurado para la API
+ * withCredentials: true permite que el browser envíe/reciba cookies httpOnly
  */
 export const apiClient: AxiosInstance = axios.create({
   baseURL: API_URL,
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 });
 
 /**
- * Interceptor para agregar token de autenticación y tenant slug
+ * Interceptor para agregar tenant slug a cada request.
+ * Los tokens de auth se envían automáticamente como cookies httpOnly por el browser.
  */
 apiClient.interceptors.request.use(
   (config) => {
-    // Agregar tenant slug dinámicamente
     config.headers['X-Tenant-Slug'] = getTenantSlug();
-
-    // Obtener token del localStorage
-    if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('access_token');
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
-      }
-    }
     return config;
   },
   (error) => {
@@ -106,8 +100,6 @@ function processQueue(error: unknown, token: string | null) {
 
 function clearSessionAndRedirect() {
   if (typeof window !== 'undefined') {
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('refresh_token');
     localStorage.removeItem('user');
     localStorage.removeItem('tenant');
     const currentPath = window.location.pathname;
@@ -167,27 +159,12 @@ apiClient.interceptors.response.use(
         return Promise.reject(authError);
       }
 
-      // Intentar renovar el access token con el refresh token
-      const refreshToken = typeof window !== 'undefined'
-        ? localStorage.getItem('refresh_token')
-        : null;
-
-      if (!refreshToken) {
-        clearSessionAndRedirect();
-        const authError = new ApiError(
-          'Sesión expirada. Por favor, inicia sesión de nuevo.',
-          401,
-          'UNAUTHORIZED'
-        );
-        return Promise.reject(authError);
-      }
-
       // Si ya hay un refresh en curso, encolar este request
       if (isRefreshing) {
         return new Promise<string>((resolve, reject) => {
           failedQueue.push({ resolve, reject });
-        }).then((newToken) => {
-          originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        }).then(() => {
+          // Las cookies se actualizaron automáticamente por el browser
           return apiClient(originalRequest);
         });
       }
@@ -195,19 +172,16 @@ apiClient.interceptors.response.use(
       isRefreshing = true;
 
       try {
-        const { data } = await axios.post<{ access: string; refresh?: string }>(
+        // El refresh token se envía automáticamente como cookie httpOnly
+        await axios.post(
           `${API_URL}/auth/refresh/`,
-          { refresh: refreshToken },
-          { headers: { 'Content-Type': 'application/json' } }
+          {},
+          { withCredentials: true, headers: { 'Content-Type': 'application/json' } }
         );
 
-        localStorage.setItem('access_token', data.access);
-        if (data.refresh) {
-          localStorage.setItem('refresh_token', data.refresh);
-        }
-        processQueue(null, data.access);
+        processQueue(null, 'refreshed');
 
-        originalRequest.headers.Authorization = `Bearer ${data.access}`;
+        // Reintentar el request original (las cookies ya se actualizaron)
         return apiClient(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError, null);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -98,15 +98,9 @@ export interface RegisterTenantData {
   phone?: string;
 }
 
-export interface AuthTokens {
-  access: string;
-  refresh: string;
-}
-
 export interface AuthResponse {
   user: User;
   tenant?: Tenant;
-  tokens: AuthTokens;
   message?: string;
 }
 


### PR DESCRIPTION
## Summary

- **Backend:** Auth endpoints now set JWT tokens as `httpOnly`/`Secure`/`SameSite=Lax` cookies instead of returning them in the JSON response body
- **Frontend:** Removed all `localStorage` reads/writes for `access_token`/`refresh_token`; axios uses `withCredentials: true` so the browser sends cookies automatically
- **New `CookieJWTAuthentication`** class reads tokens from cookie first, falls back to `Authorization` header for API clients/mobile compatibility

## Files changed (8)

| File | Change |
|---|---|
| `backend/config/settings.py` | JWT cookie config + `CookieJWTAuthentication` as default |
| `backend/core/authentication.py` | **New** — Cookie-first JWT auth with header fallback |
| `backend/core/views.py` | `set_auth_cookies()`/`clear_auth_cookies()` helpers, migrated 8 auth views, new `CookieTokenRefreshView` |
| `backend/core/urls.py` | `auth/refresh/` → `CookieTokenRefreshView` |
| `frontend/src/lib/api/client.ts` | `withCredentials: true`, removed localStorage token interceptor, cookie-based auto-refresh |
| `frontend/src/lib/api/auth.ts` | Removed all token localStorage operations |
| `frontend/src/contexts/AuthContext.tsx` | Session check via `/auth/me/` instead of localStorage token |
| `frontend/src/types/index.ts` | Removed `AuthTokens` interface, cleaned `AuthResponse` |

## Security improvements

- Tokens are **never accessible to JavaScript** (httpOnly)
- `Secure=true` in production (HTTPS only)
- `SameSite=Lax` mitigates CSRF
- Refresh cookie restricted to `/api/auth/` path
- Access cookie at `/` (needed for all authenticated endpoints)

## Test plan

- [ ] Login flow: verify cookies are set (DevTools → Application → Cookies)
- [ ] Refresh flow: verify 401 triggers silent refresh via cookie
- [ ] Logout flow: verify cookies are cleared and refresh token is blacklisted
- [ ] Register tenant flow: verify cookies set + redirect to setup
- [ ] Reactivate account flow: verify cookies set after OTP
- [ ] Page reload: verify session persists via `/auth/me/` call
- [ ] Session expiry: verify redirect to login when both tokens expire

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)