### PR TITLE
fix(websites): robustez de estado en el onboarding de pipe

### DIFF
--- a/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
@@ -948,7 +948,7 @@ export default function QuickStartPage() {
         >
           {header}
           <div className="flex-1 flex items-center justify-center">
-            <div className="flex gap-1.5">
+            <div className="flex gap-1.5" role="status" aria-live="polite" aria-label="Cargando">
               {[0, 1, 2].map((i) => (
                 <div
                   key={i}

--- a/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
+++ b/frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx
@@ -332,6 +332,17 @@ export default function QuickStartPage() {
     } catch { /* corrupted storage — start fresh */ }
   }, []);
 
+  // ─── Clamp restored index once steps load ──────────────────
+  // `steps` se carga async desde el API, así que el índice restaurado de
+  // sessionStorage puede quedar fuera de rango (negocio sin servicios = menos
+  // pasos, catálogo de pasos cambiado entre sesiones, etc.). Sin este clamp,
+  // `steps[currentStepIdx]` sería undefined y el render crashearía con
+  // "Cannot read properties of undefined (reading 'message')".
+  useEffect(() => {
+    if (steps.length === 0) return;
+    setCurrentStepIdx((prev) => Math.min(prev, steps.length - 1));
+  }, [steps.length]);
+
   // ─── Persist state to sessionStorage on changes ────────────
   useEffect(() => {
     if (pageState !== 'chat') return;
@@ -529,13 +540,26 @@ export default function QuickStartPage() {
     sections: Set<string>,
     industryKey?: string,
   ) => {
+    // Validación pre-POST: `business_description` es el único campo obligatorio
+    // del serializer (main_services ya es opcional). Si un estado restaurado
+    // incompleto lo dejó vacío, el POST a quick-start/ devolvería un 400 genérico
+    // y el polling un 404 (nunca se creó el WebsiteConfig). En vez de eso,
+    // regresamos al paso de descripción con un mensaje amable.
+    const businessDescription = (answersData.description || answersData.pipe_description || '').trim();
+    if (!businessDescription) {
+      const descIdx = steps.findIndex((s) => s.id?.includes('description'));
+      if (descIdx >= 0) setCurrentStepIdx(descIdx);
+      toast.error('Cuéntame primero sobre tu negocio para poder generar tu sitio.');
+      return;
+    }
+
     setPageState('generating');
     setGenStep(0);
     setProgress(0);
     setTimeout(() => {
       triggerQuickStartGeneration(answersData, sections, industryKey || undefined);
     }, 100);
-  }, [triggerQuickStartGeneration]);
+  }, [triggerQuickStartGeneration, steps]);
 
   // User confirmed the detected sector. Option 1: classification is decoupled
   // from generation, so confirming just records the decision (feeding NERBIS'
@@ -910,6 +934,38 @@ export default function QuickStartPage() {
   // ─── CHAT STATE — Claude-style AI Chat ──────────────────
   if (pageState === 'chat') {
     const step = steps[currentStepIdx];
+
+    // Guarda de crash: `steps` carga async y `currentStepIdx` puede provenir de
+    // sessionStorage, por lo que `step` puede ser undefined transitoriamente.
+    // Sin esta guarda, `step.message`/`step.type` más abajo crashearían con
+    // "Cannot read properties of undefined (reading 'message')". Mostramos un
+    // loader hasta que el paso esté disponible (el effect de clamp lo corrige).
+    if (!step) {
+      return (
+        <div
+          className="h-screen flex flex-col font-[family-name:var(--font-geist-sans)]"
+          style={{ backgroundColor: WARM_GRAY_50 }}
+        >
+          {header}
+          <div className="flex-1 flex items-center justify-center">
+            <div className="flex gap-1.5">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="w-2 h-2 rounded-full animate-bounce"
+                  style={{
+                    backgroundColor: WARM_GRAY_400,
+                    animationDelay: `${i * 150}ms`,
+                    animationDuration: '0.8s',
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     const minLen = step?.minLength || 0;
     const canSend = step?.type === 'modules'
       ? selectedModules.size > 0


### PR DESCRIPTION
### **User description**
## Resumen

Corrige los bugs de estado del onboarding de Pipe (quick-start) reportados en #282, que causaban un crash de la página y un 400 silencioso (+ 404 posterior en el polling) cuando el estado restaurado de `sessionStorage` quedaba incompleto o fuera de rango.

Cambios en `quick-start/page.tsx`:

- **Guarda de crash en el render**: si `steps[currentStepIdx]` es `undefined` (los `steps` cargan async desde el API), muestra un loader en vez de crashear con `Cannot read properties of undefined (reading 'message')`.
- **Clamp del índice restaurado**: nuevo effect que ajusta `currentStepIdx` a `steps.length - 1` cuando los pasos cargan, evitando índices persistidos fuera de rango sin perder progreso.
- **Validación pre-POST de `business_description`**: si está vacío (estado incompleto), vuelve al paso de descripción con un toast amable en vez de disparar un POST que devolvería 400 y dejaría el polling en 404.

## Contexto

- El control de `has_services` (hacer `main_services` opcional en el serializer) **ya quedó resuelto en backend por #283**, así que este PR cubre solo la parte de robustez de frontend del issue.
- Bug preexistente en `develop`, no introducido por #280.

## Test plan

- [x] `eslint` pasa (0 errores; 3 warnings preexistentes ajenos al cambio)
- [x] Camino feliz: onboarding completo genera el sitio normalmente
- [ ] Prueba A: `currentStepIdx` fuera de paso + `answers` vacío → toast "Cuéntame primero sobre tu negocio…" y vuelve al paso de descripción (sin 400/404)
- [ ] Prueba B: `currentStepIdx = 99` → loader sin crash; el índice se autoajusta al último paso válido

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Evita crashes por índice de paso fuera de rango.

- Muestra un loader si los pasos cargan asíncronamente.

- Valida la descripción del negocio antes de enviar.

- Mejora la experiencia de usuario con mensajes amigables.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Mejora la robustez del estado y la validación en el onboarding</code></dd></summary>
<hr>

frontend/src/app/(tenant)/dashboard/website-builder/quick-start/page.tsx

<ul><li>Añade un <code>useEffect</code> para ajustar el índice de paso (<code>currentStepIdx</code>) <br>restaurado, evitando errores de rango si los pasos cambian o se <br>restauran incompletos.<br> <li> Implementa una validación previa al envío para <code>business_description</code>, <br>redirigiendo al paso correspondiente y mostrando un mensaje amigable <br>si está vacío.<br> <li> Incorpora una guarda de crash en el render del chat para manejar casos <br>donde el paso actual (<code>step</code>) es <code>undefined</code> debido a la carga asíncrona, <br>mostrando un loader.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/288/files#diff-31abaab252e7eb27824ed75c3ebfe7b6f56c81de31685d994b5a9e90f4193339">+57/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

