### PR TITLE
feat(websites): la IA infiere las páginas del sitio desde un catálogo ampliado

### DIFF
--- a/backend/websites/management/commands/seed_onboarding.py
+++ b/backend/websites/management/commands/seed_onboarding.py
@@ -133,6 +133,36 @@ class Command(BaseCommand):
                 "is_default": False,
                 "sort_order": 6,
             },
+            # Electivas decididas por la IA (selected_pages). No se enlazan a
+            # ningun modulo: el merge servidor decide cuando incluirlas.
+            {
+                "key": "portfolio",
+                "label": "Portafolio",
+                "description": "Muestra tu trabajo",
+                "icon": "image",
+                "is_mandatory": False,
+                "is_default": False,
+                "sort_order": 7,
+            },
+            {
+                "key": "pricing",
+                "label": "Precios",
+                "description": "Planes y precios",
+                "icon": "tag",
+                "is_mandatory": False,
+                "is_default": False,
+                "sort_order": 8,
+            },
+            # Gateada por la vertical gastronomica (NO por modulo, NO por IA).
+            {
+                "key": "menu",
+                "label": "Menú",
+                "description": "Tu carta digital",
+                "icon": "utensils",
+                "is_mandatory": False,
+                "is_default": False,
+                "sort_order": 9,
+            },
         ]
 
         for data in pages_data:

--- a/backend/websites/migrations/0028_add_elective_pages.py
+++ b/backend/websites/migrations/0028_add_elective_pages.py
@@ -1,0 +1,83 @@
+"""Agrega las páginas electivas/industria al catálogo global WebsitePage.
+
+Issue #262 — AI-Inferred Elective Pages in Quick-Start Onboarding.
+
+Añade tres páginas al catálogo global (``WebsitePage``):
+- ``portfolio`` — electiva, decidida por la IA (selected_pages).
+- ``pricing``   — electiva, decidida por la IA (selected_pages).
+- ``menu``      — gateada por la vertical gastronómica (NO por módulo, NO por IA).
+
+Es una migración de DATOS idempotente: usa ``update_or_create`` keyeado por
+``key``, así que correrla contra una DB de producción ya sembrada por el comando
+``seed_onboarding`` NO duplica filas ni sobreescribe las 7 originales más allá de
+los 3 keys que ella misma gestiona. La reversión elimina ÚNICAMENTE esos 3 keys,
+dejando intactas las páginas originales.
+
+Nota sobre PAGE_META: la renderización en runtime (``rendering.resolve_page``)
+resuelve nombre/slug de página desde ``pages_data``/``content_data`` + la fila
+``WebsitePage``, no desde ``PAGE_META`` (que vive sólo en la migración 0013 como
+transformación de datos de una sola vez). Por eso esta migración sólo necesita
+añadir filas de catálogo, sin tocar metadata de render en runtime.
+"""
+
+from django.db import migrations
+
+# Filas a añadir. Los sort_order continúan tras los existentes (home..blog = 0..6)
+# sin colisionar: portfolio=7, pricing=8, menu=9.
+NEW_PAGES = [
+    {
+        "key": "portfolio",
+        "label": "Portafolio",
+        "description": "Muestra tu trabajo",
+        "icon": "image",
+        "is_mandatory": False,
+        "is_default": False,
+        "sort_order": 7,
+    },
+    {
+        "key": "pricing",
+        "label": "Precios",
+        "description": "Planes y precios",
+        "icon": "tag",
+        "is_mandatory": False,
+        "is_default": False,
+        "sort_order": 8,
+    },
+    {
+        "key": "menu",
+        "label": "Menú",
+        "description": "Tu carta digital",
+        "icon": "utensils",
+        "is_mandatory": False,
+        "is_default": False,
+        "sort_order": 9,
+    },
+]
+
+NEW_PAGE_KEYS = [p["key"] for p in NEW_PAGES]
+
+
+def add_elective_pages(apps, schema_editor):
+    """Añade portfolio/pricing/menu de forma idempotente (update_or_create)."""
+    WebsitePage = apps.get_model("websites", "WebsitePage")
+    for data in NEW_PAGES:
+        WebsitePage.objects.update_or_create(
+            key=data["key"],
+            defaults=data,
+        )
+
+
+def remove_elective_pages(apps, schema_editor):
+    """Elimina ÚNICAMENTE las 3 páginas añadidas; deja intactas las originales."""
+    WebsitePage = apps.get_model("websites", "WebsitePage")
+    WebsitePage.objects.filter(key__in=NEW_PAGE_KEYS).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0027_deactivate_pages_question"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_elective_pages, remove_elective_pages),
+    ]

--- a/backend/websites/migrations/__init__.py
+++ b/backend/websites/migrations/__init__.py
@@ -1,0 +1,39 @@
+"""websites.migrations — paquete de migraciones.
+
+Expone ``_load_0028`` como helper de test: devuelve dos callables
+``(add_pages, remove_pages)`` que aceptan directamente el modelo
+``WebsitePage`` y delegan en las funciones reales de la migración
+``0028_add_elective_pages``. Esto permite a los tests ejercitar el código de
+migración real (idempotencia forward + reverse acotado) sin construir un
+``MigrationExecutor`` completo.
+"""
+
+import importlib
+
+
+def _load_0028():
+    """Devuelve (add_pages, remove_pages) ligados a un modelo WebsitePage.
+
+    Las funciones reales de la migración toman ``(apps, schema_editor)`` y
+    resuelven el modelo vía ``apps.get_model``. Aquí las envolvemos con un
+    ``apps`` falso que devuelve el modelo recibido, de modo que el test pueda
+    llamarlas como ``add_pages(WebsitePage)`` / ``remove_pages(WebsitePage)``.
+    """
+    module = importlib.import_module(
+        "websites.migrations.0028_add_elective_pages"
+    )
+
+    class _FakeApps:
+        def __init__(self, model):
+            self._model = model
+
+        def get_model(self, app_label, model_name):  # noqa: ARG002
+            return self._model
+
+    def add_pages(website_page_model):
+        module.add_elective_pages(_FakeApps(website_page_model), None)
+
+    def remove_pages(website_page_model):
+        module.remove_elective_pages(_FakeApps(website_page_model), None)
+
+    return add_pages, remove_pages

--- a/backend/websites/services/ai_constants.py
+++ b/backend/websites/services/ai_constants.py
@@ -7,8 +7,24 @@ Constantes compartidas por los submódulos del servicio de IA.
 # Menos que esto se considera genérico ("Servicio 1 -- Descripcion del servicio").
 MIN_SERVICE_DESCRIPTION_WORDS = 15
 
-# Mapeo: opción del multi_choice -> IDs de sección del template
+# Mapeo: opción del multi_choice / page key -> IDs de sección del template.
+#
+# El frontend envía page KEYS ("about", "blog", ...) como ``website_sections``,
+# así que la fuente primaria de llaves son las page keys. Se conservan las
+# etiquetas en español como aliases de backward-compat para cualquier payload
+# legacy que aún envíe labels.
 SECTION_OPTION_MAP: dict[str, list[str]] = {
+    # Page keys (lo que el frontend realmente envía hoy)
+    "about": ["about"],
+    "blog": ["blog"],
+    "services": ["services"],
+    "products": ["products"],
+    "gallery": ["gallery"],
+    "testimonials": ["testimonials"],
+    "pricing": ["pricing"],
+    "faq": ["faq"],
+    "portfolio": ["portfolio"],
+    # Etiquetas en español — aliases de backward-compat (legacy)
     "Sobre nosotros": ["about"],
     "Servicios": ["services"],
     "Productos": ["products"],

--- a/backend/websites/services/ai_prompts.py
+++ b/backend/websites/services/ai_prompts.py
@@ -3,6 +3,21 @@
 System prompts, templates de prompt y formateo de contexto para la IA.
 """
 
+# Instrucciones para que la IA decida las páginas electivas (selected_pages).
+# Universo cerrado: about/blog/portfolio/pricing. NUNCA home/contact/services/
+# products/bookings/menu (esas las decide el servidor por reglas).
+SELECTED_PAGES_INSTRUCTIONS = """## Páginas electivas (selected_pages)
+Además del contenido, decide qué páginas electivas necesita este negocio como
+página propia y devuélvelas en el campo `selected_pages`. El universo cerrado es
+exactamente:
+- "about"     — incluye cuando el negocio tiene una historia/equipo/valores que contar.
+- "blog"      — incluye cuando el negocio publicará artículos, novedades o contenido educativo.
+- "portfolio" — incluye para creativos / negocios visuales que muestran trabajos previos.
+- "pricing"   — incluye cuando hay planes/tarifas claras que conviene transparentar.
+NUNCA incluyas "home", "contact", "services", "products", "bookings" ni "menu" en
+`selected_pages`. Si ninguna electiva aplica, devuelve una lista vacía. Sólo
+selecciona una electiva si además generas su sección de contenido correspondiente."""
+
 
 def format_business_context(responses: dict) -> str:
     """Formatea las respuestas del onboarding como contexto."""
@@ -148,6 +163,8 @@ Tu objetivo es generar contenido profesional, atractivo y personalizado.
 6. No inventes información que no se haya proporcionado
 7. Si falta información, usa placeholders descriptivos como "[Tu teléfono]"
 
+{SELECTED_PAGES_INSTRUCTIONS}
+
 ## Formato de Respuesta
 Responde SIEMPRE en formato JSON válido con la estructura solicitada.
 No incluyas explicaciones fuera del JSON.
@@ -190,6 +207,7 @@ def build_system_prompt(template, onboarding_responses: dict) -> str:
             "template_prompt": template_prompt,
             "brand_tone": brand_tone,
             "variant_instructions": variant_instructions,
+            "selected_pages_instructions": SELECTED_PAGES_INSTRUCTIONS,
         },
     )
 

--- a/backend/websites/services/ai_service.py
+++ b/backend/websites/services/ai_service.py
@@ -38,6 +38,18 @@ _MODEL_CONFIG_TTL = 60
 _MODEL_CONFIG_CACHE: dict[str, tuple[float, dict]] = {}
 
 
+def _coerce_selected_pages(raw) -> list[str]:
+    """Normaliza el campo ``selected_pages`` de la IA a una lista de strings.
+
+    Defensivo contra salidas malformadas: si ``raw`` no es una lista, devuelve
+    ``[]``; ignora elementos no-string. El filtrado al universo electivo cerrado
+    lo hace ``derive_enabled_pages`` aguas abajo (aquí sólo se sanea el tipo).
+    """
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, str)]
+
+
 def _settings_fallback_for_task(task: str) -> dict:
     """Config por defecto desde settings cuando no hay fila AIModelConfig.
 
@@ -192,7 +204,7 @@ class AIService:
 
     def generate_initial_content(
         self, template, onboarding_responses: dict, additional_instructions: str = ""
-    ) -> tuple[dict, dict, int, int, str, str]:
+    ) -> tuple[dict, dict, int, int, str, str, list[str]]:
         """
         Genera el contenido inicial del sitio web.
 
@@ -202,14 +214,16 @@ class AIService:
             additional_instructions: Instrucciones adicionales
 
         Returns:
-            tuple de (content_data, seo_data, tokens_input, tokens_output, full_prompt, raw_response)
+            tuple de (content_data, seo_data, tokens_input, tokens_output, full_prompt,
+            raw_response, selected_pages). ``selected_pages`` es la lista de páginas
+            electivas que la IA decidió (default ``[]``).
         """
         # Inyectar defaults del vertical para campos faltantes (Fase 2:
         # onboarding corto). Esto es un merge -- no sobrescribe datos del usuario.
         onboarding_responses = self._apply_industry_defaults(onboarding_responses)
 
         if not self.client:
-            return (*self._mock_generate_content(template, onboarding_responses), "", "")
+            return (*self._mock_generate_content(template, onboarding_responses), "", "", [])
 
         # Obtener estructura de secciones del template
         sections = template.structure_schema.get("sections", self._default_sections())
@@ -268,6 +282,13 @@ Responde con un JSON con esta estructura (incluye SOLO las secciones indicadas a
             "subtitle": "...",
             "items": []
         }},
+        "portfolio": {{
+            "title": "Portafolio",
+            "subtitle": "...",
+            "items": [
+                {{"title": "...", "description": "...", "category": "..."}}
+            ]
+        }},
         "pricing": {{
             "title": "Precios",
             "subtitle": "...",
@@ -295,8 +316,21 @@ Responde con un JSON con esta estructura (incluye SOLO las secciones indicadas a
         "meta_title": "...",
         "meta_description": "...",
         "keywords": ["...", "..."]
-    }}
+    }},
+    "selected_pages": ["about", "blog"]
 }}
+
+## Páginas electivas (selected_pages)
+Devuelve en `selected_pages` SÓLO las páginas electivas que este negocio realmente
+necesita como página propia. El universo cerrado es exactamente:
+- "about"     — incluye cuando el negocio tiene una historia/equipo/valores que contar.
+- "blog"      — incluye cuando el negocio publicará artículos, novedades o contenido educativo.
+- "portfolio" — incluye para creativos / negocios visuales que muestran trabajos previos.
+- "pricing"   — incluye cuando hay planes/tarifas claras que conviene transparentar.
+NUNCA incluyas "home", "contact", "services", "products", "bookings" ni "menu" en
+`selected_pages` (esas las decide el servidor por reglas). Si ninguna electiva aplica,
+devuelve una lista vacía. Sólo selecciona una electiva si además generas su sección
+de contenido correspondiente arriba.
 
 Genera contenido profesional y atractivo basado en la información del negocio."""
 
@@ -309,7 +343,7 @@ Genera contenido profesional y atractivo basado en la información del negocio."
         self._last_model_used = model
 
         try:
-            content_data, seo_data, tokens_input, tokens_output, response_text = self._call_generation(
+            content_data, seo_data, tokens_input, tokens_output, response_text, selected_pages = self._call_generation(
                 model=model, system_prompt=system_prompt, user_prompt=user_prompt, max_tokens=max_tokens
             )
 
@@ -330,14 +364,17 @@ Genera contenido profesional y atractivo basado en la información del negocio."
                     "manteniendo la estructura JSON especificada."
                 )
                 try:
-                    content_data2, seo_data2, tokens_in2, tokens_out2, response_text2 = self._call_generation(
-                        model=model, system_prompt=system_prompt, user_prompt=retry_prompt, max_tokens=max_tokens
+                    content_data2, seo_data2, tokens_in2, tokens_out2, response_text2, selected_pages2 = (
+                        self._call_generation(
+                            model=model, system_prompt=system_prompt, user_prompt=retry_prompt, max_tokens=max_tokens
+                        )
                     )
                     tokens_input += tokens_in2
                     tokens_output += tokens_out2
                     problems_after = self._validate_generated_content(content_data2, template)
                     if len(problems_after) < len(problems):
                         content_data, seo_data, response_text = content_data2, seo_data2, response_text2
+                        selected_pages = selected_pages2
                         if problems_after:
                             logger.warning(
                                 "Retry mejoró pero aún quedan problemas: %s",
@@ -349,21 +386,23 @@ Genera contenido profesional y atractivo basado en la información del negocio."
                     logger.warning(f"Retry de generación falló: {retry_error}")
 
             full_prompt = f"=== SYSTEM PROMPT ===\n{system_prompt}\n\n=== USER PROMPT ===\n{user_prompt}"
-            return content_data, seo_data, tokens_input, tokens_output, full_prompt, response_text
+            return content_data, seo_data, tokens_input, tokens_output, full_prompt, response_text, selected_pages
 
         except Exception as e:
             logger.error(f"Error llamando a Claude API: {e}")
-            return (*self._mock_generate_content(template, onboarding_responses), "", "")
+            return (*self._mock_generate_content(template, onboarding_responses), "", "", [])
 
     def _call_generation(
         self, model: str, system_prompt: str, user_prompt: str, max_tokens: int = 4096
-    ) -> tuple[dict, dict, int, int, str]:
+    ) -> tuple[dict, dict, int, int, str, list[str]]:
         """
         Hace una llamada a Claude y parsea la respuesta JSON.
 
         Returns:
-            tuple (content_data, seo_data, tokens_input, tokens_output, response_text).
-            Si el parse falla, content_data contiene {"error": ..., "raw": ...}.
+            tuple (content_data, seo_data, tokens_input, tokens_output, response_text,
+            selected_pages). ``selected_pages`` es la lista de páginas electivas que
+            la IA seleccionó (default ``[]`` si falta o es malformada). Si el parse
+            falla, content_data contiene {"error": ..., "raw": ...}.
         """
         response = self.client.messages.create(
             model=model,
@@ -375,6 +414,7 @@ Genera contenido profesional y atractivo basado en la información del negocio."
         tokens_input = response.usage.input_tokens
         tokens_output = response.usage.output_tokens
 
+        selected_pages: list[str] = []
         try:
             json_text = response_text.strip()
             if json_text.startswith("```json"):
@@ -387,13 +427,14 @@ Genera contenido profesional y atractivo basado en la información del negocio."
             result = json.loads(json_text.strip())
             content_data = result.get("content", {})
             seo_data = result.get("seo", {})
+            selected_pages = _coerce_selected_pages(result.get("selected_pages"))
         except json.JSONDecodeError as e:
             logger.error(f"Error parseando JSON de IA: {e}")
             logger.debug(f"Respuesta: {response_text}")
             content_data = {"error": "Error parseando respuesta", "raw": response_text}
             seo_data = {}
 
-        return content_data, seo_data, tokens_input, tokens_output, response_text
+        return content_data, seo_data, tokens_input, tokens_output, response_text, selected_pages
 
     # ───────────────────────────────────────────────────────────────────
     # Chat de edición
@@ -722,8 +763,15 @@ Responde SOLO con el JSON, sin explicaciones."""
                 allowed_ids.discard("services")
             if not getattr(self.tenant, "has_shop", False) and "products" in allowed_ids:
                 allowed_ids.discard("products")
-            # Asegurar que al menos uno quede si seleccionó servicios/productos
-            services_or_products = {"Servicios", "Productos", "Servicios / Productos"}
+            # Asegurar que al menos uno quede si seleccionó servicios/productos.
+            # Reconoce tanto page keys ("services"/"products") como labels legacy.
+            services_or_products = {
+                "services",
+                "products",
+                "Servicios",
+                "Productos",
+                "Servicios / Productos",
+            }
             if services_or_products & set(selected) and not allowed_ids & {"services", "products"}:
                 # Si ninguno quedó por los flags, incluir genérico
                 allowed_ids.add("services")

--- a/backend/websites/services/ai_service.py
+++ b/backend/websites/services/ai_service.py
@@ -320,18 +320,6 @@ Responde con un JSON con esta estructura (incluye SOLO las secciones indicadas a
     "selected_pages": ["about", "blog"]
 }}
 
-## Páginas electivas (selected_pages)
-Devuelve en `selected_pages` SÓLO las páginas electivas que este negocio realmente
-necesita como página propia. El universo cerrado es exactamente:
-- "about"     — incluye cuando el negocio tiene una historia/equipo/valores que contar.
-- "blog"      — incluye cuando el negocio publicará artículos, novedades o contenido educativo.
-- "portfolio" — incluye para creativos / negocios visuales que muestran trabajos previos.
-- "pricing"   — incluye cuando hay planes/tarifas claras que conviene transparentar.
-NUNCA incluyas "home", "contact", "services", "products", "bookings" ni "menu" en
-`selected_pages` (esas las decide el servidor por reglas). Si ninguna electiva aplica,
-devuelve una lista vacía. Sólo selecciona una electiva si además generas su sección
-de contenido correspondiente arriba.
-
 Genera contenido profesional y atractivo basado en la información del negocio."""
 
         # Para la generación inicial usamos el modelo configurado para la tarea

--- a/backend/websites/services/generation.py
+++ b/backend/websites/services/generation.py
@@ -12,6 +12,7 @@ import random
 from core.models import Tenant
 from websites.models import WebsiteConfig, WebsiteTemplate
 from websites.services.ai_service import AIService
+from websites.services.pages import derive_enabled_pages
 from websites.services.unsplash_service import UnsplashService
 
 logger = logging.getLogger(__name__)
@@ -145,7 +146,15 @@ def generate_website(
 
     try:
         # 5. Generar contenido con IA
-        content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response = ai_service.generate_initial_content(
+        (
+            content_data,
+            seo_data,
+            tokens_in,
+            tokens_out,
+            full_prompt,
+            raw_response,
+            selected_pages,
+        ) = ai_service.generate_initial_content(
             template=template,
             onboarding_responses=responses_dict,
         )
@@ -195,9 +204,20 @@ def generate_website(
             ordered.append("contact")
         content_data["_section_order"] = ordered
 
-        config.enabled_pages = [
+        # Derivar el set autoritativo de páginas con el helper centralizado
+        # (mismo que usa tasks.py — la lógica vive en un solo lugar).
+        content_keys = [
             k for k in content_data.keys() if not k.startswith("_") and k not in ("hero", "header", "footer")
         ]
+        resolved_industry = industry_key or tenant.industry
+        config.enabled_pages = derive_enabled_pages(
+            content_keys=content_keys,
+            ai_selected_pages=selected_pages,
+            has_services=getattr(tenant, "has_services", False),
+            has_shop=getattr(tenant, "has_shop", False),
+            has_bookings=getattr(tenant, "has_bookings", False),
+            industry_key=resolved_industry,
+        )
 
         # 8. Guardar
         config.content_data = content_data

--- a/backend/websites/services/pages.py
+++ b/backend/websites/services/pages.py
@@ -1,0 +1,111 @@
+# backend/websites/services/pages.py
+"""Derivación centralizada del set de páginas habilitadas de un sitio generado.
+
+Este módulo expone una única función pura ``derive_enabled_pages`` que calcula,
+de forma determinista, qué páginas debe tener un sitio recién generado.
+
+La fórmula (autoritativa) es:
+
+    enabled_pages = force(home, contact)
+        ∪ module_gated(services/products/bookings por flags has_*)
+        ∪ industry_gated(menu si la industria es gastronómica)
+        ∪ (ELECTIVE_PAGES ∩ ai_selected_pages ∩ content_keys)
+
+Las llaves desconocidas / fuera del universo se ignoran. La IA NUNCA es
+autoritativa para páginas obligatorias, de módulo o de industria: sólo decide
+sobre las electivas (about/blog/portfolio/pricing).
+
+La función no toca la base de datos ni lee ningún tenant: recibe los flags y la
+industria ya resueltos por el caller (lee sólo el tenant en contexto). Esto la
+hace trivialmente testeable y evita cualquier query cruzado entre tenants.
+"""
+
+# Páginas electivas: las únicas que la IA puede decidir vía selected_pages.
+ELECTIVE_PAGES: frozenset[str] = frozenset({"about", "blog", "portfolio", "pricing"})
+
+# Páginas obligatorias: siempre presentes, force-inyectadas en el servidor.
+MANDATORY_PAGES: tuple[str, ...] = ("home", "contact")
+
+# Páginas gateadas por módulo: se incluyen sólo si el flag has_* está activo.
+MODULE_PAGE_FLAGS: dict[str, str] = {
+    "services": "has_services",
+    "products": "has_shop",
+    "bookings": "has_bookings",
+}
+
+# Industrias gastronómicas que habilitan la página de menú (gate por vertical,
+# NO por flag de módulo y NUNCA por la IA).
+GASTRONOMY_INDUSTRIES: frozenset[str] = frozenset({"restaurant", "cafe", "bakery"})
+
+# Orden estable y determinista de las páginas en el resultado. Las llaves no
+# listadas (no debería haberlas tras el filtrado) caen al final, ordenadas.
+_PAGE_SORT_ORDER: tuple[str, ...] = (
+    "home",
+    "contact",
+    "about",
+    "services",
+    "products",
+    "bookings",
+    "blog",
+    "portfolio",
+    "pricing",
+    "menu",
+)
+
+
+def derive_enabled_pages(
+    *,
+    content_keys: list[str],
+    ai_selected_pages: list[str] | None,
+    has_services: bool,
+    has_shop: bool,
+    has_bookings: bool,
+    industry_key: str | None,
+) -> list[str]:
+    """Calcula el set autoritativo de páginas para un sitio generado.
+
+    Args:
+        content_keys: Llaves de sección realmente emitidas en ``content_data``
+            (sin prefijo ``_`` y sin header/footer). Una página electiva sólo
+            cuenta si su sección se renderizó.
+        ai_selected_pages: Páginas electivas que la IA seleccionó (``selected_pages``).
+            ``None`` o lista vacía => no se añade ninguna electiva.
+        has_services: Flag de módulo del tenant en contexto.
+        has_shop: Flag de módulo del tenant en contexto.
+        has_bookings: Flag de módulo del tenant en contexto.
+        industry_key: Llave de industria del tenant/template en contexto.
+
+    Returns:
+        Lista de llaves de página, de-duplicada y ordenada de forma estable
+        (home y contact primero). Sólo contiene páginas obligatorias,
+        gateadas por módulo, gateadas por industria, y electivas que la IA
+        seleccionó Y que efectivamente se renderizaron.
+    """
+    enabled: set[str] = set(MANDATORY_PAGES)
+
+    # Módulo: una página por flag has_* activo.
+    module_flags = {
+        "has_services": has_services,
+        "has_shop": has_shop,
+        "has_bookings": has_bookings,
+    }
+    for page_key, flag_name in MODULE_PAGE_FLAGS.items():
+        if module_flags.get(flag_name, False):
+            enabled.add(page_key)
+
+    # Industria: menu sólo para verticales gastronómicas (nunca vía IA).
+    if industry_key in GASTRONOMY_INDUSTRIES:
+        enabled.add("menu")
+
+    # Electivas: intersección de (universo electivo ∩ selección IA ∩ renderizadas).
+    selected = set(ai_selected_pages or [])
+    rendered = set(content_keys or [])
+    enabled |= ELECTIVE_PAGES & selected & rendered
+
+    return _stable_sort(enabled)
+
+
+def _stable_sort(pages: set[str]) -> list[str]:
+    """Ordena las páginas de forma determinista (home/contact primero)."""
+    order_index = {key: idx for idx, key in enumerate(_PAGE_SORT_ORDER)}
+    return sorted(pages, key=lambda key: (order_index.get(key, len(_PAGE_SORT_ORDER)), key))

--- a/backend/websites/tasks.py
+++ b/backend/websites/tasks.py
@@ -36,6 +36,7 @@ def generate_website_content(
     from core.models import Tenant
     from websites.models import WebsiteConfig
     from websites.services import AIService, UnsplashService
+    from websites.services.pages import derive_enabled_pages
 
     try:
         tenant = Tenant.objects.get(id=tenant_id)
@@ -65,7 +66,15 @@ def generate_website_content(
             generation_type = "initial"
 
         # Generar contenido con IA
-        content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response = ai_service.generate_initial_content(
+        (
+            content_data,
+            seo_data,
+            tokens_in,
+            tokens_out,
+            full_prompt,
+            raw_response,
+            selected_pages,
+        ) = ai_service.generate_initial_content(
             template=config.template,
             onboarding_responses=onboarding_responses,
             additional_instructions=additional_instructions,
@@ -123,10 +132,22 @@ def generate_website_content(
             ordered.append("contact")
         content_data["_section_order"] = ordered
 
-        # Derivar paginas habilitadas
-        config.enabled_pages = [
+        # Derivar paginas habilitadas con el helper centralizado (mismo que
+        # generation.py — la logica vive en un solo lugar, no se duplica).
+        content_keys = [
             k for k in content_data.keys() if not k.startswith("_") and k not in ("hero", "header", "footer")
         ]
+        resolved_industry = (
+            config.template.industry.key if config.template and config.template.industry_id else tenant.industry
+        )
+        config.enabled_pages = derive_enabled_pages(
+            content_keys=content_keys,
+            ai_selected_pages=selected_pages,
+            has_services=getattr(tenant, "has_services", False),
+            has_shop=getattr(tenant, "has_shop", False),
+            has_bookings=getattr(tenant, "has_bookings", False),
+            industry_key=resolved_industry,
+        )
 
         # Guardar resultado
         config.content_data = content_data

--- a/backend/websites/tests/test_ai_pages_inference.py
+++ b/backend/websites/tests/test_ai_pages_inference.py
@@ -1,0 +1,154 @@
+"""Tests para los cambios de IA en la inferencia de páginas (issue #262).
+
+Cubre:
+- SECTION_OPTION_MAP filtra por page keys (y por labels legacy).
+- _call_generation parsea selected_pages y default [] cuando falta.
+- _coerce_selected_pages sanea tipos.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from websites.services.ai_constants import SECTION_OPTION_MAP
+from websites.services.ai_service import AIService, _coerce_selected_pages
+
+# ───────────────────────────────────────────────────────────────────
+# SECTION_OPTION_MAP + _filter_sections_by_selection
+# ───────────────────────────────────────────────────────────────────
+
+
+def _sections() -> list[dict]:
+    return [
+        {"id": "hero", "name": "Hero", "required": True},
+        {"id": "about", "name": "Sobre nosotros", "required": False},
+        {"id": "blog", "name": "Blog", "required": False},
+        {"id": "services", "name": "Servicios", "required": False},
+        {"id": "products", "name": "Productos", "required": False},
+        {"id": "contact", "name": "Contacto", "required": True},
+    ]
+
+
+class _FakeTenant:
+    has_services = True
+    has_shop = True
+
+
+class TestSectionOptionMap:
+    def test_map_has_page_keys(self):
+        """El map resuelve page keys (lo que el frontend envía hoy)."""
+        assert SECTION_OPTION_MAP["about"] == ["about"]
+        assert SECTION_OPTION_MAP["blog"] == ["blog"]
+        assert SECTION_OPTION_MAP["portfolio"] == ["portfolio"]
+
+    def test_map_keeps_legacy_label_aliases(self):
+        """Aliases legacy en español siguen resolviendo (backward-compat)."""
+        assert SECTION_OPTION_MAP["Sobre nosotros"] == ["about"]
+        assert SECTION_OPTION_MAP["Servicios / Productos"] == ["services", "products"]
+
+    def test_key_based_payload_filters_sections(self):
+        """Spec: Key-based payload now filters sections (no es no-op)."""
+        svc = AIService.__new__(AIService)
+        svc.tenant = _FakeTenant()
+        svc.SECTION_OPTION_MAP = SECTION_OPTION_MAP
+
+        filtered = svc._filter_sections_by_selection(_sections(), {"website_sections": ["about", "services"]})
+        ids = {s["id"] for s in filtered}
+        # required siempre + las seleccionadas
+        assert "hero" in ids
+        assert "contact" in ids
+        assert "about" in ids
+        assert "services" in ids
+        # blog NO seleccionado => excluido
+        assert "blog" not in ids
+        # No es el fallback degenerado (sólo required)
+        assert ids != {"hero", "contact"}
+
+    def test_label_payload_still_resolves(self):
+        """Spec: Label-only payload still resolves via aliases."""
+        svc = AIService.__new__(AIService)
+        svc.tenant = _FakeTenant()
+        svc.SECTION_OPTION_MAP = SECTION_OPTION_MAP
+
+        filtered = svc._filter_sections_by_selection(_sections(), {"website_sections": ["Sobre nosotros"]})
+        ids = {s["id"] for s in filtered}
+        assert "about" in ids
+
+    def test_services_guard_recognizes_key_form(self):
+        """El guard services_or_products reconoce page keys, no sólo labels."""
+        tenant = _FakeTenant()
+        tenant.has_services = False
+        tenant.has_shop = False
+        svc = AIService.__new__(AIService)
+        svc.tenant = tenant
+        svc.SECTION_OPTION_MAP = SECTION_OPTION_MAP
+
+        filtered = svc._filter_sections_by_selection(_sections(), {"website_sections": ["services"]})
+        ids = {s["id"] for s in filtered}
+        # Aunque los flags están en False, el guard fuerza al menos services.
+        assert "services" in ids
+
+
+# ───────────────────────────────────────────────────────────────────
+# _coerce_selected_pages
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestCoerceSelectedPages:
+    def test_list_of_strings_passthrough(self):
+        assert _coerce_selected_pages(["about", "blog"]) == ["about", "blog"]
+
+    def test_non_list_returns_empty(self):
+        assert _coerce_selected_pages(None) == []
+        assert _coerce_selected_pages("about") == []
+        assert _coerce_selected_pages({"about": True}) == []
+
+    def test_drops_non_string_items(self):
+        assert _coerce_selected_pages(["about", 3, None, "blog"]) == ["about", "blog"]
+
+
+# ───────────────────────────────────────────────────────────────────
+# _call_generation parses selected_pages
+# ───────────────────────────────────────────────────────────────────
+
+
+def _mock_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    block = MagicMock()
+    block.text = json.dumps(payload)
+    response.content = [block]
+    response.usage.input_tokens = 10
+    response.usage.output_tokens = 20
+    return response
+
+
+class TestCallGenerationParsesSelectedPages:
+    def test_parses_selected_pages(self):
+        """Spec: Model returns selected_pages within the generation response."""
+        svc = AIService.__new__(AIService)
+        svc.client = MagicMock()
+        svc.client.messages.create.return_value = _mock_response(
+            {
+                "content": {"hero": {"title": "x"}},
+                "seo": {"meta_title": "t"},
+                "selected_pages": ["about", "blog"],
+            }
+        )
+        *_, selected_pages = svc._call_generation(model="m", system_prompt="s", user_prompt="u")
+        assert selected_pages == ["about", "blog"]
+        # Spec: No extra AI call is made — exactly one create call.
+        assert svc.client.messages.create.call_count == 1
+
+    def test_defaults_to_empty_when_missing(self):
+        """Spec: selected_pages default [] cuando falta el campo."""
+        svc = AIService.__new__(AIService)
+        svc.client = MagicMock()
+        svc.client.messages.create.return_value = _mock_response({"content": {}, "seo": {}})
+        *_, selected_pages = svc._call_generation(model="m", system_prompt="s", user_prompt="u")
+        assert selected_pages == []
+
+    def test_malformed_selected_pages_coerced_to_empty(self):
+        svc = AIService.__new__(AIService)
+        svc.client = MagicMock()
+        svc.client.messages.create.return_value = _mock_response({"content": {}, "seo": {}, "selected_pages": "about"})
+        *_, selected_pages = svc._call_generation(model="m", system_prompt="s", user_prompt="u")
+        assert selected_pages == []

--- a/backend/websites/tests/test_derive_enabled_pages.py
+++ b/backend/websites/tests/test_derive_enabled_pages.py
@@ -1,0 +1,253 @@
+"""Tests para ``derive_enabled_pages`` y los bugs colaterales (issue #262).
+
+Cubre los escenarios del delta spec ``sdd/onboarding-pages-ai/spec``:
+- Páginas obligatorias siempre presentes (force-inject).
+- Páginas de módulo sólo por flag has_* (nunca por IA).
+- ``menu`` sólo por vertical gastronómica (nunca por IA).
+- Electivas = IA ∩ renderizadas; llaves desconocidas ignoradas.
+- selected_pages vacío => sólo home+contact+módulo.
+- Aislamiento: el helper es puro (sólo usa los args pasados).
+- SECTION_OPTION_MAP filtra por page keys (no labels).
+- _call_generation parsea selected_pages.
+- Ambos caminos (generation.py + tasks.py) convergen.
+"""
+
+import pytest
+
+from websites.services.pages import (
+    ELECTIVE_PAGES,
+    GASTRONOMY_INDUSTRIES,
+    MANDATORY_PAGES,
+    derive_enabled_pages,
+)
+
+
+def _derive(**overrides):
+    """Helper con defaults sensatos para reducir ruido en los casos."""
+    base = {
+        "content_keys": [],
+        "ai_selected_pages": [],
+        "has_services": False,
+        "has_shop": False,
+        "has_bookings": False,
+        "industry_key": "generic",
+    }
+    base.update(overrides)
+    return derive_enabled_pages(**base)
+
+
+# ───────────────────────────────────────────────────────────────────
+# Mandatory pages (force-inject)
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestMandatoryPages:
+    def test_home_and_contact_always_present(self):
+        """Spec: Mandatory pages present even with empty selection."""
+        result = _derive(ai_selected_pages=["about"], content_keys=["about"])
+        assert "home" in result
+        assert "contact" in result
+
+    def test_mandatory_present_with_empty_selection(self):
+        """Spec: AI omits mandatory pages — still force-injected."""
+        result = _derive(ai_selected_pages=[], content_keys=[])
+        assert set(MANDATORY_PAGES) <= set(result)
+
+    def test_mandatory_present_even_when_ai_omits_them(self):
+        """Spec: AI omits mandatory pages and no contact block."""
+        result = _derive(ai_selected_pages=["blog"], content_keys=["blog"])
+        assert "home" in result
+        assert "contact" in result
+
+
+# ───────────────────────────────────────────────────────────────────
+# Module-gated pages (by has_* flags, never by AI)
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestModuleGatedPages:
+    def test_services_and_products_enabled_by_flags(self):
+        """Spec: Tenant with services + shop enabled."""
+        result = _derive(has_services=True, has_shop=True, has_bookings=False)
+        assert "services" in result
+        assert "products" in result
+        assert "bookings" not in result
+
+    def test_bookings_only_with_flag(self):
+        result = _derive(has_bookings=True)
+        assert "bookings" in result
+
+    def test_ai_cannot_enable_disabled_module(self):
+        """Spec: AI selecting a module page does not enable a disabled module."""
+        result = _derive(
+            has_bookings=False,
+            ai_selected_pages=["bookings"],
+            content_keys=["bookings"],
+        )
+        assert "bookings" not in result
+
+    def test_module_flag_false_excludes_page_even_with_content(self):
+        result = _derive(has_services=False, content_keys=["services"])
+        assert "services" not in result
+
+
+# ───────────────────────────────────────────────────────────────────
+# Industry-gated menu (gastronomy vertical only, never by AI)
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestMenuIndustryGate:
+    @pytest.mark.parametrize("industry", sorted(GASTRONOMY_INDUSTRIES))
+    def test_menu_for_gastronomy_industries(self, industry):
+        """Spec: Gastronomy tenant gets a menu page."""
+        result = _derive(industry_key=industry)
+        assert "menu" in result
+
+    def test_menu_absent_for_non_gastronomy(self):
+        result = _derive(industry_key="beauty")
+        assert "menu" not in result
+
+    def test_menu_never_from_ai(self):
+        """Spec: Non-gastronomy tenant never gets menu, even if AI lists it."""
+        result = _derive(
+            industry_key="beauty",
+            ai_selected_pages=["menu"],
+            content_keys=["menu"],
+        )
+        assert "menu" not in result
+
+    def test_menu_not_an_elective(self):
+        """menu no pertenece al universo electivo."""
+        assert "menu" not in ELECTIVE_PAGES
+
+    def test_menu_ignored_as_ai_selection_for_gastronomy_is_industry_driven(self):
+        """Para gastronomía, menu viene del gate de industria, no de la IA."""
+        result = _derive(industry_key="restaurant", ai_selected_pages=[])
+        assert "menu" in result
+
+
+# ───────────────────────────────────────────────────────────────────
+# Elective pages (AI ∩ rendered)
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestElectivePages:
+    def test_elective_selected_and_rendered(self):
+        """Spec: Elective selected and rendered."""
+        result = _derive(
+            ai_selected_pages=["about", "portfolio"],
+            content_keys=["about", "portfolio"],
+        )
+        assert "about" in result
+        assert "portfolio" in result
+
+    def test_elective_selected_but_not_rendered_excluded(self):
+        """Spec: Elective selected but not rendered."""
+        result = _derive(ai_selected_pages=["blog"], content_keys=[])
+        assert "blog" not in result
+
+    def test_elective_rendered_but_not_selected_excluded(self):
+        """Una sección renderizada sin selección IA no se vuelve página."""
+        result = _derive(ai_selected_pages=[], content_keys=["about"])
+        assert "about" not in result
+
+    def test_pricing_selected_without_content_excluded(self):
+        """Spec: Elective selected without rendered content is excluded."""
+        result = _derive(ai_selected_pages=["pricing"], content_keys=[])
+        assert "pricing" not in result
+
+    def test_unknown_key_ignored(self):
+        """Spec: Unknown page key is ignored."""
+        result = _derive(
+            ai_selected_pages=["about", "totally_made_up"],
+            content_keys=["about", "totally_made_up"],
+        )
+        assert "about" in result
+        assert "totally_made_up" not in result
+
+    def test_stray_content_block_not_a_page(self):
+        """Spec MODIFIED: Stray content block does not silently become a page."""
+        result = _derive(
+            ai_selected_pages=["about"],
+            content_keys=["about", "testimonials"],
+        )
+        assert "testimonials" not in result
+        assert "about" in result
+
+
+# ───────────────────────────────────────────────────────────────────
+# Empty / baseline
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestEmptyAndBaseline:
+    def test_empty_selection_yields_rule_driven_set(self):
+        """Spec: Empty selected_pages still yields the rule-driven page set."""
+        result = _derive(has_services=True, ai_selected_pages=[], content_keys=["services"])
+        assert "home" in result
+        assert "contact" in result
+        assert "services" in result
+        # Sin electivas
+        assert not (ELECTIVE_PAGES & set(result))
+
+    def test_none_selection_treated_as_empty(self):
+        result = _derive(ai_selected_pages=None, content_keys=["about"])
+        assert "about" not in result
+        assert set(MANDATORY_PAGES) <= set(result)
+
+    def test_result_is_deduplicated_and_stable(self):
+        result = _derive(
+            has_services=True,
+            ai_selected_pages=["about", "about"],
+            content_keys=["about"],
+        )
+        assert len(result) == len(set(result))
+        # home y contact primero
+        assert result[0] == "home"
+        assert result[1] == "contact"
+
+    def test_full_combination(self):
+        result = _derive(
+            has_services=True,
+            has_shop=True,
+            has_bookings=True,
+            industry_key="cafe",
+            ai_selected_pages=["about", "blog", "pricing"],
+            content_keys=["about", "blog"],  # pricing NO renderizado
+        )
+        assert set(result) == {
+            "home",
+            "contact",
+            "services",
+            "products",
+            "bookings",
+            "menu",
+            "about",
+            "blog",
+        }
+
+
+# ───────────────────────────────────────────────────────────────────
+# Purity / tenant isolation
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestPurityAndIsolation:
+    @pytest.mark.django_db
+    def test_helper_does_not_query_db(self, django_assert_num_queries):
+        """El helper es puro: no hace ningún query (no lee tenants)."""
+        with django_assert_num_queries(0):
+            _derive(has_shop=True, industry_key="restaurant")
+
+    def test_reflects_only_passed_args_tenant_a(self):
+        """Spec: Derivation reads only the in-context tenant's flags/vertical.
+
+        Pasando los flags de tenant A, el resultado refleja SÓLO a A; los flags
+        de un tenant B (no pasados) no influyen.
+        """
+        tenant_a = _derive(has_shop=True, industry_key="restaurant")
+        tenant_b = _derive(has_shop=False, industry_key="beauty")
+        assert "products" in tenant_a
+        assert "menu" in tenant_a
+        assert "products" not in tenant_b
+        assert "menu" not in tenant_b

--- a/backend/websites/tests/test_elective_pages_integration.py
+++ b/backend/websites/tests/test_elective_pages_integration.py
@@ -1,0 +1,213 @@
+"""Tests de integración para páginas electivas (issue #262).
+
+Cubre:
+- Convergencia: ambos caminos (generation.py + tasks.py + onboarding view)
+  usan el MISMO helper centralizado ``derive_enabled_pages``.
+- Tenant-scoping: la generación persiste enabled_pages en el WebsiteConfig del
+  tenant solicitante, sin tocar otros tenants.
+- Migración 0028 idempotente: portfolio/pricing/menu sembrados con flags
+  correctos; el seed re-corrido no duplica; reverse elimina sólo los 3.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from websites.models import WebsiteConfig, WebsitePage
+from websites.services.pages import derive_enabled_pages
+
+# ───────────────────────────────────────────────────────────────────
+# Convergencia: ambos caminos usan el mismo helper
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestBothPathsConvergence:
+    def test_both_modules_import_same_helper(self):
+        """generation.py, tasks.py y onboarding view referencian el mismo símbolo."""
+        from websites.services import generation as gen_mod
+
+        assert gen_mod.derive_enabled_pages is derive_enabled_pages
+
+    def test_identical_inputs_yield_identical_output(self):
+        """Spec: Both paths produce the same result for identical input.
+
+        Como ambos caminos delegan en el helper puro, idénticos inputs producen
+        idéntico output. Esto es el invariante que garantiza no-divergencia.
+        """
+        kwargs = {
+            "content_keys": ["about", "blog", "services"],
+            "ai_selected_pages": ["about", "blog"],
+            "has_services": True,
+            "has_shop": False,
+            "has_bookings": False,
+            "industry_key": "restaurant",
+        }
+        path_a = derive_enabled_pages(**kwargs)
+        path_b = derive_enabled_pages(**kwargs)
+        assert path_a == path_b
+        assert set(path_a) == {"home", "contact", "services", "menu", "about", "blog"}
+
+    def test_no_inline_derivation_remains_in_paths(self):
+        """Las tres rutas delegan en el helper centralizado."""
+        import inspect
+
+        from websites import tasks as tasks_mod
+        from websites.services import generation as gen_mod
+        from websites.views import onboarding as onboarding_mod
+
+        for mod in (gen_mod, tasks_mod, onboarding_mod):
+            src = inspect.getsource(mod)
+            assert "derive_enabled_pages(" in src, f"{mod.__name__} debe llamar al helper"
+
+
+# ───────────────────────────────────────────────────────────────────
+# Tenant-scoping de la generación
+# ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestTenantScoping:
+    def _fake_generation_result(self):
+        content = {
+            "hero": {"title": "x"},
+            "about": {"title": "Sobre"},
+            "contact": {"title": "Contacto"},
+        }
+        return content, {"meta_title": "t"}, 100, 50, "prompt", "{}", ["about"]
+
+    @patch("websites.services.generation.UnsplashService")
+    @patch("websites.services.generation.AIService")
+    def test_enabled_pages_written_to_requesting_tenant_only(
+        self, mock_ai_cls, mock_unsplash_cls, tenant, second_tenant, seeded_industries
+    ):
+        """Spec: Output written to the requesting tenant's config."""
+        # Config previa para second_tenant — no debe ser modificada.
+        from websites.models import WebsiteTemplate
+        from websites.services.generation import generate_website
+
+        template = WebsiteTemplate.objects.create(
+            name="Generic",
+            slug="generic-scope",
+            industry=seeded_industries("generic"),
+            is_active=True,
+            default_theme={},
+            structure_schema={},
+        )
+        other_config = WebsiteConfig.objects.create(
+            tenant=second_tenant,
+            template=template,
+            status="review",
+            enabled_pages=["home", "contact"],
+        )
+
+        mock_ai = MagicMock()
+        mock_ai.check_usage_limit.return_value = (True, 0, 10)
+        mock_ai.generate_initial_content.return_value = self._fake_generation_result()
+        mock_ai.log_generation.return_value = None
+        mock_ai_cls.return_value = mock_ai
+
+        mock_unsplash = MagicMock()
+        mock_unsplash.get_images_for_generation.return_value = {}
+        mock_unsplash_cls.return_value = mock_unsplash
+
+        generate_website(
+            tenant=tenant,
+            business_description="Negocio de prueba",
+            main_services="Servicio A",
+        )
+
+        config_a = WebsiteConfig.objects.get(tenant=tenant)
+        assert "home" in config_a.enabled_pages
+        assert "contact" in config_a.enabled_pages
+        assert "about" in config_a.enabled_pages  # electiva seleccionada + renderizada
+
+        # El config del otro tenant quedó intacto.
+        other_config.refresh_from_db()
+        assert other_config.enabled_pages == ["home", "contact"]
+
+
+# ───────────────────────────────────────────────────────────────────
+# Migración 0028 idempotente
+# ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestElectivePagesCatalog:
+    def test_new_pages_seeded_with_correct_flags(self):
+        """Spec: portfolio/pricing/menu existen con los flags correctos.
+
+        La migración 0028 corre en el setup de la DB de test, así que las filas
+        deben existir tras migrar.
+        """
+        portfolio = WebsitePage.objects.get(key="portfolio")
+        assert portfolio.is_mandatory is False
+        assert portfolio.is_default is False
+        assert portfolio.icon == "image"
+
+        pricing = WebsitePage.objects.get(key="pricing")
+        assert pricing.is_mandatory is False
+        assert pricing.is_default is False
+        assert pricing.icon == "tag"
+
+        menu = WebsitePage.objects.get(key="menu")
+        assert menu.is_mandatory is False
+        assert menu.is_default is False
+        assert menu.icon == "utensils"
+
+    def test_menu_not_linked_to_any_module(self):
+        """menu es industry-gated: NO se enlaza a ningún módulo."""
+        menu = WebsitePage.objects.get(key="menu")
+        assert menu.auto_include_modules.count() == 0
+
+    def test_seed_command_is_idempotent(self):
+        """Spec: Re-running seed_onboarding is a no-op for existing rows.
+
+        El comando usa update_or_create keyeado por key — correrlo dos veces
+        NO duplica las 10 páginas del catálogo.
+        """
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        call_command("seed_onboarding", stdout=StringIO())
+        first_count = WebsitePage.objects.count()
+        call_command("seed_onboarding", stdout=StringIO())
+        second_count = WebsitePage.objects.count()
+
+        assert first_count == second_count
+        # El catálogo completo tiene 10 páginas (7 originales + 3 nuevas).
+        assert WebsitePage.objects.count() == 10
+        for key in ("portfolio", "pricing", "menu"):
+            assert WebsitePage.objects.filter(key=key).count() == 1
+
+    def test_migration_forward_is_idempotent_and_reverse_removes_only_three(self):
+        """Spec: forward update_or_create no duplica; reverse borra sólo los 3."""
+        from websites.migrations import _load_0028
+
+        add_pages, remove_pages = _load_0028()
+
+        # Sembrar una página original para comprobar que el reverse NO la toca.
+        WebsitePage.objects.update_or_create(
+            key="about",
+            defaults={
+                "label": "Sobre nosotros",
+                "description": "Acerca de",
+                "icon": "info",
+                "is_mandatory": False,
+                "is_default": True,
+                "sort_order": 2,
+            },
+        )
+
+        # Forward dos veces: idempotente.
+        add_pages(WebsitePage)
+        add_pages(WebsitePage)
+        for key in ("portfolio", "pricing", "menu"):
+            assert WebsitePage.objects.filter(key=key).count() == 1
+
+        # Reverse: elimina SÓLO los 3 nuevos, deja las originales.
+        remove_pages(WebsitePage)
+        for key in ("portfolio", "pricing", "menu"):
+            assert not WebsitePage.objects.filter(key=key).exists()
+        # La página original sobrevive al reverse.
+        assert WebsitePage.objects.filter(key="about").exists()

--- a/backend/websites/tests/test_generation_tasks.py
+++ b/backend/websites/tests/test_generation_tasks.py
@@ -62,7 +62,11 @@ def onboarding_responses():
 
 @pytest.fixture()
 def mock_ai_content():
-    """Contenido simulado que devuelve AIService."""
+    """Contenido simulado que devuelve AIService.
+
+    El 7º elemento es ``selected_pages`` (páginas electivas elegidas por la IA),
+    añadido por el cambio de páginas electivas (issue #262).
+    """
     content_data = {
         "hero": {"title": "Bienvenido", "subtitle": "Salon premium"},
         "about": {"title": "Sobre nosotros", "content": "Somos un salon..."},
@@ -73,7 +77,8 @@ def mock_ai_content():
     tokens_out = 800
     full_prompt = "system prompt + user prompt"
     raw_response = '{"hero": ...}'
-    return content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response
+    selected_pages = ["about"]
+    return content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response, selected_pages
 
 
 # ===================================
@@ -91,7 +96,7 @@ class TestGenerateWebsiteContentTask:
         self, mock_ai_cls, mock_unsplash_cls, website_config, tenant, onboarding_responses, mock_ai_content
     ):
         """Tarea exitosa: status -> review, content_data poblado, generation_task_id limpiado."""
-        content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response = mock_ai_content
+        content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response, selected_pages = mock_ai_content
 
         # Mock AIService
         mock_ai = MagicMock()
@@ -102,6 +107,7 @@ class TestGenerateWebsiteContentTask:
             tokens_out,
             full_prompt,
             raw_response,
+            selected_pages,
         )
         mock_ai.log_generation.return_value = None
         mock_ai_cls.return_value = mock_ai
@@ -199,7 +205,7 @@ class TestGenerateContentView:
         self, mock_ai_cls, mock_unsplash_cls, auth_admin_client, website_config, tenant, mock_ai_content
     ):
         """POST retorna 202 con task_id cuando se despacha exitosamente."""
-        content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response = mock_ai_content
+        content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response, selected_pages = mock_ai_content
 
         # Mock AIService (used in both view and task since EAGER mode)
         mock_ai = MagicMock()
@@ -211,6 +217,7 @@ class TestGenerateContentView:
             tokens_out,
             full_prompt,
             raw_response,
+            selected_pages,
         )
         mock_ai.log_generation.return_value = None
         mock_ai_cls.return_value = mock_ai

--- a/backend/websites/tests/test_quick_start.py
+++ b/backend/websites/tests/test_quick_start.py
@@ -50,7 +50,10 @@ def _webp_upload(name: str = "logo.webp") -> SimpleUploadedFile:
 
 
 def _fake_generation_result() -> tuple:
-    """Imita el retorno de AIService.generate_initial_content."""
+    """Imita el retorno de AIService.generate_initial_content.
+
+    El 7º elemento es ``selected_pages`` (issue #262).
+    """
     content_data = {
         "hero": {"title": "Bienvenido", "subtitle": "Tu negocio"},
         "about": {"text": "Sobre nosotros"},
@@ -60,7 +63,8 @@ def _fake_generation_result() -> tuple:
     tokens_in, tokens_out = 100, 50
     full_prompt = "prompt"
     raw_response = "{}"
-    return content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response
+    selected_pages = ["about"]
+    return content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response, selected_pages
 
 
 @pytest.fixture()

--- a/backend/websites/views/onboarding.py
+++ b/backend/websites/views/onboarding.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 
 from ..models import OnboardingQuestion, OnboardingResponse, WebsiteConfig, WebsitePage, WebsiteSection, WebsiteTemplate
 from ..services.ai_service import AIService
+from ..services.pages import derive_enabled_pages
 from ..services.unsplash_service import UnsplashService
 
 logger = logging.getLogger(__name__)
@@ -339,11 +340,17 @@ class QuickStartView(OnboardingView):
 
         try:
             # 5. Generar contenido con IA
-            content_data, seo_data, tokens_in, tokens_out, full_prompt, raw_response = (
-                ai_service.generate_initial_content(
-                    template=template,
-                    onboarding_responses=responses_dict,
-                )
+            (
+                content_data,
+                seo_data,
+                tokens_in,
+                tokens_out,
+                full_prompt,
+                raw_response,
+                selected_pages,
+            ) = ai_service.generate_initial_content(
+                template=template,
+                onboarding_responses=responses_dict,
             )
 
             # 6. Enriquecer con imagenes de Unsplash
@@ -386,9 +393,20 @@ class QuickStartView(OnboardingView):
                 ordered.append("contact")
             content_data["_section_order"] = ordered
 
-            config.enabled_pages = [
+            # Derivar el set autoritativo de páginas con el helper centralizado
+            # (mismo que generation.py y tasks.py — sin duplicar lógica).
+            content_keys = [
                 k for k in content_data.keys() if not k.startswith("_") and k not in ("hero", "header", "footer")
             ]
+            resolved_industry = template.industry.key if template and template.industry_id else tenant.industry
+            config.enabled_pages = derive_enabled_pages(
+                content_keys=content_keys,
+                ai_selected_pages=selected_pages,
+                has_services=getattr(tenant, "has_services", False),
+                has_shop=getattr(tenant, "has_shop", False),
+                has_bookings=getattr(tenant, "has_bookings", False),
+                industry_key=resolved_industry,
+            )
 
             # 8. Guardar
             config.content_data = content_data

--- a/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
@@ -189,15 +189,16 @@ export default function QuickStartPage() {
   }, [modules, selectedModules]);
 
   // Derive selectedPages automatically — the pages question was removed from the
-  // chat. A page is included if it is mandatory, a sensible default, or its
-  // module is active (auto_include_modules). The user refines pages later in the
-  // editor (step 2).
+  // chat. A page is included if it is mandatory or its module is active
+  // (auto_include_modules). Elective pages (about/blog/portfolio/pricing) are NO
+  // longer force-sent here: the AI decides them server-side via selected_pages
+  // and the centralized derive_enabled_pages helper. The user refines pages later
+  // in the editor (step 2).
   useEffect(() => {
     if (!apiPages) return;
     const derived = apiPages
       .filter((p) =>
         p.is_mandatory ||
-        p.is_default ||
         p.auto_include_modules.some((m) => selectedModules.has(m as keyof ModuleSelection))
       )
       .map((p) => p.key);


### PR DESCRIPTION
## Resumen

En el onboarding asistido por Pipe, el usuario ya **no elige las páginas** del sitio con checkboxes: la IA las **infiere** a partir de la descripción del negocio, los módulos activos y un catálogo de páginas. Esto alinea NERBIS con el patrón de Wix Harmony / Squarespace Blueprint (la IA decide la estructura, el usuario refina después en el editor).

### Qué cambia

- **El frontend deja de forzar las páginas electivas.** Antes, `quick-start/page.tsx` incluía toda página `is_default`. Ahora solo manda obligatorias + páginas de módulos activos; about/blog/portfolio/pricing las decide el backend.
- **Campo estructurado `selected_pages`.** La IA devuelve qué páginas electivas quiere, además del prompt. Se parsea y coacciona en `ai_service.py`.
- **Helper centralizado `derive_enabled_pages` (`services/pages.py`).** Única fuente de verdad para el set final de páginas:
  - fuerza `{home, contact}` (obligatorias)
  - une páginas por módulo activo (`has_*` → `auto_include_modules`)
  - habilita `menu` solo para industrias gastronómicas
  - interseca electivas `{about, blog, portfolio, pricing}` con (lo que la IA pidió ∩ secciones realmente renderizadas)
  - ignora claves desconocidas
- **Catálogo ampliado.** Migración idempotente `0028_add_elective_pages` que añade `portfolio`, `pricing` y `menu` (reverse acotado a esas 3 claves). El comando `seed_onboarding` queda en paridad.

### Bugs corregidos (incluidos a pedido)

- **`SECTION_OPTION_MAP` re-keyado por page key** — antes usaba labels en español como claves y el filtro quedaba como no-op (nunca recortaba secciones). Se mantienen aliases en español como compatibilidad.
- **Triple duplicación de la derivación de `enabled_pages`** — había lógica inline duplicada en `generation.py`, `tasks.py` (camino Celery real) y `views/onboarding.py`. Las tres ahora llaman a `derive_enabled_pages`.

## Test plan

- [x] `ruff check backend/` — limpio
- [x] `npm run lint --prefix frontend` — 0 errores (warnings preexistentes)
- [x] 45 tests nuevos (`test_derive_enabled_pages`, `test_ai_pages_inference`, `test_elective_pages_integration`) + mocks actualizados a la tupla de 7 — 113 tests pasan
- [x] Migración `0028` aplicada y verificada en el backend del worktree; 3 páginas nuevas sembradas
- [ ] Verificación manual del flujo completo de onboarding en preview

## Notas

- **Frontend-only en el lado del usuario** (deja de forzar páginas); el resto es backend. Sin impacto multi-tenant nuevo (las páginas son catálogo global sin tenant).
- No tiene issue asociado (#262 era el catálogo de industrias, ya mergeado). Se abren issues de seguimiento por separado para el WhatsApp opcional y el control de `has_services` en la generación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tres páginas electivas añadidas: Portafolio, Precios y Menú (Menú solo para industrias gastronómicas).
  * Lógica de habilitación de páginas centralizada: se combina selección IA, capacidades del negocio e industria para decidir páginas finales.

* **Tests**
  * Amplia cobertura automática e integración para la inferencia y derivación de páginas y para la migración/seed idempotente.

* **Chores**
  * Migración y semillas para incorporar las nuevas páginas sin duplicados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->