### PR TITLE
refactor(frontend): batch 10 — extract helpers from PageManager, PromptBlocksTab, VariantsTab, pipe-demo

### DIFF
--- a/frontend/src/app/(platform)/admin/settings/onboarding/_components/PromptBlocksTab.tsx
+++ b/frontend/src/app/(platform)/admin/settings/onboarding/_components/PromptBlocksTab.tsx
@@ -31,6 +31,14 @@ import type {
   PromptBlockCategory,
   PromptBlockScope,
 } from '@/types/admin';
+import {
+  CATEGORY_OPTIONS,
+  SCOPE_OPTIONS,
+  CATEGORY_BADGE_CLASSES,
+  SCOPE_BADGE_CLASSES,
+  EMPTY_BLOCK_FORM,
+  type BlockFormState,
+} from './prompt-blocks-helpers';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import {
@@ -74,62 +82,6 @@ import {
   BTN_SECONDARY,
   ACTION_TRIGGER,
 } from '../_helpers';
-
-// ─── Constants ───────────────────────────────────────────────────────
-
-const CATEGORY_OPTIONS: { value: PromptBlockCategory; label: string }[] = [
-  { value: 'system', label: 'System' },
-  { value: 'business', label: 'Business' },
-  { value: 'visual', label: 'Visual' },
-  { value: 'section', label: 'Section' },
-  { value: 'rules', label: 'Rules' },
-];
-
-const SCOPE_OPTIONS: { value: PromptBlockScope; label: string }[] = [
-  { value: 'global', label: 'Global' },
-  { value: 'template', label: 'Template' },
-  { value: 'industry', label: 'Industry' },
-];
-
-const CATEGORY_BADGE_CLASSES: Record<PromptBlockCategory, string> = {
-  system: 'border-slate-200 bg-slate-50 text-slate-700',
-  business: 'border-blue-200 bg-blue-50 text-blue-700',
-  visual: 'border-violet-200 bg-violet-50 text-violet-700',
-  section: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  rules: 'border-amber-200 bg-amber-50 text-amber-700',
-};
-
-const SCOPE_BADGE_CLASSES: Record<PromptBlockScope, string> = {
-  global: 'border-slate-200 bg-slate-50 text-slate-700',
-  template: 'border-teal-200 bg-teal-50 text-teal-700',
-  industry: 'border-indigo-200 bg-indigo-50 text-indigo-700',
-};
-
-// ─── Form state ──────────────────────────────────────────────────────
-
-interface BlockFormState {
-  key: string;
-  label: string;
-  content: string;
-  category: PromptBlockCategory;
-  scope: PromptBlockScope;
-  template: string;
-  industry: string;
-  sort_order: number;
-  is_active: boolean;
-}
-
-const EMPTY_BLOCK_FORM: BlockFormState = {
-  key: '',
-  label: '',
-  content: '',
-  category: 'system',
-  scope: 'global',
-  template: '',
-  industry: '',
-  sort_order: 0,
-  is_active: true,
-};
 
 // ─── Component ───────────────────────────────────────────────────────
 

--- a/frontend/src/app/(platform)/admin/settings/onboarding/_components/VariantsTab.tsx
+++ b/frontend/src/app/(platform)/admin/settings/onboarding/_components/VariantsTab.tsx
@@ -29,6 +29,13 @@ import type {
   AdminWebsiteSection,
   VariantMood,
 } from '@/types/admin';
+import {
+  MOOD_OPTIONS,
+  MOOD_BADGE_CLASSES,
+  FILTER_ALL,
+  EMPTY_VARIANT_FORM,
+  type VariantFormState,
+} from './variants-helpers';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import {
@@ -72,53 +79,6 @@ import {
   BTN_SECONDARY,
   ACTION_TRIGGER,
 } from '../_helpers';
-
-// ─── Constants ───────────────────────────────────────────────
-
-const MOOD_OPTIONS: { value: VariantMood; label: string }[] = [
-  { value: 'professional', label: 'Professional' },
-  { value: 'playful', label: 'Playful' },
-  { value: 'elegant', label: 'Elegant' },
-  { value: 'bold', label: 'Bold' },
-  { value: 'minimal', label: 'Minimal' },
-];
-
-const MOOD_BADGE_CLASSES: Record<VariantMood, string> = {
-  professional: 'border-slate-200 bg-slate-50 text-slate-700',
-  playful: 'border-amber-200 bg-amber-50 text-amber-700',
-  elegant: 'border-violet-200 bg-violet-50 text-violet-700',
-  bold: 'border-red-200 bg-red-50 text-red-700',
-  minimal: 'border-teal-200 bg-teal-50 text-teal-700',
-};
-
-// ─── Form state ──────────────────────────────────────────────
-
-interface VariantFormState {
-  section: string;
-  key: string;
-  label: string;
-  description: string;
-  css_class_hint: string;
-  mood: VariantMood;
-  tags: string;
-  is_default: boolean;
-  sort_order: number;
-}
-
-const EMPTY_VARIANT_FORM: VariantFormState = {
-  section: '',
-  key: '',
-  label: '',
-  description: '',
-  css_class_hint: '',
-  mood: 'professional',
-  tags: '',
-  is_default: false,
-  sort_order: 0,
-};
-
-// Filter sentinel — represents "show all sections"
-const FILTER_ALL = '__all__';
 
 // ─── Component ───────────────────────────────────────────────
 

--- a/frontend/src/app/(platform)/admin/settings/onboarding/_components/prompt-blocks-helpers.ts
+++ b/frontend/src/app/(platform)/admin/settings/onboarding/_components/prompt-blocks-helpers.ts
@@ -1,0 +1,57 @@
+import type { PromptBlockCategory, PromptBlockScope } from '@/types/admin';
+
+// ─── Constants ───────────────────────────────────────────────
+
+export const CATEGORY_OPTIONS: { value: PromptBlockCategory; label: string }[] = [
+  { value: 'system', label: 'System' },
+  { value: 'business', label: 'Business' },
+  { value: 'visual', label: 'Visual' },
+  { value: 'section', label: 'Section' },
+  { value: 'rules', label: 'Rules' },
+];
+
+export const SCOPE_OPTIONS: { value: PromptBlockScope; label: string }[] = [
+  { value: 'global', label: 'Global' },
+  { value: 'template', label: 'Template' },
+  { value: 'industry', label: 'Industry' },
+];
+
+export const CATEGORY_BADGE_CLASSES: Record<PromptBlockCategory, string> = {
+  system: 'border-slate-200 bg-slate-50 text-slate-700',
+  business: 'border-blue-200 bg-blue-50 text-blue-700',
+  visual: 'border-violet-200 bg-violet-50 text-violet-700',
+  section: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  rules: 'border-amber-200 bg-amber-50 text-amber-700',
+};
+
+export const SCOPE_BADGE_CLASSES: Record<PromptBlockScope, string> = {
+  global: 'border-slate-200 bg-slate-50 text-slate-700',
+  template: 'border-teal-200 bg-teal-50 text-teal-700',
+  industry: 'border-indigo-200 bg-indigo-50 text-indigo-700',
+};
+
+// ─── Form state ──────────────────────────────────────────────
+
+export interface BlockFormState {
+  key: string;
+  label: string;
+  content: string;
+  category: PromptBlockCategory;
+  scope: PromptBlockScope;
+  template: string;
+  industry: string;
+  sort_order: number;
+  is_active: boolean;
+}
+
+export const EMPTY_BLOCK_FORM: BlockFormState = {
+  key: '',
+  label: '',
+  content: '',
+  category: 'system',
+  scope: 'global',
+  template: '',
+  industry: '',
+  sort_order: 0,
+  is_active: true,
+};

--- a/frontend/src/app/(platform)/admin/settings/onboarding/_components/variants-helpers.ts
+++ b/frontend/src/app/(platform)/admin/settings/onboarding/_components/variants-helpers.ts
@@ -1,0 +1,48 @@
+import type { VariantMood } from '@/types/admin';
+
+// ─── Constants ───────────────────────────────────────────────
+
+export const MOOD_OPTIONS: { value: VariantMood; label: string }[] = [
+  { value: 'professional', label: 'Professional' },
+  { value: 'playful', label: 'Playful' },
+  { value: 'elegant', label: 'Elegant' },
+  { value: 'bold', label: 'Bold' },
+  { value: 'minimal', label: 'Minimal' },
+];
+
+export const MOOD_BADGE_CLASSES: Record<VariantMood, string> = {
+  professional: 'border-slate-200 bg-slate-50 text-slate-700',
+  playful: 'border-amber-200 bg-amber-50 text-amber-700',
+  elegant: 'border-violet-200 bg-violet-50 text-violet-700',
+  bold: 'border-red-200 bg-red-50 text-red-700',
+  minimal: 'border-teal-200 bg-teal-50 text-teal-700',
+};
+
+// Filter sentinel — represents "show all sections"
+export const FILTER_ALL = '__all__';
+
+// ─── Form state ──────────────────────────────────────────────
+
+export interface VariantFormState {
+  section: string;
+  key: string;
+  label: string;
+  description: string;
+  css_class_hint: string;
+  mood: VariantMood;
+  tags: string;
+  is_default: boolean;
+  sort_order: number;
+}
+
+export const EMPTY_VARIANT_FORM: VariantFormState = {
+  section: '',
+  key: '',
+  label: '',
+  description: '',
+  css_class_hint: '',
+  mood: 'professional',
+  tags: '',
+  is_default: false,
+  sort_order: 0,
+};

--- a/frontend/src/components/marketing/pipe-demo-helpers.ts
+++ b/frontend/src/components/marketing/pipe-demo-helpers.ts
@@ -1,0 +1,67 @@
+// ─── Conversation script ────────────────────────────────
+
+export type ChatStep = {
+  from: 'pipe' | 'user';
+  text: string;
+  preview?: string; // which preview elements to reveal
+  thinking?: string; // text shown while "thinking" before this message
+  delay: number; // ms before this message appears
+};
+
+export const CONVERSATION: ChatStep[] = [
+  {
+    from: 'pipe',
+    text: '¡Hola! Cuéntame sobre tu negocio y creo tu sitio web en segundos.',
+    delay: 400,
+  },
+  {
+    from: 'user',
+    text: 'Tengo una tienda de ropa llamada Moda Nerbis. Vendemos ropa urbana para hombres y mujeres.',
+    delay: 1400,
+  },
+  {
+    from: 'pipe',
+    text: 'Detecté "Moda Nerbis" como marca. Generando nav, hero y paleta de colores...',
+    preview: 'nav-hero',
+    thinking: 'Analizando nombre y tipo de negocio...',
+    delay: 1800,
+  },
+  {
+    from: 'user',
+    text: 'Tenemos camisetas, jeans, accesorios y zapatos.',
+    delay: 800,
+  },
+  {
+    from: 'pipe',
+    text: 'Catálogo creado con 4 categorías y precios sugeridos.',
+    preview: 'services',
+    thinking: 'Estructurando catálogo de productos...',
+    delay: 1600,
+  },
+  {
+    from: 'user',
+    text: 'También quiero mostrar fotos de nuestros productos.',
+    delay: 1000,
+  },
+  {
+    from: 'pipe',
+    text: 'Galería y reseñas de clientes agregadas.',
+    preview: 'gallery-reviews',
+    thinking: 'Generando galería y social proof...',
+    delay: 1400,
+  },
+  {
+    from: 'pipe',
+    text: 'Contacto, mapa y redes sociales configurados.',
+    preview: 'contact',
+    thinking: 'Agregando sección de contacto...',
+    delay: 800,
+  },
+  {
+    from: 'pipe',
+    text: '¡Tu sitio está listo en modanerbis.nerbis.com!',
+    preview: 'publish',
+    thinking: 'Publicando sitio...',
+    delay: 1200,
+  },
+];

--- a/frontend/src/components/marketing/pipe-demo.tsx
+++ b/frontend/src/components/marketing/pipe-demo.tsx
@@ -8,75 +8,9 @@ import { useGSAP } from '@gsap/react';
 import { ArrowRight, RotateCcw } from 'lucide-react';
 import { PipeAvatar } from '@/components/pipe-avatar';
 import type { PipeMood } from '@/components/pipe-avatar';
+import { CONVERSATION } from './pipe-demo-helpers';
 
 gsap.registerPlugin(ScrollTrigger);
-
-// ─── Conversation script ────────────────────────────────
-type ChatStep = {
-  from: 'pipe' | 'user';
-  text: string;
-  preview?: string; // which preview elements to reveal
-  thinking?: string; // text shown while "thinking" before this message
-  delay: number; // ms before this message appears
-};
-
-const CONVERSATION: ChatStep[] = [
-  {
-    from: 'pipe',
-    text: '¡Hola! Cuéntame sobre tu negocio y creo tu sitio web en segundos.',
-    delay: 400,
-  },
-  {
-    from: 'user',
-    text: 'Tengo una tienda de ropa llamada Moda Nerbis. Vendemos ropa urbana para hombres y mujeres.',
-    delay: 1400,
-  },
-  {
-    from: 'pipe',
-    text: 'Detecté "Moda Nerbis" como marca. Generando nav, hero y paleta de colores...',
-    preview: 'nav-hero',
-    thinking: 'Analizando nombre y tipo de negocio...',
-    delay: 1800,
-  },
-  {
-    from: 'user',
-    text: 'Tenemos camisetas, jeans, accesorios y zapatos.',
-    delay: 800,
-  },
-  {
-    from: 'pipe',
-    text: 'Catálogo creado con 4 categorías y precios sugeridos.',
-    preview: 'services',
-    thinking: 'Estructurando catálogo de productos...',
-    delay: 1600,
-  },
-  {
-    from: 'user',
-    text: 'También quiero mostrar fotos de nuestros productos.',
-    delay: 1000,
-  },
-  {
-    from: 'pipe',
-    text: 'Galería y reseñas de clientes agregadas.',
-    preview: 'gallery-reviews',
-    thinking: 'Generando galería y social proof...',
-    delay: 1400,
-  },
-  {
-    from: 'pipe',
-    text: 'Contacto, mapa y redes sociales configurados.',
-    preview: 'contact',
-    thinking: 'Agregando sección de contacto...',
-    delay: 800,
-  },
-  {
-    from: 'pipe',
-    text: '¡Tu sitio está listo en modanerbis.nerbis.com!',
-    preview: 'publish',
-    thinking: 'Publicando sitio...',
-    delay: 1200,
-  },
-];
 
 // ─── Preview Components (realistic miniature site) ──────
 function PreviewNav() {

--- a/frontend/src/components/website-builder/PageManager.tsx
+++ b/frontend/src/components/website-builder/PageManager.tsx
@@ -26,95 +26,17 @@ import {
   LayoutTemplate,
   Check,
   GripVertical,
-  Menu,
-  Home,
-  BookOpen,
-  Wrench,
-  ShoppingBag,
-  Phone,
-  Star,
-  Image,
-  DollarSign,
-  HelpCircle,
-  PanelBottom,
-  Users,
-  PenLine,
-  Sparkles,
-  BarChart3,
   FileText,
   X,
-  type LucideIcon,
 } from 'lucide-react';
-import type { PagesData, SitePage } from '@/types';
 import SectionLibrary from './SectionLibrary';
-
-const SECTION_LABELS: Record<string, string> = {
-  header: 'Menú principal',
-  hero: 'Inicio',
-  about: 'Sobre Nosotros',
-  services: 'Servicios',
-  products: 'Productos',
-  contact: 'Contacto',
-  testimonials: 'Testimonios',
-  gallery: 'Galería',
-  pricing: 'Precios',
-  faq: 'Preguntas frecuentes',
-  footer: 'Pie de página',
-  team: 'Equipo',
-  blog: 'Blog',
-  features: 'Características',
-  stats: 'Estadísticas',
-};
-
-const SECTION_ICONS: Record<string, LucideIcon> = {
-  header: Menu,
-  hero: Home,
-  about: BookOpen,
-  services: Wrench,
-  products: ShoppingBag,
-  contact: Phone,
-  testimonials: Star,
-  gallery: Image,
-  pricing: DollarSign,
-  faq: HelpCircle,
-  footer: PanelBottom,
-  team: Users,
-  blog: PenLine,
-  features: Sparkles,
-  stats: BarChart3,
-};
-
-const PAGE_ICONS: Record<string, LucideIcon> = {
-  home: Home,
-  about: BookOpen,
-  services: Wrench,
-  products: ShoppingBag,
-  contact: Phone,
-  pricing: DollarSign,
-  blog: PenLine,
-  gallery: Image,
-  faq: HelpCircle,
-};
-
-interface SectionInfo {
-  id: string;
-  name: string;
-  required: boolean;
-}
-
-interface PageManagerProps {
-  pagesData: PagesData;
-  activePage: string;
-  activeSection: string;
-  allSections: SectionInfo[];
-  editorContent?: React.ReactNode;
-  onSelectPage: (pageId: string) => void;
-  onSelectSection: (sectionId: string) => void;
-  onAddPage: (page: SitePage) => void;
-  onRemovePage: (pageId: string) => void;
-  onUpdatePages: (pagesData: PagesData) => void;
-  onAddSectionWithContent?: (sectionId: string, initialContent?: Record<string, unknown>, variant?: string) => void;
-}
+import type { SitePage } from '@/types';
+import {
+  SECTION_LABELS,
+  SECTION_ICONS,
+  PAGE_ICONS,
+  type PageManagerProps,
+} from './page-manager-helpers';
 
 export default function PageManager({
   pagesData,

--- a/frontend/src/components/website-builder/page-manager-helpers.ts
+++ b/frontend/src/components/website-builder/page-manager-helpers.ts
@@ -1,0 +1,87 @@
+import {
+  Menu,
+  Home,
+  BookOpen,
+  Wrench,
+  ShoppingBag,
+  Phone,
+  Star,
+  Image,
+  DollarSign,
+  HelpCircle,
+  PanelBottom,
+  Users,
+  PenLine,
+  Sparkles,
+  BarChart3,
+  type LucideIcon,
+} from 'lucide-react';
+import type { PagesData, SitePage } from '@/types';
+
+export const SECTION_LABELS: Record<string, string> = {
+  header: 'Menú principal',
+  hero: 'Inicio',
+  about: 'Sobre Nosotros',
+  services: 'Servicios',
+  products: 'Productos',
+  contact: 'Contacto',
+  testimonials: 'Testimonios',
+  gallery: 'Galería',
+  pricing: 'Precios',
+  faq: 'Preguntas frecuentes',
+  footer: 'Pie de página',
+  team: 'Equipo',
+  blog: 'Blog',
+  features: 'Características',
+  stats: 'Estadísticas',
+};
+
+export const SECTION_ICONS: Record<string, LucideIcon> = {
+  header: Menu,
+  hero: Home,
+  about: BookOpen,
+  services: Wrench,
+  products: ShoppingBag,
+  contact: Phone,
+  testimonials: Star,
+  gallery: Image,
+  pricing: DollarSign,
+  faq: HelpCircle,
+  footer: PanelBottom,
+  team: Users,
+  blog: PenLine,
+  features: Sparkles,
+  stats: BarChart3,
+};
+
+export const PAGE_ICONS: Record<string, LucideIcon> = {
+  home: Home,
+  about: BookOpen,
+  services: Wrench,
+  products: ShoppingBag,
+  contact: Phone,
+  pricing: DollarSign,
+  blog: PenLine,
+  gallery: Image,
+  faq: HelpCircle,
+};
+
+export interface SectionInfo {
+  id: string;
+  name: string;
+  required: boolean;
+}
+
+export interface PageManagerProps {
+  pagesData: PagesData;
+  activePage: string;
+  activeSection: string;
+  allSections: SectionInfo[];
+  editorContent?: React.ReactNode;
+  onSelectPage: (pageId: string) => void;
+  onSelectSection: (sectionId: string) => void;
+  onAddPage: (page: SitePage) => void;
+  onRemovePage: (pageId: string) => void;
+  onUpdatePages: (pagesData: PagesData) => void;
+  onAddSectionWithContent?: (sectionId: string, initialContent?: Record<string, unknown>, variant?: string) => void;
+}


### PR DESCRIPTION
## Summary

Batch 10 of issue #244 — frontend clean code & technical debt reduction.

Extracts constants, types, and form state into co-located helper files:

| Source file | Helper file | Extracted |
|---|---|---|
| `PageManager.tsx` | `page-manager-helpers.ts` | `SECTION_LABELS`, `SECTION_ICONS`, `PAGE_ICONS`, `SectionInfo`, `PageManagerProps` |
| `PromptBlocksTab.tsx` | `prompt-blocks-helpers.ts` | `CATEGORY_OPTIONS`, `SCOPE_OPTIONS`, badge classes, `BlockFormState`, `EMPTY_BLOCK_FORM` |
| `VariantsTab.tsx` | `variants-helpers.ts` | `MOOD_OPTIONS`, `MOOD_BADGE_CLASSES`, `FILTER_ALL`, `VariantFormState`, `EMPTY_VARIANT_FORM` |
| `pipe-demo.tsx` | `pipe-demo-helpers.ts` | `ChatStep` type, `CONVERSATION` array |

Closes partially #244

## Test plan
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm run lint` passes (0 errors, pre-existing warnings only)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Refactor**
  * Se reorganizó el código interno para mejorar la mantenibilidad y modularidad, extrayendo definiciones y constantes compartidas en módulos auxiliares dedicados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->