### PR TITLE
fix(websites): hardening del catálogo de industrias (follow-up #265)

### DIFF
--- a/backend/core/admin_settings_serializers.py
+++ b/backend/core/admin_settings_serializers.py
@@ -484,6 +484,7 @@ class AdminPromptBlockSerializer(serializers.ModelSerializer):
             template = attrs.get("template", getattr(self.instance, "template", None) if self.instance else None)
             if template is None:
                 raise serializers.ValidationError({"template": "Este campo es requerido cuando scope es 'template'."})
+            attrs["industry"] = None
         elif scope == "industry":
             industry = attrs.get("industry", getattr(self.instance, "industry", None) if self.instance else None)
             if not industry:
@@ -554,6 +555,23 @@ class AdminIndustrySerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["created_by_ai", "status", "created_at", "updated_at"]
+
+    def validate(self, attrs):
+        # ``default_template`` debe pertenecer a esta industria (o no tener
+        # industria asignada — templates genéricos/compartidos). Evita asignar
+        # como default un template curado para otra industria.
+        template = attrs.get("default_template")
+        if template is not None and template.industry_id is not None:
+            current_id = self.instance.pk if self.instance else None
+            if template.industry_id != current_id:
+                raise serializers.ValidationError(
+                    {
+                        "default_template": (
+                            "El template debe pertenecer a esta industria o no tener industria asignada."
+                        )
+                    }
+                )
+        return attrs
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/admin_settings_views.py
+++ b/backend/core/admin_settings_views.py
@@ -416,6 +416,29 @@ class AdminIndustryDetailView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = AdminIndustrySerializer
     queryset = Industry.objects.select_related("default_template").order_by("sort_order", "label")
 
+    def destroy(self, request, *args, **kwargs):
+        """Bloquea el borrado físico si la industria está en uso.
+
+        En v1 ``Tenant.industry`` es un key libre (CharField, sin FK), así que
+        eliminar la fila dejaría a esos tenants apuntando a un key inexistente.
+        Mientras exista esa referencia se devuelve 409 y se sugiere desactivar
+        (``is_active=false``) en lugar de borrar.
+        """
+        from core.models import Tenant
+
+        instance = self.get_object()
+        if Tenant.objects.filter(industry=instance.key).exists():
+            return Response(
+                {
+                    "detail": (
+                        "No se puede eliminar una industria en uso por uno o más "
+                        "tenants. Desactívala (is_active=false) en lugar de borrarla."
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        return super().destroy(request, *args, **kwargs)
+
 
 class AdminIndustryPromoteView(APIView):
     """POST ``/api/admin/settings/industries/<int:pk>/promote/``.

--- a/backend/websites/migrations/0030_promptblock_industry_set_null.py
+++ b/backend/websites/migrations/0030_promptblock_industry_set_null.py
@@ -1,0 +1,34 @@
+"""Change ``PromptBlock.industry`` on_delete from CASCADE to SET_NULL.
+
+Issue #270 (CodeRabbit follow-up of PR #265): ``PromptBlock.industry`` is a
+classification relation (``null=True, blank=True``). With ``CASCADE``, deleting
+an industry silently deletes every prompt block scoped to it — losing curated
+content. ``SET_NULL`` keeps the prompt blocks and just clears the industry link,
+which matches the field already being optional.
+
+Schema-only change (``ALTER ... ON DELETE``); no data migration needed.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0029_seed_suggest_colors_config"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="promptblock",
+            name="industry",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="prompt_blocks",
+                to="websites.industry",
+                verbose_name="Industria",
+            ),
+        ),
+    ]

--- a/backend/websites/models.py
+++ b/backend/websites/models.py
@@ -923,7 +923,7 @@ class PromptBlock(models.Model):
     )
     industry = models.ForeignKey(
         "Industry",
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
         related_name="prompt_blocks",
         null=True,
         blank=True,

--- a/backend/websites/serializers.py
+++ b/backend/websites/serializers.py
@@ -385,7 +385,7 @@ class QuickStartSerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Telefono de contacto del negocio",
     )
-    industry_key = serializers.CharField(
+    industry_key = serializers.SlugField(
         max_length=50,
         required=False,
         allow_blank=True,
@@ -487,7 +487,7 @@ class SuggestColorsSerializer(serializers.Serializer):
         max_length=1000,
         help_text="Descripción del negocio (qué hace, a quién atiende)",
     )
-    industry_key = serializers.CharField(
+    industry_key = serializers.SlugField(
         max_length=50,
         required=False,
         allow_blank=True,

--- a/backend/websites/services/ai_service.py
+++ b/backend/websites/services/ai_service.py
@@ -371,11 +371,16 @@ Genera contenido profesional y atractivo basado en la información del negocio."
         task_config = self.get_model_for_task("web_content")
         model = task_config["model"]
         max_tokens = task_config["max_tokens"]
+        temperature = task_config["temperature"]
         self._last_model_used = model
 
         try:
             content_data, seo_data, tokens_input, tokens_output, response_text, selected_pages = self._call_generation(
-                model=model, system_prompt=system_prompt, user_prompt=user_prompt, max_tokens=max_tokens
+                model=model,
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
             )
 
             # Validación post-generación. Si hay problemas, reintentamos una
@@ -397,7 +402,11 @@ Genera contenido profesional y atractivo basado en la información del negocio."
                 try:
                     content_data2, seo_data2, tokens_in2, tokens_out2, response_text2, selected_pages2 = (
                         self._call_generation(
-                            model=model, system_prompt=system_prompt, user_prompt=retry_prompt, max_tokens=max_tokens
+                            model=model,
+                            system_prompt=system_prompt,
+                            user_prompt=retry_prompt,
+                            max_tokens=max_tokens,
+                            temperature=temperature,
                         )
                     )
                     tokens_input += tokens_in2
@@ -424,7 +433,12 @@ Genera contenido profesional y atractivo basado en la información del negocio."
             return (*self._mock_generate_content(template, onboarding_responses), "", "", [])
 
     def _call_generation(
-        self, model: str, system_prompt: str, user_prompt: str, max_tokens: int = 4096
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 4096,
+        temperature: float = 1.0,
     ) -> tuple[dict, dict, int, int, str, list[str]]:
         """
         Hace una llamada a Claude y parsea la respuesta JSON.
@@ -438,6 +452,7 @@ Genera contenido profesional y atractivo basado en la información del negocio."
         response = self.client.messages.create(
             model=model,
             max_tokens=max_tokens,
+            temperature=temperature,
             system=system_prompt,
             messages=[{"role": "user", "content": user_prompt}],
         )
@@ -533,6 +548,7 @@ Si el usuario hace una pregunta sin pedir cambios, responde solo con:
             response = self.client.messages.create(
                 model=task_config["model"],
                 max_tokens=min(task_config["max_tokens"], 2048),
+                temperature=task_config["temperature"],
                 system=system_prompt,
                 messages=messages,
             )
@@ -740,6 +756,7 @@ Responde SOLO con el JSON, sin explicaciones."""
             response = self.client.messages.create(
                 model=task_config["model"],
                 max_tokens=min(task_config["max_tokens"], 512),
+                temperature=task_config["temperature"],
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_prompt}],
             )

--- a/backend/websites/services/template_resolution.py
+++ b/backend/websites/services/template_resolution.py
@@ -40,8 +40,9 @@ def resolve_template_for_industry(industry_key: str | None) -> WebsiteTemplate |
 
     industry = Industry.objects.filter(key=key).select_related("default_template").first() if key else None
 
-    # 1. default_template de la industria clasificada.
-    if industry and industry.default_template_id and industry.default_template.is_active:
+    # 1. default_template de la industria clasificada (solo si la industria
+    #    está activa — una industria desactivada no debe resolver su template).
+    if industry and industry.is_active and industry.default_template_id and industry.default_template.is_active:
         return industry.default_template
 
     # 2. Mapeo vertical (wellness -> belleza-elegante, etc.).

--- a/backend/websites/views/classify.py
+++ b/backend/websites/views/classify.py
@@ -126,6 +126,15 @@ class ClassifyIndustryView(APIView):
             ai_service._last_model_used = model_config["model"]
         except Exception as e:
             logger.error("Error llamando a Claude para classify-industry: %s", e)
+            ai_service.log_generation(
+                generation_type="classify_industry",
+                tokens_input=0,
+                tokens_output=0,
+                is_successful=False,
+                error_message=f"Anthropic no disponible: {e}",
+                full_prompt=full_prompt,
+                raw_response="",
+            )
             return self._mock_classify(tenant, business_description, selected_modules, normalized, active_industries)
 
         try:
@@ -317,6 +326,13 @@ class ClassifyIndustryView(APIView):
             industry, created = Industry.objects.get_or_create(key=key, defaults=defaults)
             if created:
                 return industry, True, confidence
+            # La key ya existe. Si pertenece a la MISMA industria (mismo label
+            # normalizado), la reutilizamos en vez de crear una variante: esto
+            # deduplica requests concurrentes idénticos que crearon la fila
+            # entre nuestro snapshot de active_industries y este punto.
+            if _normalize(industry.label) == normalized:
+                return industry, False, confidence
+            # Key tomada por OTRA industria: probamos la siguiente variante.
             key = f"{base_key}-{suffix}"
             suffix += 1
 

--- a/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
@@ -1225,6 +1225,7 @@ export default function QuickStartPage() {
                             onChange={(e) => setCorrectionInput(e.target.value)}
                             onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); submitCorrection(); } }}
                             placeholder="Ej: Floristería, taller mecánico, estudio de tatuajes..."
+                            aria-label="Describe a qué se dedica tu negocio para reclasificar tu sector"
                             autoFocus
                             className="flex-1 min-w-[12rem] h-10 px-3.5 rounded-lg border text-[0.85rem] outline-none focus:ring-2"
                             style={{ borderColor: WARM_GRAY_200, backgroundColor: WARM_GRAY_50, color: WARM_GRAY_800 }}


### PR DESCRIPTION
### **User description**
## Resumen

Follow-up de los ~18 comentarios de CodeRabbit del PR #265 (issue #270). Fixes quirúrgicos de data-integrity, lógica de servicios, validación y accesibilidad sobre el catálogo de industrias. **No se modifica ninguna migración existente** (0021/0022 intactas); se agrega `0030`.

## Cambios

### 🟠 Data-integrity
- `PromptBlock.industry`: `CASCADE` → `SET_NULL` (relación de clasificación `null/blank`). Borrar una industria ya no elimina los prompt blocks. Migración **`0030`** (AlterField, schema-only).

### 🟠 Lógica / servicios
- `ai_service.py`: `temperature` (editable en `AIModelConfig`) ahora se propaga a Anthropic en **generación, chat y SEO** (antes solo `model` + `max_tokens`).
- `template_resolution.py`: el paso 1 ahora exige `industry.is_active` — una industria desactivada no resuelve su `default_template`.
- `classify.py`: el fallback cuando Anthropic cae ahora **loguea a `AIGenerationLog`** (`is_successful=False`).
- `classify.py`: **dedupe atómico** — bajo requests concurrentes idénticos se reutiliza la fila si el label normalizado coincide, en vez de crear variantes sufijadas (`cafeteria` + `cafeteria-2`).

### 🟡 Validación / contratos
- `AdminPromptBlockSerializer`: `scope=template` ahora limpia la FK `industry` (simétrico al branch `industry`).
- `AdminIndustrySerializer`: valida que `default_template` pertenezca a la misma industria (o sin industria).
- `industry_key`: `CharField` → `SlugField` (contrato slug, max 50).
- `AdminIndustryDetailView`: bloquea borrado físico con **409** si algún `Tenant` referencia la industria (key libre en v1); sugiere desactivar.

### 🟡 Accesibilidad
- `quick-start/page.tsx`: `aria-label` en el input de corrección de industria.

## Diferido / fuera de alcance
- **Reverse de `0022` borra el catálogo**: el reverse problemático vive dentro de `0022` y la regla del proyecto prohíbe modificar migraciones existentes; una migración nueva no puede interceptar el reverse de una vieja. Los reverse-migrations son de dev (no corren en prod) → **se documenta como limitación conocida v1**.
- **`AIModelsTab.tsx`**: no existe en `develop` (se reestructuró el panel admin en #265) → sin objeto.

## Test plan
- [ ] CI backend: Ruff lint + format (verde local) + Pytest
- [ ] CI frontend: ESLint + build
- [ ] Verificar `0030` aplica limpio (`makemigrations --check`)
- [ ] Smoke: borrar industria en uso → 409; desactivar industria → su template no se resuelve

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Mejora la integridad de datos de industrias.

- Propaga el parámetro `temperature` a la API de IA.

- Refuerza la resolución de plantillas por industria.

- Mejora el registro de fallos y deduplicación de IA.

- Añade validaciones y bloquea borrado de industrias.

- Mejora la accesibilidad en el Quick Start.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Accessibility</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>page.tsx</strong><dd><code>Añade `aria-label` al input de corrección de industria.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-31abaab252e7eb27824ed75c3ebfe7b6f56c81de31685d994b5a9e90f4193339">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Validation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>admin_settings_serializers.py</strong><dd><code>Mejora la validación de `PromptBlock` e `Industry` en el admin.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-74deab7e8d03e2741611c338f99518f17d6207a5b0de67c2ca2d6055304afef4">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Convierte `industry_key` a `SlugField` en serializadores.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-94f0f5b4e96608ced7752e206cab102e746384eadbbc8168ad262237ccd233b4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>admin_settings_views.py</strong><dd><code>Bloquea el borrado de industrias en uso por tenants.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-99f7d351bdfea21bf1930f6887d0929295e638e46e3ca3c788dec17f9091f0f8">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Data migration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0030_promptblock_industry_set_null.py</strong><dd><code>Nueva migración para cambiar <code>on_delete</code> de <code>PromptBlock.industry</code> a <br><code>SET_NULL</code>.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-907547f79156f651488850bd909e01e732a2197c54e8db0f2af700f57dc9badc">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Data integrity</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>models.py</strong><dd><code>Actualiza `on_delete` de `PromptBlock.industry` a `SET_NULL`.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-8d588ffaf3e82dce7a29be70522fd161e3ee28a99b95e2e9b5ba7ee1f08a99a3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ai_service.py</strong><dd><code>Propaga el parámetro `temperature` a las llamadas a la API de IA.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-c312c69b669fee407d4a437d7587e004daec750dda1df4e5b8fd5544ebb4fcac">+20/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>template_resolution.py</strong><dd><code>Asegura que la resolución de plantillas respete `industry.is_active`.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-a070ac2af41f4ac5820be28af8853ce55a0df302ad4239a69acb7c660887e88b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>classify.py</strong><dd><code>Mejora el registro de fallos y la deduplicación de industrias.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/286/files#diff-791367a87da1c18d439f07b682813c1c1a28bb08becb0dae7a5c7019aa138e37">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

