### PR TITLE
feat(core): subida de avatar de perfil con validación segura (PR4) (#255)

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -454,9 +454,13 @@ class SetPasswordSerializer(serializers.Serializer):
 class UpdateProfileSerializer(serializers.ModelSerializer):
     """Serializer para actualizar el perfil del usuario"""
 
+    # Tamano y formatos permitidos para el avatar
+    MAX_AVATAR_SIZE = 2 * 1024 * 1024  # 2 MB
+    ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
+
     class Meta:
         model = User
-        fields = ["first_name", "last_name", "phone"]
+        fields = ["first_name", "last_name", "phone", "avatar"]
 
     def validate_first_name(self, value):
         if not value or not value.strip():
@@ -467,6 +471,45 @@ class UpdateProfileSerializer(serializers.ModelSerializer):
         if not value or not value.strip():
             raise serializers.ValidationError("El apellido es requerido")
         return value.strip()
+
+    def validate_avatar(self, value):
+        """Valida el avatar: tamano maximo (2 MB) y formato real con Pillow.
+
+        Permite limpiar el avatar (valor vacio/null) sin validar imagen: solo
+        valida cuando hay un archivo subido real. El sniffing de contenido se
+        hace con ``PIL.Image.verify()`` para no confiar en la extension ni en
+        el content-type enviado por el cliente.
+        """
+        # Permitir limpiar el avatar (vacio/null) sin validar imagen.
+        if not value:
+            return value
+
+        if value.size > self.MAX_AVATAR_SIZE:
+            raise serializers.ValidationError(
+                f"La imagen no puede superar 2 MB (recibido: {value.size / 1024 / 1024:.1f} MB)."
+            )
+
+        from PIL import Image, UnidentifiedImageError
+
+        pillow_to_mime: dict[str, str] = {
+            "JPEG": "image/jpeg",
+            "PNG": "image/png",
+            "WEBP": "image/webp",
+        }
+        try:
+            img = Image.open(value)
+            # verify() confirma que es una imagen real (no un .txt renombrado).
+            img.verify()
+        except (UnidentifiedImageError, OSError):
+            raise serializers.ValidationError("El archivo no es una imagen válida.")
+
+        detected_mime: str | None = pillow_to_mime.get(img.format)
+        if detected_mime not in self.ALLOWED_AVATAR_TYPES:
+            raise serializers.ValidationError(f"Formato no permitido: {img.format}. Usa JPG, PNG o WebP.")
+
+        # verify() consume el archivo: rebobinar para que el save posterior funcione.
+        value.seek(0)
+        return value
 
 
 class ChangePasswordSerializer(serializers.Serializer):

--- a/backend/core/tests/test_avatar_upload.py
+++ b/backend/core/tests/test_avatar_upload.py
@@ -1,0 +1,169 @@
+"""Tests del upload de avatar en ProfileView (PATCH /api/auth/profile/).
+
+Cubre:
+- Subida valida de png/jpeg/webp < 2 MB -> 200, avatar guardado en users/avatars/.
+- Imagen sobredimensionada (> 2 MB) -> 400, avatar sin cambios.
+- Contenido no-imagen renombrado a .png -> 400, nada almacenado.
+- Aislamiento de dos tenants: subir para usuario de tenant A no afecta a tenant B.
+- Regresion: PATCH JSON solo con first_name sigue funcionando -> 200.
+
+Usa un MEDIA_ROOT temporal por test para no contaminar el repo.
+"""
+
+import io
+import shutil
+import tempfile
+
+import pytest
+from django.test import override_settings
+from PIL import Image
+from rest_framework.test import APIClient
+
+from core.context import clear_current_tenant, set_current_tenant
+
+PROFILE_URL = "/api/auth/profile/"
+
+
+def _make_image_bytes(fmt: str = "PNG", size: tuple[int, int] = (16, 16)) -> bytes:
+    """Genera bytes de una imagen real en memoria via Pillow."""
+    buffer = io.BytesIO()
+    Image.new("RGB", size, color=(120, 80, 200)).save(buffer, format=fmt)
+    return buffer.getvalue()
+
+
+def _upload(content: bytes, name: str, content_type: str):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    return SimpleUploadedFile(name, content, content_type=content_type)
+
+
+def _auth_client(user) -> APIClient:
+    """APIClient autenticado por JWT con header de tenant del usuario."""
+    from rest_framework_simplejwt.tokens import RefreshToken
+
+    refresh = RefreshToken.for_user(user)
+    if user.tenant:
+        refresh["tenant_id"] = str(user.tenant.id)
+        refresh["tenant_slug"] = user.tenant.slug
+    refresh["role"] = user.role
+
+    client = APIClient()
+    if user.tenant:
+        client.defaults["HTTP_X_TENANT_SLUG"] = user.tenant.slug
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+    return client
+
+
+@pytest.fixture()
+def media_root():
+    """MEDIA_ROOT temporal aislado por test; se limpia al finalizar."""
+    path = tempfile.mkdtemp(prefix="nerbis-avatar-test-")
+    with override_settings(MEDIA_ROOT=path):
+        yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("fmt", "ext", "content_type"),
+    [
+        ("PNG", "png", "image/png"),
+        ("JPEG", "jpg", "image/jpeg"),
+        ("WEBP", "webp", "image/webp"),
+    ],
+)
+def test_valid_image_upload_saves_avatar(media_root, customer_user, fmt, ext, content_type):
+    set_current_tenant(customer_user.tenant)
+    try:
+        client = _auth_client(customer_user)
+        upload = _upload(_make_image_bytes(fmt), f"avatar.{ext}", content_type)
+
+        response = client.patch(PROFILE_URL, {"avatar": upload}, format="multipart")
+
+        assert response.status_code == 200, response.content
+        data = response.json()
+        assert data["avatar"], "La respuesta debe incluir la URL del avatar"
+        assert "users/avatars/" in data["avatar"]
+
+        customer_user.refresh_from_db()
+        assert customer_user.avatar
+        assert customer_user.avatar.name.startswith("users/avatars/")
+    finally:
+        clear_current_tenant()
+
+
+@pytest.mark.django_db()
+def test_oversized_image_rejected(media_root, customer_user):
+    set_current_tenant(customer_user.tenant)
+    try:
+        client = _auth_client(customer_user)
+        # Imagen real grande (> 2 MB) generando un PNG de gran tamano.
+        big = _make_image_bytes("PNG", size=(2000, 2000))
+        # Asegurar > 2 MB rellenando con copias si fuese necesario no aplica:
+        # un PNG ruidoso seria mas grande; usamos bytes crudos garantizados.
+        payload = big + b"0" * (2 * 1024 * 1024)
+        upload = _upload(payload, "big.png", "image/png")
+
+        response = client.patch(PROFILE_URL, {"avatar": upload}, format="multipart")
+
+        assert response.status_code == 400, response.content
+        customer_user.refresh_from_db()
+        assert not customer_user.avatar
+    finally:
+        clear_current_tenant()
+
+
+@pytest.mark.django_db()
+def test_non_image_renamed_to_png_rejected(media_root, customer_user):
+    set_current_tenant(customer_user.tenant)
+    try:
+        client = _auth_client(customer_user)
+        upload = _upload(b"not an image", "fake.png", "image/png")
+
+        response = client.patch(PROFILE_URL, {"avatar": upload}, format="multipart")
+
+        assert response.status_code == 400, response.content
+        customer_user.refresh_from_db()
+        assert not customer_user.avatar
+    finally:
+        clear_current_tenant()
+
+
+@pytest.mark.django_db()
+def test_tenant_isolation_per_user_path(media_root, customer_user, second_tenant_admin):
+    """Subir avatar para usuario del tenant A no afecta al usuario del tenant B."""
+    # Usuario A (tenant de prueba) sube su avatar.
+    set_current_tenant(customer_user.tenant)
+    try:
+        client_a = _auth_client(customer_user)
+        upload = _upload(_make_image_bytes("PNG"), "a.png", "image/png")
+        resp_a = client_a.patch(PROFILE_URL, {"avatar": upload}, format="multipart")
+        assert resp_a.status_code == 200, resp_a.content
+    finally:
+        clear_current_tenant()
+
+    customer_user.refresh_from_db()
+    second_tenant_admin.refresh_from_db()
+
+    assert customer_user.avatar
+    # El usuario del segundo tenant NO debe tener avatar.
+    assert not second_tenant_admin.avatar
+    # La ruta del avatar de A no debe coincidir con ninguna de B.
+    assert customer_user.avatar.name != getattr(second_tenant_admin.avatar, "name", None)
+
+
+@pytest.mark.django_db()
+def test_json_only_first_name_patch_still_works(media_root, customer_user):
+    """Regresion: PATCH JSON (sin multipart) con first_name sigue devolviendo 200."""
+    set_current_tenant(customer_user.tenant)
+    try:
+        client = _auth_client(customer_user)
+
+        response = client.patch(PROFILE_URL, {"first_name": "Nuevo"}, format="json")
+
+        assert response.status_code == 200, response.content
+        customer_user.refresh_from_db()
+        assert customer_user.first_name == "Nuevo"
+        assert not customer_user.avatar
+    finally:
+        clear_current_tenant()

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -10,6 +10,7 @@ from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_sche
 from rest_framework import generics, status
 from rest_framework import serializers as drf_serializers
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -784,6 +785,8 @@ class ProfileView(APIView):
     """
 
     permission_classes = [IsAuthenticated]
+    # Permite subir avatar via multipart sin romper updates JSON (first_name, etc.).
+    parser_classes = [MultiPartParser, FormParser, JSONParser]
 
     @extend_schema(responses={200: UserSerializer})
     def get(self, request):

--- a/frontend/src/app/(tenant)/dashboard/settings/profile/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/settings/profile/page.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/contexts/AuthContext';
-import { updateUserProfile, deleteAccount, getUserProfile } from '@/lib/api/user';
+import { updateUserProfile, updateUserAvatar, deleteAccount, getUserProfile } from '@/lib/api/user';
 import { Trash2, Save, Eye, EyeOff } from 'lucide-react';
 import {
   AlertDialog,
@@ -32,6 +32,7 @@ import {
   ViewEditList,
   DangerZone,
   DangerAction,
+  AvatarUploader,
 } from '@/components/settings';
 
 // ─── Toggle de visibilidad de contraseña ──────────────────
@@ -103,6 +104,14 @@ export default function SettingsProfilePage() {
     },
   });
 
+  const updateAvatarMutation = useMutation({
+    mutationFn: updateUserAvatar,
+    onSuccess: (data) => {
+      setUser(data);
+      queryClient.invalidateQueries({ queryKey: ['user-profile'] });
+    },
+  });
+
   const deleteAccountMutation = useMutation({
     mutationFn: deleteAccount,
     onSuccess: () => {
@@ -146,6 +155,24 @@ export default function SettingsProfilePage() {
 
   return (
     <div className="max-w-2xl">
+      {/* ── Foto de perfil ── */}
+      <section className="mb-8" aria-labelledby="profile-avatar">
+        <SectionHeader
+          id="profile-avatar"
+          title="Foto de perfil"
+          description="Se mostrará en tu cuenta y en el equipo."
+        />
+        <SettingCard>
+          <div className="px-4 py-5">
+            <AvatarUploader
+              user={user}
+              onUpload={updateAvatarMutation.mutateAsync}
+              isUploading={updateAvatarMutation.isPending}
+            />
+          </div>
+        </SettingCard>
+      </section>
+
       {/* ── Datos personales ── */}
       <section className="mb-8" aria-labelledby="profile-personal-data">
         <SectionHeader

--- a/frontend/src/components/settings/avatar-uploader.tsx
+++ b/frontend/src/components/settings/avatar-uploader.tsx
@@ -1,0 +1,250 @@
+// src/components/settings/avatar-uploader.tsx
+// Subida de foto de perfil (avatar) con vista previa optimista, validación
+// en cliente (tipo + tamaño) y estados de carga / error accesibles.
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Camera, Loader2 } from 'lucide-react';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { User } from '@/types';
+
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const;
+const ACCEPT_ATTR = 'image/png,image/jpeg,image/webp';
+const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
+
+/** Iniciales a partir del nombre del usuario para el fallback del avatar. */
+function getInitials(user: User | null): string {
+  if (!user) return '?';
+  const source =
+    user.full_name?.trim() ||
+    `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() ||
+    user.email ||
+    '';
+  const initials = source
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('');
+  return initials || '?';
+}
+
+interface AvatarUploaderProps {
+  /** Usuario actual (provee la imagen y las iniciales del fallback). */
+  user: User | null;
+  /** Dispara la subida del archivo. Debe resolver con el usuario actualizado. */
+  onUpload: (file: File) => Promise<User>;
+  /** Notifica al contenedor cuando el avatar se actualizó (p. ej. setUser). */
+  onUploaded?: (user: User) => void;
+  /** Indica si la mutación está en curso (si se controla desde el contenedor). */
+  isUploading?: boolean;
+}
+
+export function AvatarUploader({
+  user,
+  onUpload,
+  onUploaded,
+  isUploading: isUploadingProp,
+}: AvatarUploaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const previewUrlRef = useRef<string | null>(null);
+
+  const [preview, setPreview] = useState<string | null>(null);
+  const [internalUploading, setInternalUploading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isUploading = isUploadingProp ?? internalUploading;
+
+  // Revocar cualquier object URL pendiente al desmontar.
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    };
+  }, []);
+
+  const revokePreview = useCallback(() => {
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+  }, []);
+
+  const validate = useCallback((file: File): string | null => {
+    if (!ACCEPTED_TYPES.includes(file.type as (typeof ACCEPTED_TYPES)[number])) {
+      return 'Formato no permitido. Usa PNG, JPG o WebP.';
+    }
+    if (file.size > MAX_BYTES) {
+      return 'La imagen supera el límite de 2 MB.';
+    }
+    return null;
+  }, []);
+
+  const upload = useCallback(
+    async (file: File) => {
+      // Vista previa optimista.
+      revokePreview();
+      const objectUrl = URL.createObjectURL(file);
+      previewUrlRef.current = objectUrl;
+      setPreview(objectUrl);
+      setErrorMessage(null);
+      setInternalUploading(true);
+
+      try {
+        const updated = await onUpload(file);
+        onUploaded?.(updated);
+        // La fuente de verdad pasa a ser el usuario actualizado.
+        revokePreview();
+        setPreview(null);
+        toast.success('Foto de perfil actualizada');
+      } catch (error) {
+        // Revertir vista previa al avatar previo.
+        revokePreview();
+        setPreview(null);
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'No se pudo actualizar la foto.';
+        setErrorMessage(message);
+        toast.error('No se pudo actualizar la foto', { description: message });
+      } finally {
+        setInternalUploading(false);
+      }
+    },
+    [onUpload, onUploaded, revokePreview],
+  );
+
+  const handleFile = useCallback(
+    (file: File | undefined) => {
+      if (!file) return;
+      const validationError = validate(file);
+      if (validationError) {
+        setErrorMessage(validationError);
+        toast.error('Imagen no válida', { description: validationError });
+        return;
+      }
+      void upload(file);
+    },
+    [upload, validate],
+  );
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    handleFile(event.target.files?.[0]);
+    // Permitir volver a seleccionar el mismo archivo.
+    event.target.value = '';
+  };
+
+  const openPicker = useCallback(() => {
+    if (isUploading) return;
+    inputRef.current?.click();
+  }, [isUploading]);
+
+  const handleAvatarKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openPicker();
+    }
+  };
+
+  const currentImage = preview ?? user?.avatar ?? undefined;
+  const initials = getInitials(user);
+
+  return (
+    <div className="flex items-center gap-4">
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPT_ATTR}
+        onChange={handleInputChange}
+        className="sr-only"
+        aria-label="Cambiar foto de perfil"
+        tabIndex={-1}
+      />
+
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Cambiar foto de perfil"
+        aria-disabled={isUploading}
+        onClick={openPicker}
+        onKeyDown={handleAvatarKeyDown}
+        className={cn(
+          'group relative rounded-full outline-none',
+          'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          isUploading ? 'cursor-default' : 'cursor-pointer',
+        )}
+      >
+        <Avatar className="size-16 border border-border">
+          {currentImage ? (
+            <AvatarImage src={currentImage} alt="Foto de perfil" />
+          ) : null}
+          <AvatarFallback className="text-base font-medium text-muted-foreground">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+
+        {/* Overlay de hover (colapsa con prefers-reduced-motion). */}
+        <span
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute inset-0 flex items-center justify-center rounded-full',
+            'bg-foreground/40 text-background opacity-0 transition-opacity',
+            'group-hover:opacity-100 group-focus-visible:opacity-100',
+            'motion-reduce:transition-none',
+            isUploading && 'opacity-0',
+          )}
+        >
+          <Camera className="size-5" />
+        </span>
+
+        {/* Spinner de carga (única excepción de movimiento permitida). */}
+        {isUploading ? (
+          <span className="absolute inset-0 flex items-center justify-center rounded-full bg-foreground/40 text-background">
+            <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={openPicker}
+            disabled={isUploading}
+          >
+            <Camera className="size-3.5" aria-hidden="true" />
+            {isUploading ? 'Subiendo…' : 'Cambiar foto'}
+          </Button>
+          {errorMessage ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={openPicker}
+              className="text-[var(--color-text-brand)] hover:bg-accent hover:text-[var(--color-text-brand)]"
+            >
+              Reintentar
+            </Button>
+          ) : null}
+        </div>
+
+        {errorMessage ? (
+          <p role="alert" className="text-sm text-destructive">
+            {errorMessage}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            PNG, JPG o WebP. Máximo 2 MB.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/index.ts
+++ b/frontend/src/components/settings/index.ts
@@ -7,3 +7,4 @@ export { SettingsField } from './SettingsField';
 export { ViewEditRow, ViewEditList } from './ViewEditRow';
 export { DangerZone, DangerAction } from './DangerZone';
 export { ComingSoonState } from './ComingSoonState';
+export { AvatarUploader } from './avatar-uploader';

--- a/frontend/src/lib/api/user.ts
+++ b/frontend/src/lib/api/user.ts
@@ -24,6 +24,40 @@ export async function updateUserProfile(userData: {
 }
 
 /**
+ * Actualizar la foto de perfil (avatar) del usuario.
+ *
+ * Envía un PATCH multipart a `/auth/profile/` con el archivo en el campo `avatar`.
+ * Se fuerza `Content-Type: undefined` para que el navegador genere el boundary
+ * de `multipart/form-data` automáticamente (el cliente tiene `application/json`
+ * como header por defecto, que rompería el envío del archivo).
+ */
+export async function updateUserAvatar(file: File): Promise<User> {
+  const formData = new FormData();
+  formData.append('avatar', file);
+
+  const { data } = await apiClient.patch<User>('/auth/profile/', formData, {
+    headers: { 'Content-Type': undefined },
+  });
+  return data;
+}
+
+/**
+ * Eliminar la foto de perfil (avatar) del usuario.
+ *
+ * Envía un PATCH multipart con el campo `avatar` vacío para que el backend
+ * limpie la imagen actual.
+ */
+export async function removeAvatar(): Promise<User> {
+  const formData = new FormData();
+  formData.append('avatar', '');
+
+  const { data } = await apiClient.patch<User>('/auth/profile/', formData, {
+    headers: { 'Content-Type': undefined },
+  });
+  return data;
+}
+
+/**
  * Cambiar contraseña del usuario
  */
 export async function changePassword(passwordData: {


### PR DESCRIPTION
## Summary
Cuarto PR de la reingeniería de settings (issue #255). Añade la subida de foto de perfil (avatar) end-to-end con validación segura. **Único PR que toca backend** e independiente de PR2/PR3.

- **Backend**: `UpdateProfileSerializer.validate_avatar` valida tamaño (máx 2 MB) y tipo real de imagen via content sniffing con Pillow (jpeg/png/webp); rechaza archivos no-imagen renombrados. `ProfileView` acepta `multipart/form-data` preservando el PATCH JSON existente (se mantiene `JSONParser`). Sin nueva migración (el campo `avatar` ya existía).
- **Frontend**: `AvatarUploader` (shadcn `Avatar`) con preview optimista (`URL.createObjectURL`), validación cliente de tipo/tamaño, estados de carga/error/éxito y accesibilidad (role button, Enter/Space, `role="alert"`, `motion-reduce`). Montado al tope de la página de perfil. `user.ts` expone `updateUserAvatar`/`removeAvatar` via multipart con override `Content-Type: undefined`.

## Stacking
- Base: `feat/reingenieria-settings-255` (PR1, #271). **Mergear PR1 primero**, luego rebasar este PR a `develop`.
- Independiente de PR2 (#272) y PR3 (#273).

## Test plan
- [ ] Backend: `pytest backend/core/tests/test_avatar_upload.py` (7 tests: formatos válidos <2MB, rechazo oversize, no-imagen renombrado, aislamiento entre tenants, regresión PATCH JSON)
- [ ] `ruff check backend/` limpio
- [ ] Frontend: `npm run lint` limpio
- [ ] Subir avatar válido (png/jpeg/webp) → preview optimista + persistencia
- [ ] Subir archivo >2MB o no-imagen → error de validación
- [ ] PATCH JSON de perfil (nombre/teléfono) sigue funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #255