### PR TITLE
feat(security): middleware para activar RLS con current_tenant_id en cada request

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -107,6 +107,8 @@ MIDDLEWARE = [
     "core.middleware.TimezoneMiddleware",
     "middleware.tenant.TenantExclusionMiddleware",
     "middleware.tenant.TenantMiddleware",
+    # RLS: propaga tenant_id a PostgreSQL para Row-Level Security policies
+    "middleware.rls.RLSTenantMiddleware",
     # Verificacion de suscripcion del tenant (debe ir despues de auth)
     "core.middleware.SubscriptionMiddleware",
 ]

--- a/backend/middleware/__init__.py
+++ b/backend/middleware/__init__.py
@@ -1,5 +1,6 @@
 # backend/core/middleware/__init__.py
 
+from .rls import RLSTenantMiddleware
 from .tenant import TenantExclusionMiddleware, TenantMiddleware
 
-__all__ = ["TenantMiddleware", "TenantExclusionMiddleware"]
+__all__ = ["TenantMiddleware", "TenantExclusionMiddleware", "RLSTenantMiddleware"]

--- a/backend/middleware/rls.py
+++ b/backend/middleware/rls.py
@@ -1,0 +1,55 @@
+import logging
+
+from django.db import connection
+
+logger = logging.getLogger(__name__)
+
+
+class RLSTenantMiddleware:
+    """
+    Establece app.current_tenant_id en PostgreSQL para activar
+    Row-Level Security (RLS) policies por tenant.
+
+    Debe ir DESPUES de TenantMiddleware en settings.MIDDLEWARE.
+    Patron: SET al inicio + RESET en finally (belt-and-suspenders).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        tenant = getattr(request, "tenant", None)
+        tenant_excluded = getattr(request, "tenant_excluded", False)
+
+        if not tenant or tenant_excluded:
+            return self.get_response(request)
+
+        tenant_id = str(tenant.id)
+
+        self._set_tenant(tenant_id)
+        try:
+            response = self.get_response(request)
+        finally:
+            self._reset_tenant()
+
+        return response
+
+    def _set_tenant(self, tenant_id: str) -> None:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT set_config('app.current_tenant_id', %s, false)",
+                    [tenant_id],
+                )
+            logger.debug("RLS: SET app.current_tenant_id = %s", tenant_id)
+        except Exception:
+            logger.error("RLS: SET failed", exc_info=True)
+
+    def _reset_tenant(self) -> None:
+        try:
+            if connection.connection is not None:
+                with connection.cursor() as cursor:
+                    cursor.execute("RESET app.current_tenant_id")
+                logger.debug("RLS: RESET app.current_tenant_id")
+        except Exception:
+            logger.error("RLS: RESET failed", exc_info=True)

--- a/backend/middleware/tests/test_rls.py
+++ b/backend/middleware/tests/test_rls.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from middleware.rls import RLSTenantMiddleware
+
+
+@pytest.fixture
+def make_middleware():
+    def _make(response=None):
+        if response is None:
+            response = MagicMock(status_code=200)
+        get_response = MagicMock(return_value=response)
+        return RLSTenantMiddleware(get_response), get_response
+
+    return _make
+
+
+@pytest.fixture
+def tenant():
+    t = MagicMock()
+    t.id = "550e8400-e29b-41d4-a716-446655440000"
+    return t
+
+
+class TestRLSTenantMiddleware:
+    @patch("middleware.rls.connection")
+    def test_sets_tenant_id_on_request(self, mock_conn, make_middleware, tenant):
+        """SET se ejecuta cuando hay tenant valido."""
+        mw, get_response = make_middleware()
+        request = MagicMock(tenant=tenant, tenant_excluded=False)
+
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.connection = MagicMock()  # conexion activa
+
+        mw(request)
+
+        # Verificar SET
+        calls = mock_cursor.execute.call_args_list
+        assert any("set_config" in str(c) and str(tenant.id) in str(c) for c in calls)
+        # Verificar RESET
+        assert any("RESET" in str(c) for c in calls)
+        # Verificar que get_response se llamo
+        get_response.assert_called_once_with(request)
+
+    @patch("middleware.rls.connection")
+    def test_skips_when_tenant_excluded(self, mock_conn, make_middleware, tenant):
+        """No hace SET si la ruta esta excluida."""
+        mw, get_response = make_middleware()
+        request = MagicMock(tenant=tenant, tenant_excluded=True)
+
+        mw(request)
+
+        mock_conn.cursor.assert_not_called()
+        get_response.assert_called_once_with(request)
+
+    @patch("middleware.rls.connection")
+    def test_skips_when_no_tenant(self, mock_conn, make_middleware):
+        """No hace SET si no hay tenant."""
+        mw, get_response = make_middleware()
+        request = MagicMock(spec=[])  # sin atributo tenant
+
+        mw(request)
+
+        mock_conn.cursor.assert_not_called()
+        get_response.assert_called_once_with(request)
+
+    @patch("middleware.rls.connection")
+    def test_resets_on_view_exception(self, mock_conn, make_middleware, tenant):
+        """RESET se ejecuta incluso si la view lanza excepcion."""
+        get_response = MagicMock(side_effect=RuntimeError("view crash"))
+        mw = RLSTenantMiddleware(get_response)
+        request = MagicMock(tenant=tenant, tenant_excluded=False)
+
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.connection = MagicMock()
+
+        with pytest.raises(RuntimeError, match="view crash"):
+            mw(request)
+
+        # RESET debe haberse ejecutado a pesar de la excepcion
+        calls = mock_cursor.execute.call_args_list
+        assert any("RESET" in str(c) for c in calls)
+
+    @patch("middleware.rls.connection")
+    def test_skips_reset_when_no_db_connection(self, mock_conn, make_middleware, tenant):
+        """No intenta RESET si no hay conexion fisica a la DB."""
+        mw, get_response = make_middleware()
+        request = MagicMock(tenant=tenant, tenant_excluded=False)
+
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.connection = None  # sin conexion fisica
+
+        mw(request)
+
+        # Solo SET, no RESET (porque connection es None)
+        calls = mock_cursor.execute.call_args_list
+        assert any("set_config" in str(c) for c in calls)
+        # RESET no se ejecuto porque connection es None
+        assert not any("RESET" in str(c) for c in calls)


### PR DESCRIPTION
## Summary

- Crea `RLSTenantMiddleware` en `backend/middleware/rls.py` que ejecuta `SET app.current_tenant_id` en PostgreSQL al inicio de cada request con tenant, activando las políticas RLS de la migración 0041
- Usa `set_config()` con bind parameters (previene SQL injection)
- `RESET` en `finally` garantiza limpieza incluso ante excepciones de la view
- Skip automático para rutas excluidas (`/admin/`, `/api/admin/`, etc.) y requests sin tenant
- 5 tests unitarios con mocks cubriendo: SET+RESET normal, skip excluidas, skip sin tenant, RESET on exception, skip RESET sin conexión física

Closes #215

## Test plan

- [x] `ruff check` — lint limpio
- [x] `pytest middleware/tests/test_rls.py` — 5/5 tests pasando
- [x] `pytest` suite completa — 240/240 pasando
- [ ] Verificar manualmente con `SELECT current_setting('app.current_tenant_id', true)` en un request real
- [ ] Verificar que superadmin panel (`/api/admin/`) no se ve afectado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>