### PR TITLE
refactor(core): split de team/page.tsx en secciones (PR3) (#255)

### DIFF
--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/BlockMemberDialog.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/BlockMemberDialog.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import type { TeamMember } from '@/lib/api/team';
+
+interface BlockMemberDialogProps {
+  /** 'block' bloquea al miembro; 'unblock' lo desbloquea. */
+  mode: 'block' | 'unblock';
+  open: boolean;
+  member: TeamMember | null;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export function BlockMemberDialog({
+  mode,
+  open,
+  member,
+  isPending,
+  onOpenChange,
+  onConfirm,
+}: BlockMemberDialogProps) {
+  if (mode === 'unblock') {
+    return (
+      <AlertDialog open={open} onOpenChange={onOpenChange}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Desbloquear usuario</AlertDialogTitle>
+            <AlertDialogDescription>
+              {member && (
+                <>
+                  ¿Desbloquear a <strong>{member.full_name}</strong>?
+                  <br /><br />
+                  El usuario podrá iniciar sesión nuevamente.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={onConfirm} disabled={isPending}>
+              {isPending ? 'Desbloqueando...' : 'Desbloquear'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Bloquear usuario</AlertDialogTitle>
+          <AlertDialogDescription>
+            {member && (
+              <>
+                ¿Bloquear a <strong>{member.full_name}</strong>?
+                <br /><br />
+                El usuario no podrá iniciar sesión hasta que lo desbloquees.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            variant="destructive"
+            disabled={isPending}
+          >
+            {isPending ? 'Bloqueando...' : 'Bloquear'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/DisconnectSocialDialog.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/DisconnectSocialDialog.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import type { TeamMember, SocialAccountDetail } from '@/lib/api/team';
+import { PROVIDER_CONFIG, DEFAULT_PROVIDER_CONFIG } from '../_helpers';
+
+interface DisconnectSocialDialogProps {
+  open: boolean;
+  member: TeamMember | null;
+  social: SocialAccountDetail | null;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export function DisconnectSocialDialog({
+  open,
+  member,
+  social,
+  isPending,
+  onOpenChange,
+  onConfirm,
+}: DisconnectSocialDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Desvincular cuenta social</AlertDialogTitle>
+          <AlertDialogDescription>
+            {member && social && (
+              <>
+                ¿Desvincular la cuenta de{' '}
+                <strong>
+                  {(PROVIDER_CONFIG[social.provider] ?? DEFAULT_PROVIDER_CONFIG).label}
+                </strong>{' '}
+                de <strong>{member.full_name}</strong>?
+                <br />
+                <br />
+                El usuario ya no podrá iniciar sesión con este proveedor.
+                {!member.has_password &&
+                  member.social_accounts.length <= 1 && (
+                    <span className="block mt-2 text-destructive font-medium">
+                      Este usuario no tiene contraseña y esta es su única cuenta
+                      social. No se podrá desvincular.
+                    </span>
+                  )}
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            variant="destructive"
+            disabled={
+              isPending ||
+              (!member?.has_password &&
+                (member?.social_accounts.length ?? 0) <= 1)
+            }
+          >
+            {isPending ? 'Desvinculando...' : 'Desvincular'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/EditMemberDialog.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/EditMemberDialog.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { TeamMember } from '@/lib/api/team';
+import { navyText, ROLE_CONFIG } from '../_helpers';
+
+interface EditMemberDialogProps {
+  open: boolean;
+  member: TeamMember | null;
+  selectedRole: 'admin' | 'staff';
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectedRoleChange: (role: 'admin' | 'staff') => void;
+  onConfirm: () => void;
+}
+
+export function EditMemberDialog({
+  open,
+  member,
+  selectedRole,
+  isPending,
+  onOpenChange,
+  onSelectedRoleChange,
+  onConfirm,
+}: EditMemberDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className={`text-lg font-semibold ${navyText}`}>Cambiar rol</DialogTitle>
+          <DialogDescription>
+            {member && (
+              <>
+                Cambiar el rol de <strong>{member.full_name}</strong>.
+                Rol actual: {ROLE_CONFIG[member.role].label}.
+              </>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <div className="space-y-2">
+            <Label htmlFor="role-select" className="text-muted-foreground">Nuevo rol</Label>
+            <Select value={selectedRole} onValueChange={(v) => onSelectedRoleChange(v as 'admin' | 'staff')}>
+              <SelectTrigger id="role-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="admin">Administrador</SelectItem>
+                <SelectItem value="staff">Staff</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            onClick={onConfirm}
+            disabled={isPending || selectedRole === member?.role}
+          >
+            {isPending ? 'Guardando...' : 'Guardar'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/InvitationsList.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/InvitationsList.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Send,
+  X,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+} from 'lucide-react';
+import type { TeamInvitation } from '@/types';
+
+const STATUS_CONFIG = {
+  pending: { label: 'Pendiente', icon: Clock, color: 'text-amber-600', bg: 'bg-amber-50' },
+  accepted: { label: 'Aceptada', icon: CheckCircle2, color: 'text-emerald-600', bg: 'bg-emerald-50' },
+  cancelled: { label: 'Cancelada', icon: XCircle, color: 'text-muted-foreground', bg: 'bg-muted' },
+  expired: { label: 'Expirada', icon: AlertCircle, color: 'text-destructive', bg: 'bg-destructive/10' },
+} as const;
+
+interface InvitationsListProps {
+  pendingInvitations: TeamInvitation[];
+  pastInvitations: TeamInvitation[];
+  isResendPending: boolean;
+  isCancelPending: boolean;
+  onResend: (id: number) => void;
+  onCancel: (id: number) => void;
+}
+
+export function InvitationsList({
+  pendingInvitations,
+  pastInvitations,
+  isResendPending,
+  isCancelPending,
+  onResend,
+  onCancel,
+}: InvitationsListProps) {
+  return (
+    <>
+      {/* ── Invitaciones pendientes ── */}
+      {pendingInvitations.length > 0 && (
+        <section className="mb-8">
+          <h3 className="text-xs text-muted-foreground font-medium tracking-wide uppercase mb-3">
+            Invitaciones pendientes
+          </h3>
+          <div className="rounded-xl border border-border bg-card divide-y divide-border">
+            {pendingInvitations.map((inv) => (
+              <div key={inv.id} className="px-4 py-3.5 hover:bg-muted/50 transition-colors">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium text-foreground truncate">{inv.email}</p>
+                      <Badge variant={inv.role === 'admin' ? 'default' : 'secondary'} className="text-xs py-0 px-1.5">
+                        {inv.role_display}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Invitado por {inv.invited_by_name} · {new Date(inv.created_at).toLocaleDateString('es')}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-xs gap-1"
+                      onClick={() => onResend(inv.id)}
+                      disabled={isResendPending}
+                    >
+                      <Send className="h-3 w-3" />
+                      Reenviar
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-xs text-destructive gap-1"
+                      onClick={() => onCancel(inv.id)}
+                      disabled={isCancelPending}
+                    >
+                      <X className="h-3 w-3" />
+                      Cancelar
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Historial de invitaciones ── */}
+      {pastInvitations.length > 0 && (
+        <section className="mb-8">
+          <h3 className="text-xs text-muted-foreground font-medium tracking-wide uppercase mb-3">
+            Historial de invitaciones
+          </h3>
+          <div className="rounded-xl border border-border bg-card divide-y divide-border">
+            {pastInvitations.map((inv) => {
+              const statusConf = STATUS_CONFIG[inv.status as keyof typeof STATUS_CONFIG] || STATUS_CONFIG.expired;
+              return (
+                <div key={inv.id} className="px-4 py-3 hover:bg-muted/50 transition-colors">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm text-muted-foreground truncate">{inv.email}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {inv.role_display} · {new Date(inv.created_at).toLocaleDateString('es')}
+                      </p>
+                    </div>
+                    <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${statusConf.bg} ${statusConf.color}`}>
+                      <statusConf.icon className="h-3 w-3" />
+                      {statusConf.label}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/InviteMemberDialog.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/InviteMemberDialog.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { UserPlus, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { navyText } from '../_helpers';
+
+interface InviteMemberDialogProps {
+  open: boolean;
+  canInvite: boolean;
+  email: string;
+  role: 'staff' | 'admin';
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onEmailChange: (email: string) => void;
+  onRoleChange: (role: 'staff' | 'admin') => void;
+  onSubmit: () => void;
+}
+
+export function InviteMemberDialog({
+  open,
+  canInvite,
+  email,
+  role,
+  isPending,
+  onOpenChange,
+  onEmailChange,
+  onRoleChange,
+  onSubmit,
+}: InviteMemberDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm" className="gap-1.5 text-xs" disabled={!canInvite}>
+          <UserPlus className="h-3.5 w-3.5" />
+          Invitar
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className={`text-lg font-semibold ${navyText}`}>Invitar miembro al equipo</DialogTitle>
+          <DialogDescription>
+            Se enviará un email con un enlace para unirse al equipo.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmit();
+          }}
+        >
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="invite-email" className="text-muted-foreground">Email</Label>
+              <Input
+                id="invite-email"
+                type="email"
+                placeholder="ejemplo@email.com"
+                value={email}
+                onChange={(e) => onEmailChange(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="invite-role" className="text-muted-foreground">Rol</Label>
+              <Select value={role} onValueChange={(v) => onRoleChange(v as 'staff' | 'admin')}>
+                <SelectTrigger id="invite-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="staff">Staff</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="submit"
+              disabled={isPending}
+              className="gap-2"
+            >
+              <Send className="h-4 w-4" />
+              {isPending ? 'Enviando...' : 'Enviar invitación'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/MemberRow.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/MemberRow.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  MoreVertical,
+  Unlink,
+  ShieldCheck,
+  ShieldOff,
+  Ban,
+  UserCheck,
+  UserX,
+  RefreshCw,
+} from 'lucide-react';
+import type { TeamMember, SocialAccountDetail } from '@/lib/api/team';
+import {
+  PROVIDER_CONFIG,
+  ROLE_CONFIG,
+  DEFAULT_PROVIDER_CONFIG,
+  getInitials,
+  ProviderBadge,
+  AuthMethodBadge,
+} from '../_helpers';
+
+interface MemberRowProps {
+  member: TeamMember;
+  /** Id del usuario en sesión (oculta el menú de acciones para sí mismo). */
+  currentUserId?: number;
+  onEdit: (member: TeamMember) => void;
+  onBlock: (member: TeamMember) => void;
+  onUnblock: (member: TeamMember) => void;
+  onRemove: (member: TeamMember) => void;
+  onReset2FA: (member: TeamMember) => void;
+  onDisconnectSocial: (member: TeamMember, social: SocialAccountDetail) => void;
+}
+
+export function MemberRow({
+  member,
+  currentUserId,
+  onEdit,
+  onBlock,
+  onUnblock,
+  onRemove,
+  onReset2FA,
+  onDisconnectSocial,
+}: MemberRowProps) {
+  return (
+    <div className="px-4 py-3.5 hover:bg-muted/50 transition-colors">
+      <div className="flex items-center justify-between gap-3">
+        {/* Info del miembro */}
+        <div className="flex items-center gap-3 min-w-0">
+          <Avatar className="h-9 w-9 shrink-0">
+            {member.avatar && (
+              <AvatarImage src={member.avatar} alt={member.full_name} />
+            )}
+            <AvatarFallback className="text-xs bg-muted text-muted-foreground">
+              {getInitials(member)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium text-foreground truncate">
+                {member.full_name}
+              </p>
+              <Badge variant={ROLE_CONFIG[member.role].variant} className="text-xs py-0 px-1.5">
+                {ROLE_CONFIG[member.role].label}
+              </Badge>
+              {!member.is_active && (
+                <Badge variant="destructive" className="text-xs py-0 px-1.5">
+                  Bloqueado
+                </Badge>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground truncate">{member.email}</p>
+          </div>
+        </div>
+
+        {/* Acciones */}
+        <div className="flex items-center gap-2 shrink-0">
+          <AuthMethodBadge method={member.auth_method} />
+          {member.has_2fa && (
+            <Badge variant="outline" className="text-xs py-0 px-1.5 gap-1 text-emerald-600 border-emerald-200">
+              <ShieldCheck className="h-3 w-3" />
+              2FA
+            </Badge>
+          )}
+          {member.id !== currentUserId && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-foreground" aria-label="Acciones del miembro">
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {member.role !== 'customer' && (
+                  <>
+                    <DropdownMenuItem onClick={() => onEdit(member)}>
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Cambiar rol
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
+                )}
+                {member.is_active ? (
+                  <DropdownMenuItem
+                    onClick={() => onBlock(member)}
+                    variant="destructive"
+                  >
+                    <Ban className="h-4 w-4 mr-2" />
+                    Bloquear usuario
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem onClick={() => onUnblock(member)}>
+                    <UserCheck className="h-4 w-4 mr-2" />
+                    Desbloquear usuario
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem
+                  onClick={() => onRemove(member)}
+                  variant="destructive"
+                >
+                  <UserX className="h-4 w-4 mr-2" />
+                  Eliminar del equipo
+                </DropdownMenuItem>
+                {(member.social_accounts.length > 0 || member.has_2fa) && (
+                  <>
+                    <DropdownMenuSeparator />
+                    {member.social_accounts.map((sa) => (
+                      <DropdownMenuItem
+                        key={sa.id}
+                        onClick={() => onDisconnectSocial(member, sa)}
+                        variant="destructive"
+                      >
+                        <Unlink className="h-4 w-4 mr-2" />
+                        Desvincular {(PROVIDER_CONFIG[sa.provider] ?? DEFAULT_PROVIDER_CONFIG).label}
+                      </DropdownMenuItem>
+                    ))}
+                    {member.has_2fa && (
+                      <DropdownMenuItem
+                        onClick={() => onReset2FA(member)}
+                        variant="destructive"
+                      >
+                        <ShieldOff className="h-4 w-4 mr-2" />
+                        Resetear 2FA
+                      </DropdownMenuItem>
+                    )}
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </div>
+
+      {/* Social accounts */}
+      {member.social_accounts.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-2 ml-12">
+          {member.social_accounts.map((sa) => (
+            <ProviderBadge key={sa.id} social={sa} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/MembersList.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/MembersList.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Search, Users, Info } from 'lucide-react';
+import type { TeamMember, TeamFilters, SocialAccountDetail } from '@/lib/api/team';
+import { navyIconBg } from '../_helpers';
+import { MemberRow } from './MemberRow';
+
+interface MembersListProps {
+  members: TeamMember[];
+  isLoading: boolean;
+  filters: TeamFilters;
+  canInvite: boolean;
+  currentUserId?: number;
+  onFiltersChange: (filters: TeamFilters) => void;
+  onEdit: (member: TeamMember) => void;
+  onBlock: (member: TeamMember) => void;
+  onUnblock: (member: TeamMember) => void;
+  onRemove: (member: TeamMember) => void;
+  onReset2FA: (member: TeamMember) => void;
+  onDisconnectSocial: (member: TeamMember, social: SocialAccountDetail) => void;
+}
+
+export function MembersList({
+  members,
+  isLoading,
+  filters,
+  canInvite,
+  currentUserId,
+  onFiltersChange,
+  onEdit,
+  onBlock,
+  onUnblock,
+  onRemove,
+  onReset2FA,
+  onDisconnectSocial,
+}: MembersListProps) {
+  const hasFilters = Boolean(filters.search || filters.role || filters.auth_method);
+
+  return (
+    <>
+      {/* Buscar, filtrar y banner */}
+      <div className="rounded-xl border border-border bg-card mb-3 overflow-hidden">
+        {!canInvite && (
+          <div className="flex items-center gap-3 border-b border-border bg-muted/50 px-4 py-3">
+            <div className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${navyIconBg}`}>
+              <Info className="h-3 w-3 text-primary" />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">Tu equipo estará listo pronto</span>
+              {' — '}podrás invitar miembros una vez que tu sitio web esté publicado o en revisión.
+            </p>
+          </div>
+        )}
+
+        <div className="px-4 py-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="relative sm:col-span-3">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Buscar por nombre o email..."
+                aria-label="Buscar por nombre o email"
+                value={filters.search || ''}
+                onChange={(e) =>
+                  onFiltersChange({ ...filters, search: e.target.value })
+                }
+                className="pl-9 h-10"
+              />
+            </div>
+
+            <Select
+              value={filters.role || 'all'}
+              onValueChange={(v) =>
+                onFiltersChange({ ...filters, role: v === 'all' ? undefined : v })
+              }
+            >
+              <SelectTrigger className="h-10" aria-label="Filtrar por rol">
+                <SelectValue placeholder="Rol" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos los roles</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="staff">Staff</SelectItem>
+                <SelectItem value="customer">Cliente</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={filters.auth_method || 'all'}
+              onValueChange={(v) =>
+                onFiltersChange({ ...filters, auth_method: v === 'all' ? undefined : v })
+              }
+            >
+              <SelectTrigger className="h-10" aria-label="Filtrar por método de acceso">
+                <SelectValue placeholder="Método de acceso" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos los métodos</SelectItem>
+                <SelectItem value="email_only">Solo email</SelectItem>
+                <SelectItem value="social_only">Solo social</SelectItem>
+                <SelectItem value="both">Email + Social</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-xl border border-border bg-card divide-y divide-border">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="flex items-center gap-3 px-4 py-3.5">
+              <Skeleton className="h-9 w-9 rounded-full" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-3 w-28" />
+              </div>
+              <Skeleton className="h-5 w-14 rounded-full" />
+            </div>
+          ))}
+        </div>
+      ) : members.length === 0 ? (
+        <div className="rounded-xl border border-border bg-card px-4 py-12 text-center">
+          <div className={`inline-flex items-center justify-center w-12 h-12 rounded-full mb-3 ${navyIconBg}`}>
+            <Users className="w-6 h-6 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <p className="text-sm font-medium text-muted-foreground mb-1">No hay miembros</p>
+          <p className="text-xs text-muted-foreground">
+            {hasFilters
+              ? 'No se encontraron resultados con los filtros aplicados'
+              : 'Tu equipo aparecerá aquí cuando se registren usuarios'}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border bg-card divide-y divide-border">
+          {members.map((member) => (
+            <MemberRow
+              key={member.id}
+              member={member}
+              currentUserId={currentUserId}
+              onEdit={onEdit}
+              onBlock={onBlock}
+              onUnblock={onUnblock}
+              onRemove={onRemove}
+              onReset2FA={onReset2FA}
+              onDisconnectSocial={onDisconnectSocial}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Contador */}
+      {!isLoading && members.length > 0 && (
+        <p className="text-xs text-muted-foreground mt-2 px-1">
+          {members.length} {members.length === 1 ? 'miembro' : 'miembros'}
+          {hasFilters && ' encontrados con los filtros aplicados'}
+        </p>
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/RemoveMemberDialog.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/RemoveMemberDialog.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import type { TeamMember } from '@/lib/api/team';
+
+interface RemoveMemberDialogProps {
+  open: boolean;
+  member: TeamMember | null;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export function RemoveMemberDialog({
+  open,
+  member,
+  isPending,
+  onOpenChange,
+  onConfirm,
+}: RemoveMemberDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Eliminar del equipo</AlertDialogTitle>
+          <AlertDialogDescription>
+            {member && (
+              <>
+                ¿Eliminar a <strong>{member.full_name}</strong> del equipo?
+                <br /><br />
+                Se desactivará su cuenta y su rol cambiará a cliente.
+                Puedes reactivarlo más tarde desde esta misma sección.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            variant="destructive"
+            disabled={isPending}
+          >
+            {isPending ? 'Eliminando...' : 'Eliminar'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/Reset2FADialog.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/Reset2FADialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import type { TeamMember } from '@/lib/api/team';
+
+interface Reset2FADialogProps {
+  open: boolean;
+  member: TeamMember | null;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export function Reset2FADialog({
+  open,
+  member,
+  isPending,
+  onOpenChange,
+  onConfirm,
+}: Reset2FADialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Resetear 2FA</AlertDialogTitle>
+          <AlertDialogDescription>
+            {member && (
+              <>
+                ¿Resetear la autenticación en dos pasos de{' '}
+                <strong>{member.full_name}</strong>?
+                <br />
+                <br />
+                Se eliminarán todos sus métodos de verificación (passkeys y códigos TOTP).
+                El usuario podrá iniciar sesión solo con su contraseña o cuenta social
+                y configurar 2FA nuevamente si lo desea.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            variant="destructive"
+            disabled={isPending}
+          >
+            {isPending ? 'Reseteando...' : 'Resetear 2FA'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/TeamSummary.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/TeamSummary.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Users } from 'lucide-react';
+import { navyText, ROLE_CONFIG } from '../_helpers';
+
+interface TeamSummaryProps {
+  counts: {
+    total: number;
+    admins: number;
+    staff: number;
+    customers: number;
+  };
+}
+
+export function TeamSummary({ counts }: TeamSummaryProps) {
+  const stats = [
+    { label: 'Total de miembros', value: counts.total, icon: Users, color: 'text-text-brand', bg: 'bg-text-brand/[0.08]', alwaysShow: true },
+    { ...ROLE_CONFIG.admin, label: 'Administradores', value: counts.admins },
+    { ...ROLE_CONFIG.staff, label: 'Staff', value: counts.staff },
+    { ...ROLE_CONFIG.customer, label: 'Clientes', value: counts.customers },
+  ].filter((stat) => stat.alwaysShow || stat.value > 0);
+
+  return (
+    <section className="mb-8">
+      <h3 className="text-xs text-muted-foreground font-medium tracking-wide uppercase mb-3">
+        Resumen
+      </h3>
+      <div className="rounded-xl border border-border bg-card divide-y divide-border">
+        {stats.map((stat) => (
+          <div key={stat.label} className="flex items-center justify-between px-4 py-3 hover:bg-muted/50 transition-colors">
+            <div className="flex items-center gap-3">
+              <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${stat.bg}`}>
+                <stat.icon className={`w-4 h-4 ${stat.color}`} aria-hidden="true" />
+              </div>
+              <p className="text-sm font-medium text-muted-foreground">{stat.label}</p>
+            </div>
+            <span className={`text-lg font-semibold ${navyText}`}>{stat.value}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/index.ts
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/index.ts
@@ -1,0 +1,13 @@
+// Barrel de secciones y diálogos del módulo de equipo (PR3).
+
+export { TeamSummary } from './TeamSummary';
+export { MemberRow } from './MemberRow';
+export { MembersList } from './MembersList';
+export { InvitationsList } from './InvitationsList';
+export { InviteMemberDialog } from './InviteMemberDialog';
+export { EditMemberDialog } from './EditMemberDialog';
+export { BlockMemberDialog } from './BlockMemberDialog';
+export { RemoveMemberDialog } from './RemoveMemberDialog';
+export { Reset2FADialog } from './Reset2FADialog';
+export { DisconnectSocialDialog } from './DisconnectSocialDialog';
+export { useTeamActions } from './useTeamActions';

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_components/useTeamActions.ts
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_components/useTeamActions.ts
@@ -1,0 +1,190 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  getTeamMembers,
+  disconnectTeamSocial,
+  resetTeam2FA,
+  getTeamInvitations,
+  createTeamInvitation,
+  cancelTeamInvitation,
+  resendTeamInvitation,
+  updateTeamMember,
+  blockTeamMember,
+  unblockTeamMember,
+  deleteTeamMember,
+} from '@/lib/api/team';
+import type { TeamFilters, UpdateMemberData } from '@/lib/api/team';
+import type { CreateInvitationData } from '@/types';
+
+interface UseTeamActionsParams {
+  isAdmin: boolean;
+  filters: TeamFilters;
+  /** Callbacks que cierran cada diálogo al completarse su mutación. */
+  onDisconnectSuccess: () => void;
+  onReset2faSuccess: () => void;
+  onUpdateMemberSuccess: () => void;
+  onBlockSuccess: () => void;
+  onUnblockSuccess: () => void;
+  onDeleteSuccess: () => void;
+  onCreateInvitationSuccess: () => void;
+}
+
+/**
+ * Encapsula las queries y mutaciones del módulo de equipo.
+ * Todas las llamadas pasan por `lib/api/team` (scoped por tenant vía X-Tenant-Slug).
+ * Comportamiento idéntico al original: mismos queryKeys, toasts e invalidaciones.
+ */
+export function useTeamActions({
+  isAdmin,
+  filters,
+  onDisconnectSuccess,
+  onReset2faSuccess,
+  onUpdateMemberSuccess,
+  onBlockSuccess,
+  onUnblockSuccess,
+  onDeleteSuccess,
+  onCreateInvitationSuccess,
+}: UseTeamActionsParams) {
+  const queryClient = useQueryClient();
+
+  const membersQuery = useQuery({
+    queryKey: ['team-members', filters],
+    queryFn: () => getTeamMembers(filters),
+    enabled: isAdmin,
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: ({ userId, provider }: { userId: number; provider: string }) =>
+      disconnectTeamSocial(userId, provider),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['team-members'] });
+      toast.success(data.message);
+      onDisconnectSuccess();
+    },
+    onError: (error: Error & { data?: { error?: string } }) => {
+      toast.error(error.data?.error || error.message || 'Error al desvincular la cuenta');
+    },
+  });
+
+  const reset2faMutation = useMutation({
+    mutationFn: (userId: number) => resetTeam2FA(userId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['team-members'] });
+      toast.success(data.message);
+      onReset2faSuccess();
+    },
+    onError: (error: Error & { data?: { error?: string } }) => {
+      toast.error(error.data?.error || error.message || 'Error al resetear 2FA');
+    },
+  });
+
+  const updateMemberMutation = useMutation({
+    mutationFn: ({ userId, data }: { userId: number; data: UpdateMemberData }) =>
+      updateTeamMember(userId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['team-members'] });
+      toast.success('Miembro actualizado');
+      onUpdateMemberSuccess();
+    },
+    onError: (error: Error & { data?: { error?: string } }) => {
+      toast.error(error.data?.error || error.message || 'Error al actualizar el miembro');
+    },
+  });
+
+  const blockMemberMutation = useMutation({
+    mutationFn: (userId: number) => blockTeamMember(userId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['team-members'] });
+      toast.success(data.message);
+      onBlockSuccess();
+    },
+    onError: (error: Error & { data?: { error?: string } }) => {
+      toast.error(error.data?.error || error.message || 'Error al bloquear el usuario');
+    },
+  });
+
+  const unblockMemberMutation = useMutation({
+    mutationFn: (userId: number) => unblockTeamMember(userId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['team-members'] });
+      toast.success(data.message);
+      onUnblockSuccess();
+    },
+    onError: (error: Error & { data?: { error?: string } }) => {
+      toast.error(error.data?.error || error.message || 'Error al desbloquear el usuario');
+    },
+  });
+
+  const deleteMemberMutation = useMutation({
+    mutationFn: (userId: number) => deleteTeamMember(userId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['team-members'] });
+      toast.success(data.message);
+      onDeleteSuccess();
+    },
+    onError: (error: Error & { data?: { error?: string } }) => {
+      toast.error(error.data?.error || error.message || 'Error al eliminar el miembro');
+    },
+  });
+
+  const invitationsQuery = useQuery({
+    queryKey: ['team-invitations'],
+    queryFn: getTeamInvitations,
+    enabled: isAdmin,
+  });
+
+  const createInvitationMutation = useMutation({
+    mutationFn: (data: CreateInvitationData) => createTeamInvitation(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['team-invitations'] });
+      toast.success('Invitación enviada');
+      onCreateInvitationSuccess();
+    },
+    onError: (error: Error & { response?: { status?: number; data?: { email?: string[]; detail?: string; error?: string } } }) => {
+      if (error.response?.status === 403) {
+        toast.error(error.response.data?.detail || error.response.data?.error || 'No tienes permiso para enviar invitaciones en este momento.');
+        return;
+      }
+      const msg = error.response?.data?.email?.[0]
+        || error.response?.data?.detail
+        || error.response?.data?.error
+        || error.message
+        || 'Error al enviar la invitación';
+      toast.error(msg);
+    },
+  });
+
+  const cancelInvitationMutation = useMutation({
+    mutationFn: (id: number) => cancelTeamInvitation(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['team-invitations'] });
+      toast.success('Invitación cancelada');
+    },
+    onError: () => toast.error('Error al cancelar la invitación'),
+  });
+
+  const resendInvitationMutation = useMutation({
+    mutationFn: (id: number) => resendTeamInvitation(id),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['team-invitations'] });
+      toast.success(data.message || 'Invitación reenviada');
+    },
+    onError: () => toast.error('Error al reenviar la invitación'),
+  });
+
+  return {
+    membersQuery,
+    invitationsQuery,
+    disconnectMutation,
+    reset2faMutation,
+    updateMemberMutation,
+    blockMemberMutation,
+    unblockMemberMutation,
+    deleteMemberMutation,
+    createInvitationMutation,
+    cancelInvitationMutation,
+    resendInvitationMutation,
+  };
+}

--- a/frontend/src/app/(tenant)/dashboard/settings/team/_helpers.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/_helpers.tsx
@@ -4,10 +4,12 @@ import Image from 'next/image';
 import { Mail, KeyRound, ShieldCheck, Shield, UserRound } from 'lucide-react';
 import type { TeamMember, SocialAccountDetail } from '@/lib/api/team';
 
-// ─── Style constants ──────────────────────────────────────
-
-export const navyText = { color: '#1C3B57' } as const;
-export const navyIconBg = { background: 'rgba(28, 59, 87, 0.06)' } as const;
+// ─── Style constants (tokenized) ──────────────────────────
+// Mapeo a tokens del design system:
+//   navy text → text-foreground
+//   navy 6% bg → bg-primary/[0.06]
+export const navyText = 'text-foreground';
+export const navyIconBg = 'bg-primary/[0.06]';
 
 // ─── Config objects ───────────────────────────────────────
 

--- a/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/team/page.tsx
@@ -3,100 +3,26 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/AuthContext';
-import {
-  getTeamMembers,
-  disconnectTeamSocial,
-  resetTeam2FA,
-  getTeamInvitations,
-  createTeamInvitation,
-  cancelTeamInvitation,
-  resendTeamInvitation,
-  updateTeamMember,
-  blockTeamMember,
-  unblockTeamMember,
-  deleteTeamMember,
-} from '@/lib/api/team';
-import type { TeamMember, TeamFilters, SocialAccountDetail, UpdateMemberData } from '@/lib/api/team';
-import type { CreateInvitationData } from '@/types';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import {
-  Search,
-  Users,
-  MoreVertical,
-  Unlink,
-  ShieldCheck,
-  ShieldOff,
-  UserPlus,
-  Ban,
-  UserCheck,
-  UserX,
-  RefreshCw,
-  Clock,
-  Send,
-  X,
-  CheckCircle2,
-  XCircle,
-  AlertCircle,
-  Info,
-} from 'lucide-react';
-import { toast } from 'sonner';
+import type { TeamMember, TeamFilters, SocialAccountDetail } from '@/lib/api/team';
 import { useRouter } from 'next/navigation';
 import {
-  navyText,
-  navyIconBg,
-  PROVIDER_CONFIG,
-  ROLE_CONFIG,
-  DEFAULT_PROVIDER_CONFIG,
-  getInitials,
-  ProviderBadge,
-  AuthMethodBadge,
-} from './_helpers';
+  TeamSummary,
+  MembersList,
+  InvitationsList,
+  InviteMemberDialog,
+  EditMemberDialog,
+  BlockMemberDialog,
+  RemoveMemberDialog,
+  Reset2FADialog,
+  DisconnectSocialDialog,
+  useTeamActions,
+} from './_components';
 
 // ─── Página de equipo ─────────────────────────────────────
 export default function SettingsTeamPage() {
   const { user, tenant } = useAuth();
   const router = useRouter();
-  const queryClient = useQueryClient();
 
   const canInvite = tenant?.website_status === 'published' || tenant?.website_status === 'review';
 
@@ -135,133 +61,36 @@ export default function SettingsTeamPage() {
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<'staff' | 'admin'>('staff');
 
-  const { data: members, isLoading } = useQuery({
-    queryKey: ['team-members', filters],
-    queryFn: () => getTeamMembers(filters),
-    enabled: user?.role === 'admin',
-  });
-
-  const disconnectMutation = useMutation({
-    mutationFn: ({ userId, provider }: { userId: number; provider: string }) =>
-      disconnectTeamSocial(userId, provider),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['team-members'] });
-      toast.success(data.message);
-      setDisconnectDialog({ open: false, member: null, social: null });
-    },
-    onError: (error: Error & { data?: { error?: string } }) => {
-      toast.error(error.data?.error || error.message || 'Error al desvincular la cuenta');
-    },
-  });
-
-  const reset2faMutation = useMutation({
-    mutationFn: (userId: number) => resetTeam2FA(userId),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['team-members'] });
-      toast.success(data.message);
-      setReset2faDialog({ open: false, member: null });
-    },
-    onError: (error: Error & { data?: { error?: string } }) => {
-      toast.error(error.data?.error || error.message || 'Error al resetear 2FA');
-    },
-  });
-
-  const updateMemberMutation = useMutation({
-    mutationFn: ({ userId, data }: { userId: number; data: UpdateMemberData }) =>
-      updateTeamMember(userId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['team-members'] });
-      toast.success('Miembro actualizado');
-      setRoleDialog({ open: false, member: null });
-    },
-    onError: (error: Error & { data?: { error?: string } }) => {
-      toast.error(error.data?.error || error.message || 'Error al actualizar el miembro');
-    },
-  });
-
-  const blockMemberMutation = useMutation({
-    mutationFn: (userId: number) => blockTeamMember(userId),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['team-members'] });
-      toast.success(data.message);
-      setBlockDialog({ open: false, member: null });
-    },
-    onError: (error: Error & { data?: { error?: string } }) => {
-      toast.error(error.data?.error || error.message || 'Error al bloquear el usuario');
-    },
-  });
-
-  const unblockMemberMutation = useMutation({
-    mutationFn: (userId: number) => unblockTeamMember(userId),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['team-members'] });
-      toast.success(data.message);
-      setUnblockDialog({ open: false, member: null });
-    },
-    onError: (error: Error & { data?: { error?: string } }) => {
-      toast.error(error.data?.error || error.message || 'Error al desbloquear el usuario');
-    },
-  });
-
-  const deleteMemberMutation = useMutation({
-    mutationFn: (userId: number) => deleteTeamMember(userId),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['team-members'] });
-      toast.success(data.message);
-      setDeleteDialog({ open: false, member: null });
-    },
-    onError: (error: Error & { data?: { error?: string } }) => {
-      toast.error(error.data?.error || error.message || 'Error al eliminar el miembro');
-    },
-  });
-
-  // Invitations
-  const { data: invitations } = useQuery({
-    queryKey: ['team-invitations'],
-    queryFn: getTeamInvitations,
-    enabled: user?.role === 'admin',
-  });
-
-  const createInvitationMutation = useMutation({
-    mutationFn: (data: CreateInvitationData) => createTeamInvitation(data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['team-invitations'] });
-      toast.success('Invitación enviada');
+  const {
+    membersQuery,
+    invitationsQuery,
+    disconnectMutation,
+    reset2faMutation,
+    updateMemberMutation,
+    blockMemberMutation,
+    unblockMemberMutation,
+    deleteMemberMutation,
+    createInvitationMutation,
+    cancelInvitationMutation,
+    resendInvitationMutation,
+  } = useTeamActions({
+    isAdmin: user?.role === 'admin',
+    filters,
+    onDisconnectSuccess: () => setDisconnectDialog({ open: false, member: null, social: null }),
+    onReset2faSuccess: () => setReset2faDialog({ open: false, member: null }),
+    onUpdateMemberSuccess: () => setRoleDialog({ open: false, member: null }),
+    onBlockSuccess: () => setBlockDialog({ open: false, member: null }),
+    onUnblockSuccess: () => setUnblockDialog({ open: false, member: null }),
+    onDeleteSuccess: () => setDeleteDialog({ open: false, member: null }),
+    onCreateInvitationSuccess: () => {
       setInviteDialogOpen(false);
       setInviteEmail('');
       setInviteRole('staff');
     },
-    onError: (error: Error & { response?: { status?: number; data?: { email?: string[]; detail?: string; error?: string } } }) => {
-      if (error.response?.status === 403) {
-        toast.error(error.response.data?.detail || error.response.data?.error || 'No tienes permiso para enviar invitaciones en este momento.');
-        return;
-      }
-      const msg = error.response?.data?.email?.[0]
-        || error.response?.data?.detail
-        || error.response?.data?.error
-        || error.message
-        || 'Error al enviar la invitación';
-      toast.error(msg);
-    },
   });
 
-  const cancelInvitationMutation = useMutation({
-    mutationFn: (id: number) => cancelTeamInvitation(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['team-invitations'] });
-      toast.success('Invitación cancelada');
-    },
-    onError: () => toast.error('Error al cancelar la invitación'),
-  });
-
-  const resendInvitationMutation = useMutation({
-    mutationFn: (id: number) => resendTeamInvitation(id),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['team-invitations'] });
-      toast.success(data.message || 'Invitación reenviada');
-    },
-    onError: () => toast.error('Error al reenviar la invitación'),
-  });
+  const { data: members, isLoading } = membersQuery;
+  const { data: invitations } = invitationsQuery;
 
   // Role guard — solo admins (en useEffect para evitar navegación durante render)
   useEffect(() => {
@@ -286,679 +115,156 @@ export default function SettingsTeamPage() {
   const pendingInvitations = (invitations || []).filter((inv) => inv.status === 'pending');
   const pastInvitations = (invitations || []).filter((inv) => inv.status !== 'pending');
 
-  const STATUS_CONFIG = {
-    pending: { label: 'Pendiente', icon: Clock, color: 'text-amber-600', bg: 'bg-amber-50' },
-    accepted: { label: 'Aceptada', icon: CheckCircle2, color: 'text-emerald-600', bg: 'bg-emerald-50' },
-    cancelled: { label: 'Cancelada', icon: XCircle, color: 'text-gray-500', bg: 'bg-gray-100' },
-    expired: { label: 'Expirada', icon: AlertCircle, color: 'text-red-500', bg: 'bg-red-50' },
-  } as const;
-
   return (
     <div className="max-w-2xl">
       {/* ── Resumen ── */}
-      <section className="mb-8">
-        <h3 className="text-[0.7rem] text-gray-400 font-medium tracking-wide uppercase mb-3">
-          Resumen
-        </h3>
-        <div className="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
-          {[
-            { label: 'Total de miembros', value: counts.total, icon: Users, color: 'text-[#0D9488]', bg: 'bg-[rgba(13,148,136,0.08)]', alwaysShow: true },
-            { ...ROLE_CONFIG.admin, label: 'Administradores', value: counts.admins },
-            { ...ROLE_CONFIG.staff, label: 'Staff', value: counts.staff },
-            { ...ROLE_CONFIG.customer, label: 'Clientes', value: counts.customers },
-          ].filter((stat) => stat.alwaysShow || stat.value > 0).map((stat) => (
-            <div key={stat.label} className="flex items-center justify-between px-4 py-3 hover:bg-gray-50/50 transition-colors">
-              <div className="flex items-center gap-3">
-                <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${stat.bg}`}>
-                  <stat.icon className={`w-4 h-4 ${stat.color}`} aria-hidden="true" />
-                </div>
-                <p className="text-[0.85rem] font-medium text-gray-600">{stat.label}</p>
-              </div>
-              <span className="text-lg font-semibold" style={navyText}>{stat.value}</span>
-            </div>
-          ))}
-        </div>
-      </section>
+      <TeamSummary counts={counts} />
 
       {/* ── Miembros ── */}
       <section className="mb-8">
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-[0.7rem] text-gray-400 font-medium tracking-wide uppercase">
+          <h3 className="text-xs text-muted-foreground font-medium tracking-wide uppercase">
             Miembros
           </h3>
-          <Dialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}>
-            <DialogTrigger asChild>
-              <Button size="sm" className="gap-1.5 text-xs" disabled={!canInvite}>
-                <UserPlus className="h-3.5 w-3.5" />
-                Invitar
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle className="text-lg font-semibold" style={navyText}>Invitar miembro al equipo</DialogTitle>
-                <DialogDescription>
-                  Se enviará un email con un enlace para unirse al equipo.
-                </DialogDescription>
-              </DialogHeader>
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  createInvitationMutation.mutate({ email: inviteEmail, role: inviteRole });
-                }}
-              >
-                <div className="space-y-4 py-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="invite-email" className="text-gray-600">Email</Label>
-                    <Input
-                      id="invite-email"
-                      type="email"
-                      placeholder="ejemplo@email.com"
-                      value={inviteEmail}
-                      onChange={(e) => setInviteEmail(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="invite-role" className="text-gray-600">Rol</Label>
-                    <Select value={inviteRole} onValueChange={(v) => setInviteRole(v as 'staff' | 'admin')}>
-                      <SelectTrigger id="invite-role">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="staff">Staff</SelectItem>
-                        <SelectItem value="admin">Admin</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-                <DialogFooter>
-                  <Button
-                    type="submit"
-                    disabled={createInvitationMutation.isPending}
-                    className="gap-2"
-                  >
-                    <Send className="h-4 w-4" />
-                    {createInvitationMutation.isPending ? 'Enviando...' : 'Enviar invitación'}
-                  </Button>
-                </DialogFooter>
-              </form>
-            </DialogContent>
-          </Dialog>
+          <InviteMemberDialog
+            open={inviteDialogOpen}
+            canInvite={canInvite}
+            email={inviteEmail}
+            role={inviteRole}
+            isPending={createInvitationMutation.isPending}
+            onOpenChange={setInviteDialogOpen}
+            onEmailChange={setInviteEmail}
+            onRoleChange={setInviteRole}
+            onSubmit={() => createInvitationMutation.mutate({ email: inviteEmail, role: inviteRole })}
+          />
         </div>
 
-        {/* Buscar, filtrar y banner */}
-        <div className="rounded-xl border border-gray-200 bg-white mb-3 overflow-hidden">
-          {!canInvite && (
-            <div className="flex items-center gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-3">
-              <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full" style={navyIconBg}>
-                <Info className="h-3 w-3" style={{ color: '#1C3B57' }} />
-              </div>
-              <p className="text-xs text-gray-500">
-                <span className="font-medium text-gray-700">Tu equipo estará listo pronto</span>
-                {' — '}podrás invitar miembros una vez que tu sitio web esté publicado o en revisión.
-              </p>
-            </div>
-          )}
-
-          <div className="px-4 py-4">
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-              <div className="relative sm:col-span-3">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-                <Input
-                  placeholder="Buscar por nombre o email..."
-                  value={filters.search || ''}
-                  onChange={(e) =>
-                    setFilters({ ...filters, search: e.target.value })
-                  }
-                  className="pl-9 h-10"
-                />
-              </div>
-
-              <Select
-                value={filters.role || 'all'}
-                onValueChange={(v) =>
-                  setFilters({ ...filters, role: v === 'all' ? undefined : v })
-                }
-              >
-                <SelectTrigger className="h-10">
-                  <SelectValue placeholder="Rol" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Todos los roles</SelectItem>
-                  <SelectItem value="admin">Admin</SelectItem>
-                  <SelectItem value="staff">Staff</SelectItem>
-                  <SelectItem value="customer">Cliente</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <Select
-                value={filters.auth_method || 'all'}
-                onValueChange={(v) =>
-                  setFilters({ ...filters, auth_method: v === 'all' ? undefined : v })
-                }
-              >
-                <SelectTrigger className="h-10">
-                  <SelectValue placeholder="Método de acceso" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Todos los métodos</SelectItem>
-                  <SelectItem value="email_only">Solo email</SelectItem>
-                  <SelectItem value="social_only">Solo social</SelectItem>
-                  <SelectItem value="both">Email + Social</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </div>
-
-        {isLoading ? (
-          <div className="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
-            {[...Array(4)].map((_, i) => (
-              <div key={i} className="flex items-center gap-3 px-4 py-3.5">
-                <Skeleton className="h-9 w-9 rounded-full" />
-                <div className="flex-1 space-y-1.5">
-                  <Skeleton className="h-4 w-40" />
-                  <Skeleton className="h-3 w-28" />
-                </div>
-                <Skeleton className="h-5 w-14 rounded-full" />
-              </div>
-            ))}
-          </div>
-        ) : teamList.length === 0 ? (
-          <div className="rounded-xl border border-gray-200 bg-white px-4 py-12 text-center">
-            <div className="inline-flex items-center justify-center w-12 h-12 rounded-full mb-3" style={navyIconBg}>
-              <Users className="w-6 h-6 text-gray-300" aria-hidden="true" />
-            </div>
-            <p className="text-[0.85rem] font-medium text-gray-600 mb-1">No hay miembros</p>
-            <p className="text-xs text-gray-400">
-              {filters.search || filters.role || filters.auth_method
-                ? 'No se encontraron resultados con los filtros aplicados'
-                : 'Tu equipo aparecerá aquí cuando se registren usuarios'}
-            </p>
-          </div>
-        ) : (
-          <div className="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
-            {teamList.map((member) => (
-              <div key={member.id} className="px-4 py-3.5 hover:bg-gray-50/50 transition-colors">
-                <div className="flex items-center justify-between gap-3">
-                  {/* Info del miembro */}
-                  <div className="flex items-center gap-3 min-w-0">
-                    <Avatar className="h-9 w-9 shrink-0">
-                      {member.avatar && (
-                        <AvatarImage src={member.avatar} alt={member.full_name} />
-                      )}
-                      <AvatarFallback className="text-xs bg-gray-100 text-gray-500">
-                        {getInitials(member)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <p className="text-[0.85rem] font-medium text-gray-700 truncate">
-                          {member.full_name}
-                        </p>
-                        <Badge variant={ROLE_CONFIG[member.role].variant} className="text-[0.65rem] py-0 px-1.5">
-                          {ROLE_CONFIG[member.role].label}
-                        </Badge>
-                        {!member.is_active && (
-                          <Badge variant="destructive" className="text-[0.65rem] py-0 px-1.5">
-                            Bloqueado
-                          </Badge>
-                        )}
-                      </div>
-                      <p className="text-xs text-gray-400 truncate">{member.email}</p>
-                    </div>
-                  </div>
-
-                  {/* Acciones */}
-                  <div className="flex items-center gap-2 shrink-0">
-                    <AuthMethodBadge method={member.auth_method} />
-                    {member.has_2fa && (
-                      <Badge variant="outline" className="text-[0.6rem] py-0 px-1.5 gap-1 text-emerald-600 border-emerald-200">
-                        <ShieldCheck className="h-3 w-3" />
-                        2FA
-                      </Badge>
-                    )}
-                    {member.id !== user?.id && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="icon-sm" className="text-gray-300 hover:text-gray-500">
-                            <MoreVertical className="h-4 w-4" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          {member.role !== 'customer' && (
-                            <>
-                              <DropdownMenuItem
-                                onClick={() => {
-                                  setSelectedRole(member.role === 'admin' ? 'admin' : 'staff');
-                                  setRoleDialog({ open: true, member });
-                                }}
-                              >
-                                <RefreshCw className="h-4 w-4 mr-2" />
-                                Cambiar rol
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                            </>
-                          )}
-                          {member.is_active ? (
-                            <DropdownMenuItem
-                              onClick={() => setBlockDialog({ open: true, member })}
-                              variant="destructive"
-                            >
-                              <Ban className="h-4 w-4 mr-2" />
-                              Bloquear usuario
-                            </DropdownMenuItem>
-                          ) : (
-                            <DropdownMenuItem
-                              onClick={() => setUnblockDialog({ open: true, member })}
-                            >
-                              <UserCheck className="h-4 w-4 mr-2" />
-                              Desbloquear usuario
-                            </DropdownMenuItem>
-                          )}
-                          <DropdownMenuItem
-                            onClick={() => setDeleteDialog({ open: true, member })}
-                            variant="destructive"
-                          >
-                            <UserX className="h-4 w-4 mr-2" />
-                            Eliminar del equipo
-                          </DropdownMenuItem>
-                          {(member.social_accounts.length > 0 || member.has_2fa) && (
-                            <>
-                              <DropdownMenuSeparator />
-                              {member.social_accounts.map((sa) => (
-                                <DropdownMenuItem
-                                  key={sa.id}
-                                  onClick={() =>
-                                    setDisconnectDialog({
-                                      open: true,
-                                      member,
-                                      social: sa,
-                                    })
-                                  }
-                                  variant="destructive"
-                                >
-                                  <Unlink className="h-4 w-4 mr-2" />
-                                  Desvincular {(PROVIDER_CONFIG[sa.provider] ?? DEFAULT_PROVIDER_CONFIG).label}
-                                </DropdownMenuItem>
-                              ))}
-                              {member.has_2fa && (
-                                <DropdownMenuItem
-                                  onClick={() => setReset2faDialog({ open: true, member })}
-                                  variant="destructive"
-                                >
-                                  <ShieldOff className="h-4 w-4 mr-2" />
-                                  Resetear 2FA
-                                </DropdownMenuItem>
-                              )}
-                            </>
-                          )}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
-                  </div>
-                </div>
-
-                {/* Social accounts */}
-                {member.social_accounts.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mt-2 ml-12">
-                    {member.social_accounts.map((sa) => (
-                      <ProviderBadge key={sa.id} social={sa} />
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Contador */}
-        {!isLoading && teamList.length > 0 && (
-          <p className="text-xs text-gray-400 mt-2 px-1">
-            {teamList.length} {teamList.length === 1 ? 'miembro' : 'miembros'}
-            {(filters.search || filters.role || filters.auth_method) && ' encontrados con los filtros aplicados'}
-          </p>
-        )}
+        <MembersList
+          members={teamList}
+          isLoading={isLoading}
+          filters={filters}
+          canInvite={canInvite}
+          currentUserId={user?.id}
+          onFiltersChange={setFilters}
+          onEdit={(member) => {
+            setSelectedRole(member.role === 'admin' ? 'admin' : 'staff');
+            setRoleDialog({ open: true, member });
+          }}
+          onBlock={(member) => setBlockDialog({ open: true, member })}
+          onUnblock={(member) => setUnblockDialog({ open: true, member })}
+          onRemove={(member) => setDeleteDialog({ open: true, member })}
+          onReset2FA={(member) => setReset2faDialog({ open: true, member })}
+          onDisconnectSocial={(member, social) =>
+            setDisconnectDialog({ open: true, member, social })
+          }
+        />
       </section>
 
-      {/* ── Invitaciones pendientes ── */}
-      {pendingInvitations.length > 0 && (
-        <section className="mb-8">
-          <h3 className="text-[0.7rem] text-gray-400 font-medium tracking-wide uppercase mb-3">
-            Invitaciones pendientes
-          </h3>
-          <div className="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
-            {pendingInvitations.map((inv) => (
-              <div key={inv.id} className="px-4 py-3.5 hover:bg-gray-50/50 transition-colors">
-                <div className="flex items-center justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="text-[0.85rem] font-medium text-gray-700 truncate">{inv.email}</p>
-                      <Badge variant={inv.role === 'admin' ? 'default' : 'secondary'} className="text-[0.65rem] py-0 px-1.5">
-                        {inv.role_display}
-                      </Badge>
-                    </div>
-                    <p className="text-xs text-gray-400">
-                      Invitado por {inv.invited_by_name} · {new Date(inv.created_at).toLocaleDateString('es')}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-1.5 shrink-0">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-xs gap-1"
-                      onClick={() => resendInvitationMutation.mutate(inv.id)}
-                      disabled={resendInvitationMutation.isPending}
-                    >
-                      <Send className="h-3 w-3" />
-                      Reenviar
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-xs text-destructive gap-1"
-                      onClick={() => cancelInvitationMutation.mutate(inv.id)}
-                      disabled={cancelInvitationMutation.isPending}
-                    >
-                      <X className="h-3 w-3" />
-                      Cancelar
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
+      {/* ── Invitaciones ── */}
+      <InvitationsList
+        pendingInvitations={pendingInvitations}
+        pastInvitations={pastInvitations}
+        isResendPending={resendInvitationMutation.isPending}
+        isCancelPending={cancelInvitationMutation.isPending}
+        onResend={(id) => resendInvitationMutation.mutate(id)}
+        onCancel={(id) => cancelInvitationMutation.mutate(id)}
+      />
 
-      {/* Dialog de confirmación para desvincular */}
-      <AlertDialog
+      {/* ── Diálogos ── */}
+      <DisconnectSocialDialog
         open={disconnectDialog.open}
+        member={disconnectDialog.member}
+        social={disconnectDialog.social}
+        isPending={disconnectMutation.isPending}
         onOpenChange={(open) => {
           if (!open) setDisconnectDialog({ open: false, member: null, social: null });
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Desvincular cuenta social</AlertDialogTitle>
-            <AlertDialogDescription>
-              {disconnectDialog.member && disconnectDialog.social && (
-                <>
-                  ¿Desvincular la cuenta de{' '}
-                  <strong>
-                    {(PROVIDER_CONFIG[disconnectDialog.social.provider] ?? DEFAULT_PROVIDER_CONFIG).label}
-                  </strong>{' '}
-                  de <strong>{disconnectDialog.member.full_name}</strong>?
-                  <br />
-                  <br />
-                  El usuario ya no podrá iniciar sesión con este proveedor.
-                  {!disconnectDialog.member.has_password &&
-                    disconnectDialog.member.social_accounts.length <= 1 && (
-                      <span className="block mt-2 text-destructive font-medium">
-                        Este usuario no tiene contraseña y esta es su única cuenta
-                        social. No se podrá desvincular.
-                      </span>
-                    )}
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (disconnectDialog.member && disconnectDialog.social) {
-                  disconnectMutation.mutate({
-                    userId: disconnectDialog.member.id,
-                    provider: disconnectDialog.social.provider,
-                  });
-                }
-              }}
-              variant="destructive"
-              disabled={
-                disconnectMutation.isPending ||
-                (!disconnectDialog.member?.has_password &&
-                  (disconnectDialog.member?.social_accounts.length ?? 0) <= 1)
-              }
-            >
-              {disconnectMutation.isPending ? 'Desvinculando...' : 'Desvincular'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={() => {
+          if (disconnectDialog.member && disconnectDialog.social) {
+            disconnectMutation.mutate({
+              userId: disconnectDialog.member.id,
+              provider: disconnectDialog.social.provider,
+            });
+          }
+        }}
+      />
 
-      {/* ── Historial de invitaciones ── */}
-      {pastInvitations.length > 0 && (
-        <section className="mb-8">
-          <h3 className="text-[0.7rem] text-gray-400 font-medium tracking-wide uppercase mb-3">
-            Historial de invitaciones
-          </h3>
-          <div className="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
-            {pastInvitations.map((inv) => {
-              const statusConf = STATUS_CONFIG[inv.status as keyof typeof STATUS_CONFIG] || STATUS_CONFIG.expired;
-              return (
-                <div key={inv.id} className="px-4 py-3 hover:bg-gray-50/50 transition-colors">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="text-[0.85rem] text-gray-600 truncate">{inv.email}</p>
-                      <p className="text-xs text-gray-400">
-                        {inv.role_display} · {new Date(inv.created_at).toLocaleDateString('es')}
-                      </p>
-                    </div>
-                    <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${statusConf.bg} ${statusConf.color}`}>
-                      <statusConf.icon className="h-3 w-3" />
-                      {statusConf.label}
-                    </span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
-      {/* Dialog de confirmación para resetear 2FA */}
-      <AlertDialog
+      <Reset2FADialog
         open={reset2faDialog.open}
+        member={reset2faDialog.member}
+        isPending={reset2faMutation.isPending}
         onOpenChange={(open) => {
           if (!open) setReset2faDialog({ open: false, member: null });
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Resetear 2FA</AlertDialogTitle>
-            <AlertDialogDescription>
-              {reset2faDialog.member && (
-                <>
-                  ¿Resetear la autenticación en dos pasos de{' '}
-                  <strong>{reset2faDialog.member.full_name}</strong>?
-                  <br />
-                  <br />
-                  Se eliminarán todos sus métodos de verificación (passkeys y códigos TOTP).
-                  El usuario podrá iniciar sesión solo con su contraseña o cuenta social
-                  y configurar 2FA nuevamente si lo desea.
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (reset2faDialog.member) {
-                  reset2faMutation.mutate(reset2faDialog.member.id);
-                }
-              }}
-              variant="destructive"
-              disabled={reset2faMutation.isPending}
-            >
-              {reset2faMutation.isPending ? 'Reseteando...' : 'Resetear 2FA'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={() => {
+          if (reset2faDialog.member) {
+            reset2faMutation.mutate(reset2faDialog.member.id);
+          }
+        }}
+      />
 
-      {/* Dialog para cambiar rol */}
-      <Dialog
+      <EditMemberDialog
         open={roleDialog.open}
+        member={roleDialog.member}
+        selectedRole={selectedRole}
+        isPending={updateMemberMutation.isPending}
         onOpenChange={(open) => {
           if (!open) setRoleDialog({ open: false, member: null });
         }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle className="text-lg font-semibold" style={navyText}>Cambiar rol</DialogTitle>
-            <DialogDescription>
-              {roleDialog.member && (
-                <>
-                  Cambiar el rol de <strong>{roleDialog.member.full_name}</strong>.
-                  Rol actual: {ROLE_CONFIG[roleDialog.member.role].label}.
-                </>
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="py-4">
-            <div className="space-y-2">
-              <Label htmlFor="role-select" className="text-gray-600">Nuevo rol</Label>
-              <Select value={selectedRole} onValueChange={(v) => setSelectedRole(v as 'admin' | 'staff')}>
-                <SelectTrigger id="role-select">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="admin">Administrador</SelectItem>
-                  <SelectItem value="staff">Staff</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              onClick={() => {
-                if (roleDialog.member) {
-                  updateMemberMutation.mutate({
-                    userId: roleDialog.member.id,
-                    data: { role: selectedRole },
-                  });
-                }
-              }}
-              disabled={updateMemberMutation.isPending || selectedRole === roleDialog.member?.role}
-            >
-              {updateMemberMutation.isPending ? 'Guardando...' : 'Guardar'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onSelectedRoleChange={setSelectedRole}
+        onConfirm={() => {
+          if (roleDialog.member) {
+            updateMemberMutation.mutate({
+              userId: roleDialog.member.id,
+              data: { role: selectedRole },
+            });
+          }
+        }}
+      />
 
-      {/* Dialog de confirmación para desbloquear */}
-      <AlertDialog
+      <BlockMemberDialog
+        mode="unblock"
         open={unblockDialog.open}
+        member={unblockDialog.member}
+        isPending={unblockMemberMutation.isPending}
         onOpenChange={(open) => {
           if (!open) setUnblockDialog({ open: false, member: null });
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Desbloquear usuario</AlertDialogTitle>
-            <AlertDialogDescription>
-              {unblockDialog.member && (
-                <>
-                  ¿Desbloquear a <strong>{unblockDialog.member.full_name}</strong>?
-                  <br /><br />
-                  El usuario podrá iniciar sesión nuevamente.
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (unblockDialog.member) {
-                  unblockMemberMutation.mutate(unblockDialog.member.id);
-                }
-              }}
-              disabled={unblockMemberMutation.isPending}
-            >
-              {unblockMemberMutation.isPending ? 'Desbloqueando...' : 'Desbloquear'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={() => {
+          if (unblockDialog.member) {
+            unblockMemberMutation.mutate(unblockDialog.member.id);
+          }
+        }}
+      />
 
-      {/* Dialog de confirmación para bloquear */}
-      <AlertDialog
+      <BlockMemberDialog
+        mode="block"
         open={blockDialog.open}
+        member={blockDialog.member}
+        isPending={blockMemberMutation.isPending}
         onOpenChange={(open) => {
           if (!open) setBlockDialog({ open: false, member: null });
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Bloquear usuario</AlertDialogTitle>
-            <AlertDialogDescription>
-              {blockDialog.member && (
-                <>
-                  ¿Bloquear a <strong>{blockDialog.member.full_name}</strong>?
-                  <br /><br />
-                  El usuario no podrá iniciar sesión hasta que lo desbloquees.
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (blockDialog.member) {
-                  blockMemberMutation.mutate(blockDialog.member.id);
-                }
-              }}
-              variant="destructive"
-              disabled={blockMemberMutation.isPending}
-            >
-              {blockMemberMutation.isPending ? 'Bloqueando...' : 'Bloquear'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={() => {
+          if (blockDialog.member) {
+            blockMemberMutation.mutate(blockDialog.member.id);
+          }
+        }}
+      />
 
-      {/* Dialog de confirmación para eliminar */}
-      <AlertDialog
+      <RemoveMemberDialog
         open={deleteDialog.open}
+        member={deleteDialog.member}
+        isPending={deleteMemberMutation.isPending}
         onOpenChange={(open) => {
           if (!open) setDeleteDialog({ open: false, member: null });
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Eliminar del equipo</AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteDialog.member && (
-                <>
-                  ¿Eliminar a <strong>{deleteDialog.member.full_name}</strong> del equipo?
-                  <br /><br />
-                  Se desactivará su cuenta y su rol cambiará a cliente.
-                  Puedes reactivarlo más tarde desde esta misma sección.
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (deleteDialog.member) {
-                  deleteMemberMutation.mutate(deleteDialog.member.id);
-                }
-              }}
-              variant="destructive"
-              disabled={deleteMemberMutation.isPending}
-            >
-              {deleteMemberMutation.isPending ? 'Eliminando...' : 'Eliminar'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={() => {
+          if (deleteDialog.member) {
+            deleteMemberMutation.mutate(deleteDialog.member.id);
+          }
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumen

PR3 de la reingeniería de settings (#255): split **behavior-preserving** de `settings/team/page.tsx` (964 → **270** líneas). El page queda como orquestador admin delgado; queries y mutaciones se centralizan en el hook `useTeamActions`.

> ⚠️ **Apilado sobre PR1 (#271).** Base = `feat/reingenieria-settings-255`. Mergear **después** de PR1; al mergear PR1 a develop, recalcular base a `develop`. Independiente de PR2 (#272).

## Cambios

### Secciones y diálogos extraídos (`_components/`)
- `TeamSummary.tsx`, `MemberRow.tsx`, `MembersList.tsx`, `InvitationsList.tsx`.
- Diálogos: `InviteMemberDialog`, `EditMemberDialog`, `BlockMemberDialog` (block+unblock vía `mode`), `RemoveMemberDialog`, `Reset2FADialog`, `DisconnectSocialDialog`.
- `useTeamActions.ts` — hook con todas las queries + mutaciones (mismos queryKeys, toasts e invalidaciones).
- `_helpers.tsx` — `navyText`/`navyIconBg` migrados de hex a tokens; `ROLE_CONFIG`/`getInitials`/badges intactos.

## Behavior-preserving + multi-tenancy
- **Gating admin** preservado exacto: `useEffect` redirect a `/dashboard` para no-admins + `if (user?.role !== 'admin') return null`; queries con `enabled: isAdmin`.
- **Filtrado por tenant**: todo el acceso a datos pasa por `lib/api/team.ts` (`X-Tenant-Slug`). Sin `fetch`/`axios`/queries sin filtro nuevas. QueryKeys (`['team-members', filters]`, `['team-invitations']`) verbatim.
- Mismos endpoints, validaciones, mensajes sonner (incl. caso 403 de invitaciones), labels de pending y condiciones de disabled.

## Verificación
- File-size: page.tsx (270) y cada `_components/*` < 300 líneas.
- grep-zero sobre `settings/team/**`: hex=0, `--stg-`=0, `text-[0.x]`=0, `useToast/Toaster`=0, `fetch/axios`=0.
- ESLint: 0 errores / 0 warnings. `tsc --noEmit`: limpio.

Parte de #255 (PR3 de 4)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>