### PR TITLE
fix(onboarding): errores silenciosos en Quick Start, chat y publish

### DIFF
--- a/frontend/src/app/(tenant)/dashboard/website-builder/editor/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/editor/page.tsx
@@ -440,6 +440,13 @@ export default function EditorPage() {
         refetchPreview();
       }
     },
+    onError: () => {
+      setChatMessages((prev) => [
+        ...prev,
+        { role: 'assistant', content: 'Lo siento, hubo un error al procesar tu mensaje. Intenta de nuevo.' },
+      ]);
+      toast.error('Error al enviar el mensaje');
+    },
   });
 
   const settingsMutation = useMutation({
@@ -523,6 +530,9 @@ export default function EditorPage() {
       setPublishSuccess(true);
       queryClient.invalidateQueries({ queryKey: ['websiteConfig'] });
       queryClient.invalidateQueries({ queryKey: ['onboardingStatus'] });
+    },
+    onError: () => {
+      toast.error('Error al publicar tu sitio. Intenta de nuevo.');
     },
   });
 

--- a/frontend/src/app/(tenant)/dashboard/website-builder/editor/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/editor/page.tsx
@@ -169,7 +169,7 @@ export default function EditorPage() {
     queryFn: getOnboardingStatus,
   });
 
-  const { data: config, isLoading: configLoading } = useQuery({
+  const { data: config, isLoading: configLoading, isError: configError } = useQuery({
     queryKey: ['websiteConfig'],
     queryFn: getWebsiteConfig,
     enabled: !!statusData && !['not_started', 'draft'].includes(statusData.status),
@@ -527,6 +527,7 @@ export default function EditorPage() {
   const publishMutation = useMutation({
     mutationFn: () => publishWebsite(),
     onSuccess: () => {
+      setShowPublishDialog(false);
       setPublishSuccess(true);
       queryClient.invalidateQueries({ queryKey: ['websiteConfig'] });
       queryClient.invalidateQueries({ queryKey: ['onboardingStatus'] });
@@ -897,6 +898,25 @@ export default function EditorPage() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [globalUndo, globalRedo, handleSaveAllNow]);
+
+  // ─── Error state ────────────────────────────────────────
+  if (configError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen">
+        <div className="w-12 h-12 rounded-full bg-red-50 flex items-center justify-center mb-4">
+          <AlertCircle className="h-5 w-5 text-red-500" />
+        </div>
+        <p className="text-[0.85rem] text-gray-600 mb-3">Error al cargar el editor</p>
+        <button
+          type="button"
+          onClick={() => queryClient.invalidateQueries({ queryKey: ['websiteConfig'] })}
+          className="text-[0.82rem] text-[#0D9488] hover:underline cursor-pointer"
+        >
+          Intentar de nuevo
+        </button>
+      </div>
+    );
+  }
 
   // ─── Loading state ───────────────────────────────────────
   if (statusLoading || configLoading || !config?.content_data) {
@@ -1641,7 +1661,6 @@ export default function EditorPage() {
                 onClick={async () => {
                   // Save any unsaved changes first, then publish
                   handleSaveAllNow();
-                  setShowPublishDialog(false);
                   publishMutation.mutate();
                 }}
                 disabled={publishMutation.isPending}

--- a/frontend/src/app/(tenant)/dashboard/website-builder/generate/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/generate/page.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/api/websites';
 import { GenerateContentResponse } from '@/types';
 import { ApiError } from '@/lib/api/client';
+import { toast } from 'sonner';
 
 // ─── Status messages shown during generation ─────────────────
 const GENERATION_STEPS = [
@@ -170,6 +171,8 @@ export default function GeneratePage() {
           } else {
             router.push('/dashboard/website-builder/editor');
           }
+        }).catch(() => {
+          toast.error('Error al cargar tu sitio. Intenta de nuevo.');
         });
       }
     } else if (status === 'generating') {

--- a/frontend/src/app/(tenant)/dashboard/website-builder/generate/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/generate/page.tsx
@@ -173,6 +173,8 @@ export default function GeneratePage() {
           }
         }).catch(() => {
           toast.error('Error al cargar tu sitio. Intenta de nuevo.');
+          setPageState('error');
+          hasTriggered.current = false;
         });
       }
     } else if (status === 'generating') {

--- a/frontend/src/app/(tenant)/dashboard/website-builder/onboarding/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/onboarding/page.tsx
@@ -700,7 +700,7 @@ export default function OnboardingPage() {
     try {
       await saveCurrentSection();
     } catch {
-      // Silent — don't block navigation back
+      toast.warning('No se pudo guardar esta sección. Tus datos podrían no haberse guardado.');
     }
     setCurrentSection((prev) => prev - 1);
   };

--- a/frontend/src/app/(tenant)/dashboard/website-builder/onboarding/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/onboarding/page.tsx
@@ -805,7 +805,7 @@ export default function OnboardingPage() {
                   // Allow clicking on completed or current sections
                   if (index <= currentSection) {
                     if (index < currentSection) {
-                      try { await saveCurrentSection(); } catch { /* silent */ }
+                      try { await saveCurrentSection(); } catch { toast.warning('No se pudo guardar esta sección. Tus datos podrían no haberse guardado.'); }
                     }
                     setCurrentSection(index);
                   }

--- a/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
@@ -576,7 +576,6 @@ export default function QuickStartPage() {
         setTenant(updatedTenant);
       } catch {
         toast.error('Error al configurar los módulos. Intenta de nuevo.');
-        setPageState('error');
         return;
       }
 

--- a/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
@@ -34,6 +34,7 @@ import {
 import { configureModules, ModuleSelection, getCurrentUser } from '@/lib/api/auth';
 import { useAuth } from '@/contexts/AuthContext';
 import { ApiError } from '@/lib/api/client';
+import { toast } from 'sonner';
 import { Tenant, PlatformModule, OnboardingQuestion, WebsitePage } from '@/types';
 
 // ─── Brand constants ──────────────────────────────────────
@@ -574,6 +575,7 @@ export default function QuickStartPage() {
         const updatedTenant = await configureModules(payload);
         setTenant(updatedTenant);
       } catch {
+        toast.error('Error al configurar los módulos. Intenta de nuevo.');
         setPageState('error');
         return;
       }

--- a/frontend/src/lib/api/websites.ts
+++ b/frontend/src/lib/api/websites.ts
@@ -43,12 +43,8 @@ export async function getWebsiteTemplate(id: number): Promise<WebsiteTemplate> {
  * Obtener la configuración del sitio web del tenant actual
  */
 export async function getWebsiteConfig(): Promise<WebsiteConfig | null> {
-  try {
-    const { data } = await apiClient.get<PaginatedResponse<WebsiteConfig>>('/websites/configs/');
-    return data.results.length > 0 ? data.results[0] : null;
-  } catch {
-    return null;
-  }
+  const { data } = await apiClient.get<PaginatedResponse<WebsiteConfig>>('/websites/configs/');
+  return data.results.length > 0 ? data.results[0] : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Elimina errores silenciosos en 5 flujos criticos del website builder
- Agrega `toast.error()` / `toast.warning()` con sonner en cada punto de falla
- `getWebsiteConfig` ahora propaga errores en vez de retornar null generico (callers manejan el error)

### Cambios por archivo

| Archivo | Cambio |
|---------|--------|
| `websites.ts` | Removido try/catch de `getWebsiteConfig` — errores propagan |
| `generate/page.tsx` | `.catch()` + toast.error en getWebsiteConfig |
| `quick-start/page.tsx` | `toast.error()` en catch de configureModules |
| `editor/page.tsx` | `onError` en chatMutation (toast + mensaje fallback en chat) |
| `editor/page.tsx` | `onError` en publishMutation con toast.error |
| `onboarding/page.tsx` | `toast.warning()` en handlePrev catch |

Closes #193

## Test plan

- [ ] Quick Start: desconectar red o simular error 500 en configureModules — debe aparecer toast de error
- [ ] Editor chat: simular error de red al enviar mensaje — debe aparecer mensaje de error en chat + toast
- [ ] Editor publish: simular error al publicar — debe aparecer toast de error
- [ ] Onboarding: simular error al retroceder entre secciones — debe aparecer toast warning
- [ ] Generate: simular error en getWebsiteConfig al navegar back — debe aparecer toast de error
- [ ] ESLint: 0 errores
- [ ] Next.js build: exitoso

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Mejoras en Manejo de Errores**
  * Notificaciones de error mejoradas en el editor al enviar mensajes y publicar sitios.
  * Mensajes informativos cuando falla la carga o configuración de sitios web.
  * Advertencias al usuario cuando no se pueden guardar cambios durante el proceso de configuración inicial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->