### PR TITLE
fix(onboarding): validación, autosave y recuperación de progreso

### DIFF
--- a/backend/websites/views/onboarding.py
+++ b/backend/websites/views/onboarding.py
@@ -76,9 +76,19 @@ class StartOnboardingView(OnboardingView):
             },
         )
 
-        # Si cambió el template, limpiar respuestas del template anterior
+        # Si cambió el template, limpiar respuestas y datos generados del template anterior
         if not created and old_template_id and old_template_id != template.id:
             OnboardingResponse.objects.filter(website_config=config).delete()
+            config.content_data = {}
+            config.pages_data = {}
+            config.theme_data = {}
+            config.media_data = {}
+            config.seo_data = {}
+            config.enabled_pages = []
+            config.save(update_fields=[
+                "content_data", "pages_data", "theme_data",
+                "media_data", "seo_data", "enabled_pages",
+            ])
 
         # Obtener preguntas del template
         questions = self._get_questions_for_template(template)

--- a/backend/websites/views/onboarding.py
+++ b/backend/websites/views/onboarding.py
@@ -85,10 +85,16 @@ class StartOnboardingView(OnboardingView):
             config.media_data = {}
             config.seo_data = {}
             config.enabled_pages = []
-            config.save(update_fields=[
-                "content_data", "pages_data", "theme_data",
-                "media_data", "seo_data", "enabled_pages",
-            ])
+            config.save(
+                update_fields=[
+                    "content_data",
+                    "pages_data",
+                    "theme_data",
+                    "media_data",
+                    "seo_data",
+                    "enabled_pages",
+                ]
+            )
 
         # Obtener preguntas del template
         questions = self._get_questions_for_template(template)

--- a/frontend/src/app/(tenant)/dashboard/website-builder/onboarding/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/onboarding/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import {
@@ -14,6 +14,8 @@ import {
   Sparkles,
   Check,
   Upload,
+  AlertTriangle,
+  RefreshCw,
 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -32,6 +34,67 @@ const SECTIONS: { key: QuestionSection; label: string; icon: React.ElementType }
   { key: 'content', label: 'Páginas', icon: FileText },
   { key: 'contact', label: 'Contacto', icon: Phone },
 ];
+
+// ─── sessionStorage helpers ──────────────────────────────────
+
+const SESSION_KEY_RESPONSES = (slug: string) => `onboarding_${slug}_responses`;
+const SESSION_KEY_SECTION = (slug: string) => `onboarding_${slug}_section`;
+
+function saveToSession(slug: string, responses: Record<string, string | string[]>, section: number) {
+  try {
+    sessionStorage.setItem(SESSION_KEY_RESPONSES(slug), JSON.stringify(responses));
+    sessionStorage.setItem(SESSION_KEY_SECTION(slug), String(section));
+  } catch {
+    // sessionStorage full or unavailable — silent fail
+  }
+}
+
+function loadFromSession(slug: string): { responses: Record<string, string | string[]>; section: number } | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY_RESPONSES(slug));
+    const sec = sessionStorage.getItem(SESSION_KEY_SECTION(slug));
+    if (!raw) return null;
+    return { responses: JSON.parse(raw), section: sec ? parseInt(sec, 10) : 0 };
+  } catch {
+    return null;
+  }
+}
+
+function clearSession(slug: string) {
+  try {
+    sessionStorage.removeItem(SESSION_KEY_RESPONSES(slug));
+    sessionStorage.removeItem(SESSION_KEY_SECTION(slug));
+  } catch {
+    // silent
+  }
+}
+
+// ─── Format validators ──────────────────────────────────────
+
+const FORMAT_VALIDATORS: Record<string, { regex: RegExp; message: string; minDigits?: number }> = {
+  business_email: {
+    regex: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+    message: 'Ingresa un email válido (ej: nombre@empresa.com)',
+  },
+  business_phone: {
+    regex: /^\+?[\d\s\-()]+$/,
+    message: 'Solo números, espacios, guiones y paréntesis',
+    minDigits: 7,
+  },
+  business_whatsapp: {
+    regex: /^\+?[\d\s\-()]+$/,
+    message: 'Solo números, espacios, guiones y paréntesis',
+    minDigits: 7,
+  },
+  primary_color: {
+    regex: /^#[0-9a-fA-F]{6}$/,
+    message: 'Usa formato hexadecimal (ej: #0D9488)',
+  },
+  secondary_color: {
+    regex: /^#[0-9a-fA-F]{6}$/,
+    message: 'Usa formato hexadecimal (ej: #1C3B57)',
+  },
+};
 
 // ─── Image upload + color extraction ─────────────────────────
 
@@ -376,19 +439,30 @@ export default function OnboardingPage() {
   const searchParams = useSearchParams();
   const isNavBack = searchParams.get('nav') === '1';
   const { tenant, user } = useAuth();
-  const [currentSection, setCurrentSection] = useState(0);
-  const [responses, setResponses] = useState<Record<string, string | string[]>>({});
+
+  // Hydrate initial state from sessionStorage
+  const [currentSection, setCurrentSection] = useState(() => {
+    if (typeof window === 'undefined' || !tenant?.slug) return 0;
+    const cached = loadFromSession(tenant.slug);
+    return cached?.section ?? 0;
+  });
+  const [responses, setResponses] = useState<Record<string, string | string[]>>(() => {
+    if (typeof window === 'undefined' || !tenant?.slug) return {};
+    const cached = loadFromSession(tenant.slug);
+    return cached?.responses ?? {};
+  });
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const hasRecoveredSection = useRef(false);
 
   // Fetch onboarding status (includes saved responses)
-  const { data: statusData, isLoading: isLoadingStatus } = useQuery({
+  const { data: statusData, isLoading: isLoadingStatus, isError: isStatusError, refetch: refetchStatus } = useQuery({
     queryKey: ['onboardingStatus'],
     queryFn: getOnboardingStatus,
   });
 
   // Fetch template with questions
   const templateId = statusData?.template?.id;
-  const { data: templateData, isLoading: isLoadingTemplate } = useQuery({
+  const { data: templateData, isLoading: isLoadingTemplate, isError: isTemplateError, refetch: refetchTemplate } = useQuery({
     queryKey: ['websiteTemplate', templateId],
     queryFn: () => getWebsiteTemplate(templateId!),
     enabled: !!templateId,
@@ -482,6 +556,24 @@ export default function OnboardingPage() {
     }
   }, [statusData, router, isNavBack]);
 
+  // Debounced autosave to sessionStorage
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveToSessionDebounced = useCallback((slug: string, data: Record<string, string | string[]>, section: number) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => saveToSession(slug, data, section), 1000);
+  }, []);
+
+  useEffect(() => {
+    if (!tenant?.slug) return;
+    saveToSessionDebounced(tenant.slug, responses, currentSection);
+  }, [responses, currentSection, tenant?.slug, saveToSessionDebounced]);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
   // Save mutation
   const saveMutation = useMutation({
     mutationFn: (data: Record<string, string | string[]>) => saveOnboardingResponses(data),
@@ -493,6 +585,29 @@ export default function OnboardingPage() {
     ...section,
     questions: questions.filter((q) => q.section === section.key),
   })).filter((s) => s.questions.length > 0);
+
+  // Section recovery: jump to first section with incomplete required fields
+  useEffect(() => {
+    if (hasRecoveredSection.current || questionsBySection.length === 0) return;
+    if (Object.keys(responses).length === 0) return; // Wait for data to load
+    hasRecoveredSection.current = true;
+
+    for (let i = 0; i < questionsBySection.length; i++) {
+      const section = questionsBySection[i];
+      for (const q of section.questions) {
+        if (q.is_required) {
+          const val = responses[q.question_key];
+          if (!val || (typeof val === 'string' && val.trim() === '') || (Array.isArray(val) && val.length === 0)) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setCurrentSection(i);
+            return;
+          }
+        }
+      }
+    }
+    // All required fields complete — go to last section
+    setCurrentSection(questionsBySection.length - 1);
+  }, [questionsBySection, responses]);
 
   const currentSectionData = questionsBySection[currentSection];
   const isLastSection = currentSection === questionsBySection.length - 1;
@@ -520,6 +635,19 @@ export default function OnboardingPage() {
         } else if (q.min_length && typeof val === 'string' && val.length < q.min_length) {
           newErrors[q.question_key] = `Mínimo ${q.min_length} caracteres`;
         }
+      }
+    }
+
+    // Format validation for non-empty fields
+    for (const q of currentSectionData.questions) {
+      const validator = FORMAT_VALIDATORS[q.question_key];
+      if (!validator) continue;
+      const val = responses[q.question_key];
+      if (!val || typeof val !== 'string' || val.trim() === '') continue; // skip empty
+      if (!validator.regex.test(val)) {
+        newErrors[q.question_key] = validator.message;
+      } else if (validator.minDigits && val.replace(/\D/g, '').length < validator.minDigits) {
+        newErrors[q.question_key] = `Mínimo ${validator.minDigits} dígitos`;
       }
     }
 
@@ -556,6 +684,7 @@ export default function OnboardingPage() {
       await saveCurrentSection();
 
       if (isLastSection) {
+        if (tenant?.slug) clearSession(tenant.slug);
         toast.success('Información guardada correctamente');
         router.push('/dashboard/website-builder/generate');
       } else {
@@ -577,8 +706,9 @@ export default function OnboardingPage() {
   };
 
   const isLoading = isLoadingStatus || isLoadingTemplate;
+  const isError = isStatusError || isTemplateError;
 
-  if (isLoading) {
+  if (isLoading && !isError) {
     return (
       <div className="space-y-8">
         <div className="max-w-lg">
@@ -598,6 +728,24 @@ export default function OnboardingPage() {
             </div>
           ))}
         </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 space-y-4">
+        <AlertTriangle className="h-8 w-8 text-red-400" />
+        <p className="text-gray-600 text-[0.88rem]">No pudimos cargar los datos del formulario.</p>
+        <p className="text-gray-400 text-[0.78rem]">Verifica tu conexión e intenta de nuevo.</p>
+        <button
+          type="button"
+          onClick={() => { refetchStatus(); refetchTemplate(); }}
+          className="flex items-center gap-2 h-10 px-5 rounded-lg border border-gray-200 text-[0.85rem] font-medium text-[#1C3B57] transition-all hover:border-[#0D9488] hover:text-[#0D9488] cursor-pointer"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Reintentar
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
### **User description**
## Summary

- **Autosave con sessionStorage**: guarda responses y sección actual con debounce de 1s, keyed por tenant slug para aislamiento multi-tenant
- **Recuperación de sección**: al refrescar, el formulario abre en la primera sección con campos requeridos incompletos (no siempre en 0)
- **Validación de formatos**: email (regex), teléfono/WhatsApp (numérico + mínimo 7 dígitos), colores (hex estricto #RRGGBB)
- **Error handling con retry**: si la API falla al cargar, muestra UI de error con botón "Reintentar" en vez de skeleton infinito
- **Backend: limpieza al cambiar template**: reset de content_data, pages_data, theme_data, media_data, seo_data y enabled_pages cuando el tenant cambia de template

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `backend/websites/views/onboarding.py` | Reset de 6 campos en `StartOnboardingView` al cambiar template |
| `frontend/.../onboarding/page.tsx` | sessionStorage helpers, autosave, section recovery, validación, error UI |

## Test plan

- [ ] Llenar 2 secciones del onboarding, refrescar → verificar que los datos persisten y abre en la sección correcta
- [ ] Escribir email inválido ("hola") → verificar error al avanzar
- [ ] Escribir teléfono con letras ("abc123") → verificar error al avanzar
- [ ] Escribir color como texto ("rojo") → verificar error al avanzar
- [ ] Desconectar red y recargar onboarding → verificar UI de error con botón "Reintentar"
- [ ] Cambiar de template en el onboarding → verificar que content_data se limpia en backend
- [ ] Verificar que ESLint y Ruff pasan sin errores

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Implementa autoguardado con `sessionStorage` y debounce.

- Recupera la sección del formulario al refrescar la página.

- Añade validación de formato para email, teléfono y colores.

- Muestra UI de error con opción de reintentar si la API falla.

- Limpia datos generados al cambiar de plantilla en el backend.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Usuario] --> B{Formulario Onboarding}
  B -- "Autoguarda (debounce)" --> C[sessionStorage]
  C -- "Recupera Progreso" --> B
  B -- "Valida Formatos" --> B
  B -- "Carga/Guarda API" --> D[API Backend]
  D -- "Limpia Datos (cambio plantilla)" --> E[Configuración Web]
  D -- "Fallo de Carga" --> F[UI Error]
  F -- "Reintentar" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Implementa autoguardado, recuperación de progreso y validación en </code><br><code>frontend</code></dd></summary>
<hr>

frontend/src/app/(tenant)/dashboard/website-builder/onboarding/page.tsx

<ul><li>Implementa funciones de <code>sessionStorage</code> para guardar y cargar <br>respuestas y la sección actual del formulario.<br> <li> Añade lógica de autoguardado con un debounce de 1 segundo y <br>recuperación de la sección al cargar la página.<br> <li> Incorpora validadores de formato para campos como <code>business_email</code>, <br><code>business_phone</code>, <code>business_whatsapp</code> y colores (<code>primary_color</code>, <br><code>secondary_color</code>).<br> <li> Introduce una UI de error con un botón "Reintentar" que se muestra si <br>las llamadas a la API fallan.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/245/files#diff-c45230177313e8e7a9bbaaf66e26a6a502dc7d1527d2901e0f44e5f567a70f81">+154/-6</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>onboarding.py</strong><dd><code>Limpia datos generados al cambiar plantilla en backend</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/websites/views/onboarding.py

<ul><li>Extiende la lógica de limpieza en <code>StartOnboardingView</code> al cambiar de <br>plantilla.<br> <li> Ahora, además de eliminar las respuestas del onboarding, también <br>resetea <code>content_data</code>, <code>pages_data</code>, <code>theme_data</code>, <code>media_data</code>, <code>seo_data</code> y <br><code>enabled_pages</code> a valores vacíos.<br> <li> Guarda explícitamente estos campos actualizados en la configuración <br>del sitio web.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/245/files#diff-f3e634af116bfdc71550491d99a55bce337cf1d1b163fc8c263e0fe315986969">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Onboarding progress is now automatically saved and recovered during sessions, preventing loss of entered information.
  * Auto-save functionality ensures your answers are continuously preserved while navigating through sections.
  * Smart section recovery: automatically directs you to incomplete required fields or the last section if all mandatory fields are filled.
  * Enhanced error handling with retry option when template or status loading fails.
  * Added format validation for phone numbers, messaging apps, and color fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->