### PR TITLE
fix(teams): ocultar cards de resumen con conteo en cero

### DIFF
--- a/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
@@ -379,11 +379,11 @@ export default function SettingsTeamPage() {
         </h3>
         <div className="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
           {[
-            { label: 'Total de miembros', value: counts.total, icon: Users, color: 'text-[#0D9488]', bg: 'bg-[rgba(13,148,136,0.08)]' },
+            { label: 'Total de miembros', value: counts.total, icon: Users, color: 'text-[#0D9488]', bg: 'bg-[rgba(13,148,136,0.08)]', alwaysShow: true },
             { ...ROLE_CONFIG.admin, label: 'Administradores', value: counts.admins },
             { ...ROLE_CONFIG.staff, label: 'Staff', value: counts.staff },
             { ...ROLE_CONFIG.customer, label: 'Clientes', value: counts.customers },
-          ].map((stat) => (
+          ].filter((stat) => 'alwaysShow' in stat || stat.value > 0).map((stat) => (
             <div key={stat.label} className="flex items-center justify-between px-4 py-3 hover:bg-gray-50/50 transition-colors">
               <div className="flex items-center gap-3">
                 <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${stat.bg}`}>

--- a/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
@@ -383,7 +383,7 @@ export default function SettingsTeamPage() {
             { ...ROLE_CONFIG.admin, label: 'Administradores', value: counts.admins },
             { ...ROLE_CONFIG.staff, label: 'Staff', value: counts.staff },
             { ...ROLE_CONFIG.customer, label: 'Clientes', value: counts.customers },
-          ].filter((stat) => 'alwaysShow' in stat || stat.value > 0).map((stat) => (
+          ].filter((stat) => stat.alwaysShow || stat.value > 0).map((stat) => (
             <div key={stat.label} className="flex items-center justify-between px-4 py-3 hover:bg-gray-50/50 transition-colors">
               <div className="flex items-center gap-3">
                 <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${stat.bg}`}>


### PR DESCRIPTION
### **User description**
## Summary
- Oculta las cards de resumen (Staff, Clientes) cuando su conteo es 0
- "Total de miembros" siempre se muestra independientemente del valor
- Reduce ruido visual para negocios pequeños o freelancers

Closes #222

## Test plan
- [ ] Verificar que con 0 staff y 0 clientes solo se muestran "Total de miembros" y "Administradores"
- [ ] Verificar que al agregar un staff, la card de Staff aparece
- [ ] Verificar que "Total de miembros" siempre se muestra (incluso si es 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Oculta tarjetas de resumen de equipo vacías.

- Siempre muestra la tarjeta "Total de miembros".

- Reduce el ruido visual en la página de equipo.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Implementa lógica para ocultar tarjetas de resumen de equipo vacías</code></dd></summary>
<hr>

frontend/src/app/(tenant)/dashboard/settings/team/page.tsx

<ul><li>Se añadió la propiedad <code>alwaysShow: true</code> a la configuración de la <br>tarjeta 'Total de miembros'.<br> <li> Se modificó el filtro de las tarjetas de resumen para incluir solo <br>aquellas con <code>alwaysShow</code> o un <code>value</code> mayor que cero.<br> <li> Esto asegura que las tarjetas de 'Staff' y 'Clientes' no se muestren <br>si su conteo es cero.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/223/files#diff-1c3cdd64d5d8040d5f6851525c3519245a2865273e0b2b203888e01379826949">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

