### PR TITLE
feat(teams): bloquear invitaciones al equipo hasta sitio publicado

### DIFF
--- a/backend/core/tests/test_team_invitations_guard.py
+++ b/backend/core/tests/test_team_invitations_guard.py
@@ -1,0 +1,112 @@
+"""
+Tests para el guard de invitaciones al equipo basado en website_status.
+
+Verifica que solo se puedan enviar/reenviar invitaciones cuando el sitio web
+del tenant tenga status 'published' o 'review'.
+"""
+
+from django.urls import reverse
+from rest_framework import status
+
+from core.test_base import TenantAwareTestCase
+from websites.models import WebsiteConfig, WebsiteTemplate
+
+
+class TeamInvitationsGuardBaseTestCase(TenantAwareTestCase):
+    """Clase base con helpers para tests del guard de invitaciones."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.template = WebsiteTemplate.objects.create(
+            name="Template Test",
+            slug="template-test",
+            industry="generic",
+            description="Template para tests",
+        )
+
+    def _create_website_config(self, tenant_status: str) -> WebsiteConfig:
+        """Crear o actualizar WebsiteConfig con el status dado."""
+        config, _created = WebsiteConfig.objects.update_or_create(
+            tenant=self.tenant,
+            defaults={"template": self.template, "status": tenant_status},
+        )
+        return config
+
+    def _delete_website_config(self):
+        """Eliminar WebsiteConfig del tenant si existe."""
+        WebsiteConfig.objects.filter(tenant=self.tenant).delete()
+
+
+class TeamInvitationsGuardBlockedTest(TeamInvitationsGuardBaseTestCase):
+    """Test: POST invitaciones bloqueado cuando website_status no es published/review."""
+
+    def setUp(self):
+        super().setUp()
+        self.authenticate_as_admin()
+        self.url = reverse("core:team_invitations")
+        self.payload = {"email": "nuevo@equipo.com", "role": "staff"}
+
+    def test_blocked_when_status_draft(self):
+        self._create_website_config("draft")
+        response = self.client.post(self.url, self.payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("detail", response.json())
+
+    def test_blocked_when_status_generating(self):
+        self._create_website_config("generating")
+        response = self.client.post(self.url, self.payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_blocked_when_status_onboarding(self):
+        self._create_website_config("onboarding")
+        response = self.client.post(self.url, self.payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_blocked_when_no_website_config(self):
+        self._delete_website_config()
+        response = self.client.post(self.url, self.payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class TeamInvitationsGuardAllowedTest(TeamInvitationsGuardBaseTestCase):
+    """Test: POST invitaciones permitido cuando website_status es published o review."""
+
+    def setUp(self):
+        super().setUp()
+        self.authenticate_as_admin()
+        self.url = reverse("core:team_invitations")
+        self.payload = {"email": "nuevo@equipo.com", "role": "staff"}
+
+    def test_allowed_when_status_published(self):
+        self._create_website_config("published")
+        response = self.client.post(self.url, self.payload, format="json")
+        # No debe ser 403 — puede ser 201 o cualquier otro código de la lógica normal
+        self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_allowed_when_status_review(self):
+        self._create_website_config("review")
+        response = self.client.post(self.url, self.payload, format="json")
+        self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class ResendInvitationGuardBlockedTest(TeamInvitationsGuardBaseTestCase):
+    """Test: resend invitación bloqueado cuando website_status no permite invitaciones."""
+
+    def setUp(self):
+        super().setUp()
+        self.authenticate_as_admin()
+
+    def test_resend_blocked_when_status_draft(self):
+        self._create_website_config("draft")
+        # Usamos pk=99999 — el guard debe bloquear antes de buscar la invitación
+        url = reverse("core:resend_invitation", kwargs={"pk": 99999})
+        response = self.client.post(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("detail", response.json())
+
+    def test_resend_blocked_when_no_website_config(self):
+        self._delete_website_config()
+        url = reverse("core:resend_invitation", kwargs={"pk": 99999})
+        response = self.client.post(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -2397,6 +2397,15 @@ class TeamReset2FAView(APIView):
 # ===================================
 
 
+def _tenant_can_invite(tenant) -> bool:
+    """Verifica si el estado del sitio web del tenant permite invitaciones al equipo."""
+    try:
+        website_config = tenant.website_config
+        return website_config.status in ("published", "review")
+    except Exception:
+        return False
+
+
 class TeamInvitationsView(APIView):
     """
     GET  /api/core/team/invitations/ — listar invitaciones
@@ -2432,6 +2441,14 @@ class TeamInvitationsView(APIView):
         responses=TeamInvitationSerializer,
     )
     def post(self, request):
+        if not _tenant_can_invite(request.tenant):
+            return Response(
+                {
+                    "detail": "Las invitaciones al equipo están disponibles una vez que tu sitio web esté publicado o en revisión."
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         serializer = CreateTeamInvitationSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
 
@@ -2487,6 +2504,14 @@ class ResendInvitationView(APIView):
     permission_classes = [IsAuthenticated, IsTenantAdmin]
 
     def post(self, request, pk):
+        if not _tenant_can_invite(request.tenant):
+            return Response(
+                {
+                    "detail": "Las invitaciones al equipo están disponibles una vez que tu sitio web esté publicado o en revisión."
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         try:
             invitation = TeamInvitation.objects.get(pk=pk, tenant=request.tenant, status="pending")
         except TeamInvitation.DoesNotExist:

--- a/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
@@ -72,6 +72,7 @@ import {
   CheckCircle2,
   XCircle,
   AlertCircle,
+  Info,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import Image from 'next/image';
@@ -161,9 +162,11 @@ function AuthMethodBadge({ method }: { method: TeamMember['auth_method'] }) {
 
 // ─── Página de equipo ─────────────────────────────────────
 export default function SettingsTeamPage() {
-  const { user } = useAuth();
+  const { user, tenant } = useAuth();
   const router = useRouter();
   const queryClient = useQueryClient();
+
+  const canInvite = tenant?.website_status === 'published' || tenant?.website_status === 'review';
 
   const [filters, setFilters] = useState<TeamFilters>({
     ordering: '-date_joined',
@@ -230,7 +233,11 @@ export default function SettingsTeamPage() {
       setInviteEmail('');
       setInviteRole('staff');
     },
-    onError: (error: Error & { response?: { data?: { email?: string[]; detail?: string; error?: string } } }) => {
+    onError: (error: Error & { response?: { status?: number; data?: { email?: string[]; detail?: string; error?: string } } }) => {
+      if (error.response?.status === 403) {
+        toast.error(error.response.data?.detail || error.response.data?.error || 'No tienes permiso para enviar invitaciones en este momento.');
+        return;
+      }
       const msg = error.response?.data?.email?.[0]
         || error.response?.data?.detail
         || error.response?.data?.error
@@ -323,7 +330,7 @@ export default function SettingsTeamPage() {
           </h3>
           <Dialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}>
             <DialogTrigger asChild>
-              <Button size="sm" className="gap-1.5 text-xs">
+              <Button size="sm" className="gap-1.5 text-xs" disabled={!canInvite}>
                 <UserPlus className="h-3.5 w-3.5" />
                 Invitar
               </Button>
@@ -381,54 +388,68 @@ export default function SettingsTeamPage() {
           </Dialog>
         </div>
 
-        {/* Buscar y filtrar */}
-        <div className="rounded-xl border border-gray-200 bg-white px-4 py-4 mb-3">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <div className="relative sm:col-span-3">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <Input
-                placeholder="Buscar por nombre o email..."
-                value={filters.search || ''}
-                onChange={(e) =>
-                  setFilters({ ...filters, search: e.target.value })
-                }
-                className="pl-9 h-10"
-              />
+        {/* Buscar, filtrar y banner */}
+        <div className="rounded-xl border border-gray-200 bg-white mb-3 overflow-hidden">
+          {!canInvite && (
+            <div className="flex items-center gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-3">
+              <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full" style={navyIconBg}>
+                <Info className="h-3 w-3" style={{ color: '#1C3B57' }} />
+              </div>
+              <p className="text-xs text-gray-500">
+                <span className="font-medium text-gray-700">Tu equipo estará listo pronto</span>
+                {' — '}podrás invitar miembros una vez que tu sitio web esté publicado o en revisión.
+              </p>
             </div>
+          )}
 
-            <Select
-              value={filters.role || 'all'}
-              onValueChange={(v) =>
-                setFilters({ ...filters, role: v === 'all' ? undefined : v })
-              }
-            >
-              <SelectTrigger className="h-10">
-                <SelectValue placeholder="Rol" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos los roles</SelectItem>
-                <SelectItem value="admin">Admin</SelectItem>
-                <SelectItem value="staff">Staff</SelectItem>
-                <SelectItem value="customer">Cliente</SelectItem>
-              </SelectContent>
-            </Select>
+          <div className="px-4 py-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div className="relative sm:col-span-3">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Input
+                  placeholder="Buscar por nombre o email..."
+                  value={filters.search || ''}
+                  onChange={(e) =>
+                    setFilters({ ...filters, search: e.target.value })
+                  }
+                  className="pl-9 h-10"
+                />
+              </div>
 
-            <Select
-              value={filters.auth_method || 'all'}
-              onValueChange={(v) =>
-                setFilters({ ...filters, auth_method: v === 'all' ? undefined : v })
-              }
-            >
-              <SelectTrigger className="h-10">
-                <SelectValue placeholder="Método de acceso" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos los métodos</SelectItem>
-                <SelectItem value="email_only">Solo email</SelectItem>
-                <SelectItem value="social_only">Solo social</SelectItem>
-                <SelectItem value="both">Email + Social</SelectItem>
-              </SelectContent>
-            </Select>
+              <Select
+                value={filters.role || 'all'}
+                onValueChange={(v) =>
+                  setFilters({ ...filters, role: v === 'all' ? undefined : v })
+                }
+              >
+                <SelectTrigger className="h-10">
+                  <SelectValue placeholder="Rol" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos los roles</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
+                  <SelectItem value="staff">Staff</SelectItem>
+                  <SelectItem value="customer">Cliente</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select
+                value={filters.auth_method || 'all'}
+                onValueChange={(v) =>
+                  setFilters({ ...filters, auth_method: v === 'all' ? undefined : v })
+                }
+              >
+                <SelectTrigger className="h-10">
+                  <SelectValue placeholder="Método de acceso" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos los métodos</SelectItem>
+                  <SelectItem value="email_only">Solo email</SelectItem>
+                  <SelectItem value="social_only">Solo social</SelectItem>
+                  <SelectItem value="both">Email + Social</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
### **User description**
## Summary

- Bloquea la creación y reenvío de invitaciones al equipo hasta que el tenant tenga `website_status` en `published` o `review`
- Backend: guard en `TeamInvitationsView.post()` y `ResendInvitationView.post()` que retorna 403 con mensaje descriptivo
- Frontend: botón "Invitar" deshabilitado + banner informativo integrado en la card de búsqueda cuando el sitio no está listo

Closes #184

## Test plan

- [ ] Con tenant en fase `draft`/`generating`/`onboarding`: verificar que el botón "Invitar" está deshabilitado y aparece el banner
- [ ] Con tenant en fase `published` o `review`: verificar que el botón funciona normal y no aparece banner
- [ ] POST a `/api/core/team/invitations/` con tenant no publicado → debe retornar 403
- [ ] POST a `/api/core/team/invitations/` con tenant publicado → debe retornar 201
- [ ] Resend invitation con tenant no publicado → debe retornar 403
- [ ] Verificar que GET y DELETE de invitaciones no están afectados

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Bloquea invitaciones de equipo hasta sitio publicado.

- Deshabilita botón de invitar en interfaz.

- Muestra banner informativo en UI.

- Añade guard backend para validación.

- Incluye tests unitarios para la lógica.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[Frontend UI] --> B{Estado del Sitio?};
    B -- "No Publicado/Revisión" --> C[Deshabilita Botón + Muestra Banner];
    B -- "Publicado/Revisión" --> D[Permite Invitar];
    D --> E[Backend API];
    E --> F{Valida Estado del Sitio};
    F -- "No Publicado/Revisión" --> G[Retorna 403];
    F -- "Publicado/Revisión" --> H[Procesa Invitación];
    G --> A;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Implementa bloqueo y feedback UI para invitaciones de equipo.</code></dd></summary>
<hr>

frontend/src/app/(tenant)/dashboard/settings/team/page.tsx

<ul><li>Añade lógica para determinar si el tenant puede enviar invitaciones <br>basada en <code>website_status</code>.<br> <li> Deshabilita el botón "Invitar" y muestra un banner informativo si el <br>sitio no está publicado o en revisión.<br> <li> Modifica el manejo de errores para capturar y mostrar mensajes <br>específicos de <code>403</code> del backend.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/200/files#diff-1c3cdd64d5d8040d5f6851525c3519245a2865273e0b2b203888e01379826949">+70/-49</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Implementa guard backend para invitaciones de equipo.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/core/views.py

<ul><li>Introduce la función <code>_tenant_can_invite</code> para verificar si el <br><code>website_config.status</code> del tenant permite invitaciones.<br> <li> Integra esta validación en <code>TeamInvitationsView.post()</code> para bloquear la <br>creación de invitaciones.<br> <li> Integra la misma validación en <code>ResendInvitationView.post()</code> para <br>bloquear el reenvío de invitaciones.<br> <li> Retorna un <code>HTTP_403_FORBIDDEN</code> con un mensaje descriptivo si las <br>invitaciones no están permitidas.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/200/files#diff-7d6c859a8054413b613b4964b56cfd62f279cf512c9f5362b2d05b69693a6ac3">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_team_invitations_guard.py</strong><dd><code>Añade tests para el guard de invitaciones de equipo.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/core/tests/test_team_invitations_guard.py

<ul><li>Nuevo archivo de tests para verificar el guard de invitaciones al <br>equipo.<br> <li> Incluye tests para asegurar que la creación de invitaciones se bloquea <br>con estados de sitio no permitidos.<br> <li> Confirma que la creación y reenvío de invitaciones se permite con <br>estados de sitio <code>published</code> o <code>review</code>.<br> <li> Prueba el bloqueo de reenvío de invitaciones cuando el sitio no está <br>en un estado permitido.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/200/files#diff-cb399f171a9e5f34fdb90b66360f8f5f54dad72990916e896c6b6320989cf598">+112/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

