### PR TITLE
feat(billing): api de ciclo de vida de suscripción (B1 #291)

### DIFF
--- a/backend/billing/serializers.py
+++ b/backend/billing/serializers.py
@@ -1,0 +1,205 @@
+# backend/billing/serializers.py
+"""
+Serializers de billing para la API de ciclo de vida de suscripciones (B1).
+
+Reglas multi-tenancy:
+- NUNCA exponer ``tenant``/``tenant_id`` ni el UUID de la suscripcion.
+- La suscripcion se resuelve siempre via ``request.tenant.subscription``;
+  el cliente nunca envia un id de tenant/suscripcion.
+"""
+
+from rest_framework import serializers
+
+from .models import Module, Subscription, SubscriptionModule
+
+# Periodos de facturacion validos (espejo de Subscription.BILLING_PERIOD_CHOICES).
+_BILLING_PERIODS = ("monthly", "yearly")
+
+
+# ===================================
+# READ SERIALIZERS
+# ===================================
+
+
+class ModuleSerializer(serializers.ModelSerializer):
+    """Item del catalogo global de modulos (sin datos de tenant)."""
+
+    yearly_price = serializers.ReadOnlyField()
+    annual_savings = serializers.ReadOnlyField()
+
+    class Meta:
+        model = Module
+        fields = [
+            "slug",
+            "name",
+            "description",
+            "icon",
+            "is_base",
+            "monthly_price",
+            "yearly_price",
+            "annual_discount_months",
+            "annual_savings",
+            "included_appointments",
+            "included_employees",
+            "included_products",
+            "included_services",
+            "included_sms",
+            "included_whatsapp",
+            "included_storage_gb",
+            "included_ai_requests",
+            "extra_appointment_price",
+            "extra_employee_price",
+            "extra_product_price",
+            "extra_sms_price",
+            "extra_whatsapp_price",
+            "extra_storage_price",
+            "extra_ai_request_price",
+            "has_analytics",
+            "has_api_access",
+            "sort_order",
+        ]
+
+
+class SubscriptionModuleSerializer(serializers.ModelSerializer):
+    """Modulo activo de una suscripcion (anidado, sin ids sensibles)."""
+
+    slug = serializers.CharField(source="module.slug", read_only=True)
+    name = serializers.CharField(source="module.name", read_only=True)
+    icon = serializers.CharField(source="module.icon", read_only=True)
+    is_base = serializers.BooleanField(source="module.is_base", read_only=True)
+    current_price = serializers.ReadOnlyField()
+
+    class Meta:
+        model = SubscriptionModule
+        fields = [
+            "slug",
+            "name",
+            "icon",
+            "is_base",
+            "price_locked",
+            "current_price",
+            "is_active",
+            "activated_at",
+        ]
+
+
+class SubscriptionSerializer(serializers.ModelSerializer):
+    """
+    Estado de la suscripcion del tenant (lectura).
+
+    NO expone ``id`` ni ``tenant``. Incluye derivados, modulos activos,
+    pricing, usage y el flag ``cancels_at_period_end``.
+    """
+
+    status_display = serializers.CharField(source="get_status_display", read_only=True)
+    billing_period_display = serializers.CharField(source="get_billing_period_display", read_only=True)
+    is_trial = serializers.ReadOnlyField()
+    is_active = serializers.ReadOnlyField()
+    days_remaining = serializers.ReadOnlyField()
+    trial_days_remaining = serializers.ReadOnlyField()
+    cancels_at_period_end = serializers.SerializerMethodField()
+    modules = serializers.SerializerMethodField()
+    pricing = serializers.SerializerMethodField()
+    usage = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Subscription
+        fields = [
+            "status",
+            "status_display",
+            "billing_period",
+            "billing_period_display",
+            "started_at",
+            "current_period_start",
+            "current_period_end",
+            "trial_ends_at",
+            "canceled_at",
+            "is_trial",
+            "is_active",
+            "days_remaining",
+            "trial_days_remaining",
+            "cancels_at_period_end",
+            "modules",
+            "pricing",
+            "usage",
+            "has_custom_domain",
+            "has_priority_support",
+            "has_white_label",
+            "extra_employees",
+        ]
+
+    def get_cancels_at_period_end(self, obj) -> bool:
+        """True si hay una cancelacion diferida pendiente (status sigue activo)."""
+        return obj.canceled_at is not None and obj.status == "active"
+
+    def get_modules(self, obj) -> list[dict]:
+        active = obj.subscription_modules.filter(is_active=True)
+        return SubscriptionModuleSerializer(active, many=True).data
+
+    def get_pricing(self, obj) -> dict[str, str]:
+        return {
+            "monthly_total": str(obj.monthly_total),
+            "yearly_total": str(obj.yearly_total),
+            "current_period_price": str(obj.current_period_price),
+        }
+
+    def get_usage(self, obj) -> dict[str, dict]:
+        # Snapshot ligero: solo limites derivados de get_limit (no usar
+        # UsageTracker/InvoiceGenerator que referencian subscription.plan).
+        resources = ["appointments", "employees", "sms", "whatsapp", "ai_requests"]
+        snapshot: dict[str, dict] = {}
+        for resource in resources:
+            snapshot[resource] = {"current": 0, "limit": obj.get_limit(resource)}
+        return snapshot
+
+
+# ===================================
+# INPUT SERIALIZERS
+# ===================================
+
+
+def _validate_active_slugs(slugs: list[str]) -> list[str]:
+    """Valida que cada slug exista y este activo; si no, ValidationError 400."""
+    for slug in slugs:
+        if not Module.objects.filter(slug=slug, is_active=True).exists():
+            raise serializers.ValidationError(f"Modulo invalido o no disponible: {slug}")
+    return slugs
+
+
+class SubscribeInputSerializer(serializers.Serializer):
+    """Entrada de POST /subscription/subscribe/."""
+
+    module_slugs = serializers.ListField(child=serializers.CharField(), allow_empty=False)
+    billing_period = serializers.ChoiceField(choices=_BILLING_PERIODS, default="monthly")
+
+    def validate_module_slugs(self, value: list[str]) -> list[str]:
+        return _validate_active_slugs(value)
+
+
+class ModulesInputSerializer(serializers.Serializer):
+    """Entrada de POST /subscription/modules/ (add/remove)."""
+
+    add = serializers.ListField(child=serializers.CharField(), required=False, default=list)
+    remove = serializers.ListField(child=serializers.CharField(), required=False, default=list)
+
+    def validate_add(self, value: list[str]) -> list[str]:
+        return _validate_active_slugs(value)
+
+    def validate(self, attrs: dict) -> dict:
+        add = attrs.get("add", [])
+        remove = attrs.get("remove", [])
+        if not add and not remove:
+            raise serializers.ValidationError("Debes especificar al menos un modulo en 'add' o 'remove'.")
+        return attrs
+
+
+class BillingPeriodInputSerializer(serializers.Serializer):
+    """Entrada de POST /subscription/billing-period/."""
+
+    billing_period = serializers.ChoiceField(choices=_BILLING_PERIODS)
+
+
+class CancelInputSerializer(serializers.Serializer):
+    """Entrada de POST /subscription/cancel/."""
+
+    at_period_end = serializers.BooleanField(default=True)

--- a/backend/billing/services.py
+++ b/backend/billing/services.py
@@ -433,6 +433,48 @@ class SubscriptionManager:
         return subscription
 
     @staticmethod
+    def activate_subscription(subscription, module_slugs, billing_period="monthly"):
+        """
+        Activa una suscripcion modular (NO usa el Plan deprecado).
+
+        - status -> 'active'
+        - Honra trial: si esta en trial y trial_ends_at es futuro, el periodo
+          pagado arranca en trial_ends_at; si no, arranca ahora.
+        - current_period_end = inicio + 365d (yearly) / 30d (monthly)
+        - billing_period seteado
+        - canceled_at = None  (deshace cancelacion diferida)
+        - activa cada modulo en module_slugs via add_module()
+        - save() dispara el signal que re-sincroniza tenant.has_*
+
+        Args:
+            subscription: Subscription instance
+            module_slugs: list[str] de slugs a activar (ya validados por el serializer)
+            billing_period: 'monthly' o 'yearly'
+
+        Returns:
+            Subscription instance actualizada
+        """
+        now = timezone.now()
+        if subscription.is_trial and subscription.trial_ends_at and subscription.trial_ends_at > now:
+            start = subscription.trial_ends_at
+        else:
+            start = now
+
+        subscription.status = "active"
+        subscription.billing_period = billing_period
+        subscription.current_period_start = start
+        subscription.current_period_end = start + timedelta(days=365 if billing_period == "yearly" else 30)
+        subscription.canceled_at = None
+        # trial_ends_at se conserva (historico); is_active ya es True por status
+
+        for slug in module_slugs:
+            subscription.add_module(slug)  # idempotente, reactiva si estaba inactivo
+
+        subscription.save()
+        logger.info(f"Suscripcion activada para {subscription.tenant.name} ({billing_period})")
+        return subscription
+
+    @staticmethod
     def upgrade_plan(subscription, new_plan_slug, billing_period="monthly"):
         """
         Actualiza el plan de una suscripción.

--- a/backend/billing/services.py
+++ b/backend/billing/services.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from decimal import Decimal
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
@@ -454,23 +455,24 @@ class SubscriptionManager:
         Returns:
             Subscription instance actualizada
         """
-        now = timezone.now()
-        if subscription.is_trial and subscription.trial_ends_at and subscription.trial_ends_at > now:
-            start = subscription.trial_ends_at
-        else:
-            start = now
+        with transaction.atomic():
+            now = timezone.now()
+            if subscription.is_trial and subscription.trial_ends_at and subscription.trial_ends_at > now:
+                start = subscription.trial_ends_at
+            else:
+                start = now
 
-        subscription.status = "active"
-        subscription.billing_period = billing_period
-        subscription.current_period_start = start
-        subscription.current_period_end = start + timedelta(days=365 if billing_period == "yearly" else 30)
-        subscription.canceled_at = None
-        # trial_ends_at se conserva (historico); is_active ya es True por status
+            subscription.status = "active"
+            subscription.billing_period = billing_period
+            subscription.current_period_start = start
+            subscription.current_period_end = start + timedelta(days=365 if billing_period == "yearly" else 30)
+            subscription.canceled_at = None
+            # trial_ends_at se conserva (historico); is_active ya es True por status
 
-        for slug in module_slugs:
-            subscription.add_module(slug)  # idempotente, reactiva si estaba inactivo
+            for slug in module_slugs:
+                subscription.add_module(slug)  # idempotente, reactiva si estaba inactivo
 
-        subscription.save()
+            subscription.save()
         logger.info(f"Suscripcion activada para {subscription.tenant.name} ({billing_period})")
         return subscription
 

--- a/backend/billing/tests.py
+++ b/backend/billing/tests.py
@@ -540,18 +540,18 @@ class TestMiddlewareExemption:
     def test_exempt_paths_pass_when_inactive(self, tenant, admin_user):
         self._inactive_tenant(tenant)
         for path in (
-            "/api/billing/modules/",
-            "/api/billing/subscription/",
-            "/api/billing/subscription/subscribe/",
-            "/api/billing/subscription/modules/",
-            "/api/billing/subscription/billing-period/",
+            "/api/v1/billing/modules/",
+            "/api/v1/billing/subscription/",
+            "/api/v1/billing/subscription/subscribe/",
+            "/api/v1/billing/subscription/modules/",
+            "/api/v1/billing/subscription/billing-period/",
         ):
             assert self._run(path, tenant, admin_user) is True, path
 
     def test_cancel_path_gated_when_inactive(self, tenant, admin_user):
         self._inactive_tenant(tenant)
         # Cancel NO esta exento: el gate debe bloquear (no pasa).
-        assert self._run("/api/billing/subscription/cancel/", tenant, admin_user) is False
+        assert self._run("/api/v1/billing/subscription/cancel/", tenant, admin_user) is False
 
     def test_non_billing_api_gated_when_inactive(self, tenant, admin_user):
         self._inactive_tenant(tenant)
@@ -560,5 +560,5 @@ class TestMiddlewareExemption:
     def test_billing_paths_pass_when_active(self, tenant, admin_user):
         # Suscripcion activa: nada se bloquea (incluido cancel).
         assert tenant.is_subscription_active is True
-        assert self._run("/api/billing/subscription/cancel/", tenant, admin_user) is True
+        assert self._run("/api/v1/billing/subscription/cancel/", tenant, admin_user) is True
         assert self._run("/api/products/", tenant, admin_user) is True

--- a/backend/billing/tests.py
+++ b/backend/billing/tests.py
@@ -1,1 +1,564 @@
-# Create your tests here.
+# backend/billing/tests.py
+"""
+Tests de la API de ciclo de vida de suscripciones (B1 / Issue #291).
+
+Cubre: catalogo de modulos, estado de suscripcion, subscribe (con honor-trial),
+add/remove de modulos, cambio de periodo de facturacion, cancel (inmediata,
+diferida e idempotente), aislamiento multi-tenant, limites de permisos y
+exencion del SubscriptionMiddleware para rutas de reactivacion.
+
+La suscripcion y el modulo base 'web' se crean por signals al crear el Tenant.
+Los modulos del catalogo (web/shop/bookings/services/marketing) se siembran por
+las migraciones 0007/0010.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from billing.models import Module, Subscription
+
+pytestmark = pytest.mark.django_db
+
+
+# ===================================
+# HELPERS
+# ===================================
+
+
+def _sub(tenant) -> Subscription:
+    """Refresca y devuelve la suscripcion (singleton) del tenant."""
+    return Subscription.objects.get(tenant=tenant)
+
+
+def _make_active(subscription, billing_period="monthly", days=30):
+    """Pone la suscripcion en estado active con un periodo vigente."""
+    now = timezone.now()
+    subscription.status = "active"
+    subscription.billing_period = billing_period
+    subscription.current_period_start = now
+    subscription.current_period_end = now + timedelta(days=days)
+    subscription.canceled_at = None
+    subscription.save()
+    return subscription
+
+
+def _client_for(tenant, user):
+    """Construye un APIClient JWT-autenticado para un (tenant, user) dado."""
+    from rest_framework.test import APIClient
+    from rest_framework_simplejwt.tokens import RefreshToken
+
+    refresh = RefreshToken.for_user(user)
+    refresh["tenant_id"] = str(tenant.id)
+    refresh["tenant_slug"] = tenant.slug
+    refresh["role"] = user.role
+    client = APIClient()
+    client.defaults["HTTP_X_TENANT_SLUG"] = tenant.slug
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+    return client
+
+
+def _catalog(response) -> list[dict]:
+    """Devuelve la lista de modulos del catalogo (DRF pagina con PageNumberPagination)."""
+    body = response.json()
+    return body["results"] if isinstance(body, dict) and "results" in body else body
+
+
+# ===================================
+# CATALOGO DE MODULOS
+# ===================================
+
+
+class TestModuleCatalog:
+    def test_lists_active_visible_modules_ordered(self, auth_admin_client):
+        url = reverse("billing:module-list")
+        response = auth_admin_client.get(url)
+        assert response.status_code == 200
+        data = _catalog(response)
+        slugs = [m["slug"] for m in data]
+        assert "web" in slugs
+        # Ordenado por sort_order (web=0 primero).
+        sort_orders = [m["sort_order"] for m in data]
+        assert sort_orders == sorted(sort_orders)
+        # Cada entrada trae los campos clave (sin datos de tenant).
+        first = data[0]
+        for key in ("slug", "name", "monthly_price", "yearly_price", "is_base"):
+            assert key in first
+
+    def test_excludes_inactive_and_hidden(self, auth_admin_client):
+        Module.objects.filter(slug="shop").update(is_active=False)
+        Module.objects.filter(slug="marketing").update(is_visible=False)
+        response = auth_admin_client.get(reverse("billing:module-list"))
+        assert response.status_code == 200
+        slugs = [m["slug"] for m in _catalog(response)]
+        assert "shop" not in slugs
+        assert "marketing" not in slugs
+
+    def test_catalog_identical_across_tenants(self, auth_admin_client, second_tenant, second_tenant_admin):
+        client_b = _client_for(second_tenant, second_tenant_admin)
+        a = _catalog(auth_admin_client.get(reverse("billing:module-list")))
+        b = _catalog(client_b.get(reverse("billing:module-list")))
+        assert [m["slug"] for m in a] == [m["slug"] for m in b]
+
+    def test_unauthenticated_rejected(self, api_client):
+        response = api_client.get(reverse("billing:module-list"))
+        assert response.status_code == 401
+
+
+# ===================================
+# ESTADO DE SUSCRIPCION (GET)
+# ===================================
+
+
+class TestSubscriptionStatus:
+    def test_returns_status_without_ids(self, auth_admin_client, tenant):
+        response = auth_admin_client.get(reverse("billing:subscription-detail"))
+        assert response.status_code == 200
+        data = response.json()
+        for key in (
+            "status",
+            "billing_period",
+            "current_period_start",
+            "current_period_end",
+            "days_remaining",
+            "modules",
+            "pricing",
+            "usage",
+            "cancels_at_period_end",
+        ):
+            assert key in data
+        # Nunca exponer ids sensibles.
+        assert "id" not in data
+        assert "tenant" not in data
+        assert "tenant_id" not in data
+
+    def test_trial_subscription_reports_trial(self, auth_admin_client, tenant):
+        response = auth_admin_client.get(reverse("billing:subscription-detail"))
+        data = response.json()
+        assert data["status"] == "trial"
+        assert data["is_trial"] is True
+        assert data["is_active"] is True
+
+    def test_deferred_cancel_surfaced(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant))
+        sub.canceled_at = sub.current_period_end
+        sub.save()
+        data = auth_admin_client.get(reverse("billing:subscription-detail")).json()
+        assert data["status"] == "active"
+        assert data["cancels_at_period_end"] is True
+
+    def test_no_pending_cancel_reports_false(self, auth_admin_client, tenant):
+        _make_active(_sub(tenant))
+        data = auth_admin_client.get(reverse("billing:subscription-detail")).json()
+        assert data["cancels_at_period_end"] is False
+
+
+# ===================================
+# SUBSCRIBE (POST)
+# ===================================
+
+
+class TestSubscribe:
+    def test_subscribe_during_trial_honors_trial(self, auth_admin_client, tenant):
+        sub = _sub(tenant)
+        assert sub.status == "trial"
+        trial_end = sub.trial_ends_at
+        url = reverse("billing:subscription-subscribe")
+        response = auth_admin_client.post(url, {"module_slugs": ["shop"], "billing_period": "monthly"}, format="json")
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.status == "active"
+        assert sub.current_period_start == trial_end
+        assert sub.current_period_end == trial_end + timedelta(days=30)
+        assert sub.has_module("shop")
+
+    def test_subscribe_yearly_during_trial(self, auth_admin_client, tenant):
+        sub = _sub(tenant)
+        trial_end = sub.trial_ends_at
+        response = auth_admin_client.post(
+            reverse("billing:subscription-subscribe"),
+            {"module_slugs": ["shop"], "billing_period": "yearly"},
+            format="json",
+        )
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.current_period_end == trial_end + timedelta(days=365)
+
+    def test_subscribe_after_trial_starts_now(self, auth_admin_client, tenant):
+        sub = _sub(tenant)
+        sub.trial_ends_at = timezone.now() - timedelta(days=1)
+        sub.status = "expired"
+        sub.save()
+        before = timezone.now()
+        response = auth_admin_client.post(
+            reverse("billing:subscription-subscribe"),
+            {"module_slugs": ["shop"], "billing_period": "monthly"},
+            format="json",
+        )
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.status == "active"
+        assert sub.current_period_start >= before
+        assert sub.current_period_end <= timezone.now() + timedelta(days=31)
+
+    def test_subscribe_clears_pending_cancel(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant))
+        sub.canceled_at = sub.current_period_end
+        sub.save()
+        auth_admin_client.post(
+            reverse("billing:subscription-subscribe"),
+            {"module_slugs": ["shop"]},
+            format="json",
+        )
+        sub.refresh_from_db()
+        assert sub.canceled_at is None
+        data = auth_admin_client.get(reverse("billing:subscription-detail")).json()
+        assert data["cancels_at_period_end"] is False
+
+    def test_non_admin_cannot_subscribe(self, auth_customer_client):
+        response = auth_customer_client.post(
+            reverse("billing:subscription-subscribe"),
+            {"module_slugs": ["shop"]},
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_unknown_slug_rejected(self, auth_admin_client, tenant):
+        sub = _sub(tenant)
+        status_before = sub.status
+        response = auth_admin_client.post(
+            reverse("billing:subscription-subscribe"),
+            {"module_slugs": ["nonexistent"]},
+            format="json",
+        )
+        assert response.status_code == 400
+        sub.refresh_from_db()
+        assert sub.status == status_before
+
+
+# ===================================
+# ADD / REMOVE MODULOS (POST)
+# ===================================
+
+
+class TestModules:
+    def test_add_module_syncs_flag(self, auth_admin_client, tenant):
+        _make_active(_sub(tenant))
+        response = auth_admin_client.post(
+            reverse("billing:subscription-modules"),
+            {"add": ["bookings"]},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert _sub(tenant).has_module("bookings")
+        tenant.refresh_from_db()
+        assert tenant.has_bookings is True
+
+    def test_remove_non_base_module(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant))
+        sub.add_module("shop")
+        response = auth_admin_client.post(
+            reverse("billing:subscription-modules"),
+            {"remove": ["shop"]},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert not _sub(tenant).has_module("shop")
+        # Historial preservado (soft-deactivation).
+        assert sub.subscription_modules.filter(module__slug="shop").exists()
+
+    def test_cannot_remove_base_web(self, auth_admin_client, tenant):
+        _make_active(_sub(tenant))
+        response = auth_admin_client.post(
+            reverse("billing:subscription-modules"),
+            {"remove": ["web"]},
+            format="json",
+        )
+        assert response.status_code == 409
+        assert _sub(tenant).has_module("web")
+
+    def test_remove_slug_not_on_subscription(self, auth_admin_client, tenant):
+        _make_active(_sub(tenant))
+        response = auth_admin_client.post(
+            reverse("billing:subscription-modules"),
+            {"remove": ["bookings"]},
+            format="json",
+        )
+        assert response.status_code == 404
+
+    def test_unknown_add_slug_rejected(self, auth_admin_client, tenant):
+        _make_active(_sub(tenant))
+        response = auth_admin_client.post(
+            reverse("billing:subscription-modules"),
+            {"add": ["nonexistent"]},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    def test_non_admin_cannot_mutate_modules(self, auth_customer_client):
+        response = auth_customer_client.post(
+            reverse("billing:subscription-modules"),
+            {"add": ["shop"]},
+            format="json",
+        )
+        assert response.status_code == 403
+
+
+# ===================================
+# CAMBIO DE PERIODO (POST)
+# ===================================
+
+
+class TestBillingPeriod:
+    def test_switch_monthly_to_yearly_keeps_dates(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant), billing_period="monthly")
+        end_before = sub.current_period_end
+        response = auth_admin_client.post(
+            reverse("billing:subscription-billing-period"),
+            {"billing_period": "yearly"},
+            format="json",
+        )
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.billing_period == "yearly"
+        assert sub.current_period_end == end_before
+
+    def test_same_value_is_noop_200(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant), billing_period="monthly")
+        end_before = sub.current_period_end
+        response = auth_admin_client.post(
+            reverse("billing:subscription-billing-period"),
+            {"billing_period": "monthly"},
+            format="json",
+        )
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.billing_period == "monthly"
+        assert sub.current_period_end == end_before
+
+    def test_invalid_period_rejected(self, auth_admin_client, tenant):
+        _make_active(_sub(tenant))
+        response = auth_admin_client.post(
+            reverse("billing:subscription-billing-period"),
+            {"billing_period": "weekly"},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    def test_non_admin_cannot_switch(self, auth_customer_client):
+        response = auth_customer_client.post(
+            reverse("billing:subscription-billing-period"),
+            {"billing_period": "yearly"},
+            format="json",
+        )
+        assert response.status_code == 403
+
+
+# ===================================
+# CANCEL (POST)
+# ===================================
+
+
+class TestCancel:
+    def test_deferred_cancel_keeps_active(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant))
+        end = sub.current_period_end
+        response = auth_admin_client.post(
+            reverse("billing:subscription-cancel"),
+            {"at_period_end": True},
+            format="json",
+        )
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.status == "active"
+        assert sub.canceled_at == end
+        data = auth_admin_client.get(reverse("billing:subscription-detail")).json()
+        assert data["cancels_at_period_end"] is True
+
+    def test_immediate_cancel_deactivates(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant))
+        sub.add_module("shop")
+        response = auth_admin_client.post(
+            reverse("billing:subscription-cancel"),
+            {"at_period_end": False},
+            format="json",
+        )
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.status == "canceled"
+        tenant.refresh_from_db()
+        assert tenant.has_shop is False
+
+    def test_double_deferred_cancel_idempotent_200(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant))
+        auth_admin_client.post(reverse("billing:subscription-cancel"), {"at_period_end": True}, format="json")
+        sub.refresh_from_db()
+        first_canceled_at = sub.canceled_at
+        response = auth_admin_client.post(
+            reverse("billing:subscription-cancel"), {"at_period_end": True}, format="json"
+        )
+        assert response.status_code == 200
+        sub.refresh_from_db()
+        assert sub.status == "active"
+        assert sub.canceled_at == first_canceled_at
+
+    def test_resubscribe_undoes_deferred_cancel(self, auth_admin_client, tenant):
+        sub = _make_active(_sub(tenant))
+        auth_admin_client.post(reverse("billing:subscription-cancel"), {"at_period_end": True}, format="json")
+        auth_admin_client.post(
+            reverse("billing:subscription-subscribe"),
+            {"module_slugs": ["shop"]},
+            format="json",
+        )
+        sub.refresh_from_db()
+        assert sub.canceled_at is None
+        assert sub.status == "active"
+
+    def test_non_admin_cannot_cancel(self, auth_customer_client):
+        response = auth_customer_client.post(
+            reverse("billing:subscription-cancel"),
+            {"at_period_end": True},
+            format="json",
+        )
+        assert response.status_code == 403
+
+
+# ===================================
+# AISLAMIENTO MULTI-TENANT
+# ===================================
+
+
+class TestTenantIsolation:
+    def test_a_reads_only_own_subscription(self, auth_admin_client, tenant, second_tenant):
+        _make_active(_sub(tenant), billing_period="yearly")
+        _make_active(_sub(second_tenant), billing_period="monthly")
+        data = auth_admin_client.get(reverse("billing:subscription-detail")).json()
+        assert data["billing_period"] == "yearly"
+        assert "id" not in data and "tenant" not in data
+
+    def test_a_mutation_does_not_touch_b(self, auth_admin_client, tenant, second_tenant):
+        _make_active(_sub(tenant))
+        b_before = _make_active(_sub(second_tenant))
+        b_end_before = b_before.current_period_end
+        auth_admin_client.post(
+            reverse("billing:subscription-subscribe"),
+            {"module_slugs": ["shop"], "billing_period": "yearly"},
+            format="json",
+        )
+        b_after = _sub(second_tenant)
+        assert b_after.current_period_end == b_end_before
+        assert not b_after.has_module("shop")
+
+    def test_subscription_id_in_body_ignored(self, auth_admin_client, tenant, second_tenant):
+        _make_active(_sub(tenant))
+        b_sub = _make_active(_sub(second_tenant))
+        # Enviar un id ajeno en el body: debe operar SOLO sobre la sub propia.
+        auth_admin_client.post(
+            reverse("billing:subscription-cancel"),
+            {"at_period_end": True, "subscription_id": str(b_sub.id), "tenant_id": str(second_tenant.id)},
+            format="json",
+        )
+        b_sub.refresh_from_db()
+        assert b_sub.canceled_at is None  # B intacto
+        assert _sub(tenant).canceled_at is not None  # A afectado
+
+
+# ===================================
+# LIMITES DE PERMISOS
+# ===================================
+
+
+class TestPermissionBoundaries:
+    def test_non_admin_can_read(self, auth_customer_client):
+        assert auth_customer_client.get(reverse("billing:module-list")).status_code == 200
+        assert auth_customer_client.get(reverse("billing:subscription-detail")).status_code == 200
+
+    def test_non_admin_post_forbidden(self, auth_customer_client):
+        for name, body in (
+            ("billing:subscription-subscribe", {"module_slugs": ["shop"]}),
+            ("billing:subscription-modules", {"add": ["shop"]}),
+            ("billing:subscription-billing-period", {"billing_period": "yearly"}),
+            ("billing:subscription-cancel", {"at_period_end": True}),
+        ):
+            response = auth_customer_client.post(reverse(name), body, format="json")
+            assert response.status_code == 403, name
+
+    def test_admin_can_read_and_mutate(self, auth_admin_client, tenant):
+        _make_active(_sub(tenant))
+        assert auth_admin_client.get(reverse("billing:subscription-detail")).status_code == 200
+        assert (
+            auth_admin_client.post(
+                reverse("billing:subscription-billing-period"),
+                {"billing_period": "yearly"},
+                format="json",
+            ).status_code
+            == 200
+        )
+
+
+# ===================================
+# EXENCION DE MIDDLEWARE (tenant inactivo)
+# ===================================
+
+
+class TestMiddlewareExemption:
+    """
+    Verifica el gate de SubscriptionMiddleware a nivel de unidad.
+
+    NOTA (hallazgo): el gate depende de ``request.user.is_authenticated`` que es
+    poblado por el AuthenticationMiddleware de Django (sesion). Con autenticacion
+    JWT/DRF (``CookieJWTAuthentication``) la autenticacion ocurre DENTRO del
+    dispatch de la vista, despues del middleware, por lo que ``request.user`` es
+    ``AnonymousUser`` en el middleware y el gate NO dispara para requests con
+    Bearer token. Por eso ejercemos el gate directamente con un usuario seteado a
+    mano: asi probamos la logica de exencion (paths billing) vs gating (cancel y
+    APIs no-billing) de forma determinista, sin depender del flujo JWT.
+    """
+
+    def _inactive_tenant(self, tenant):
+        tenant.subscription_ends_at = timezone.now().date() - timedelta(days=1)
+        tenant.save(update_fields=["subscription_ends_at"])
+        assert tenant.is_subscription_active is False
+        return tenant
+
+    def _run(self, path, tenant, user):
+        """Pasa un request (con user autenticado) por el middleware; True si lo deja pasar."""
+        from django.test import RequestFactory
+
+        from core.middleware import SubscriptionMiddleware
+
+        sentinel = object()
+        middleware = SubscriptionMiddleware(lambda request: sentinel)
+        request = RequestFactory().get(path)
+        request.user = user
+        result = middleware(request)
+        # Si el gate dispara devuelve un JsonResponse/redirect (no el sentinel).
+        return result is sentinel
+
+    def test_exempt_paths_pass_when_inactive(self, tenant, admin_user):
+        self._inactive_tenant(tenant)
+        for path in (
+            "/api/billing/modules/",
+            "/api/billing/subscription/",
+            "/api/billing/subscription/subscribe/",
+            "/api/billing/subscription/modules/",
+            "/api/billing/subscription/billing-period/",
+        ):
+            assert self._run(path, tenant, admin_user) is True, path
+
+    def test_cancel_path_gated_when_inactive(self, tenant, admin_user):
+        self._inactive_tenant(tenant)
+        # Cancel NO esta exento: el gate debe bloquear (no pasa).
+        assert self._run("/api/billing/subscription/cancel/", tenant, admin_user) is False
+
+    def test_non_billing_api_gated_when_inactive(self, tenant, admin_user):
+        self._inactive_tenant(tenant)
+        assert self._run("/api/products/", tenant, admin_user) is False
+
+    def test_billing_paths_pass_when_active(self, tenant, admin_user):
+        # Suscripcion activa: nada se bloquea (incluido cancel).
+        assert tenant.is_subscription_active is True
+        assert self._run("/api/billing/subscription/cancel/", tenant, admin_user) is True
+        assert self._run("/api/products/", tenant, admin_user) is True

--- a/backend/billing/urls.py
+++ b/backend/billing/urls.py
@@ -1,0 +1,28 @@
+# backend/billing/urls.py
+"""
+URLs de la API de ciclo de vida de suscripciones (B1).
+
+Montadas en ``config/urls.py`` bajo ``/api/billing/``.
+"""
+
+from django.urls import path
+
+from .views import (
+    BillingPeriodView,
+    CancelView,
+    ModuleListView,
+    ModulesView,
+    SubscribeView,
+    SubscriptionDetailView,
+)
+
+app_name = "billing"
+
+urlpatterns = [
+    path("modules/", ModuleListView.as_view(), name="module-list"),
+    path("subscription/", SubscriptionDetailView.as_view(), name="subscription-detail"),
+    path("subscription/subscribe/", SubscribeView.as_view(), name="subscription-subscribe"),
+    path("subscription/modules/", ModulesView.as_view(), name="subscription-modules"),
+    path("subscription/billing-period/", BillingPeriodView.as_view(), name="subscription-billing-period"),
+    path("subscription/cancel/", CancelView.as_view(), name="subscription-cancel"),
+]

--- a/backend/billing/views.py
+++ b/backend/billing/views.py
@@ -12,6 +12,7 @@ post_delete sobre Subscription/SubscriptionModule re-sincronizan los flags.
 
 from rest_framework import status
 from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -35,11 +36,17 @@ def _subscription_response(subscription, request) -> Response:
     return Response(SubscriptionSerializer(subscription, context={"request": request}).data)
 
 
+class ModuleCatalogPagination(PageNumberPagination):
+    page_size = 20
+    max_page_size = 100
+
+
 class ModuleListView(ListAPIView):
-    """GET /api/billing/modules/ — catalogo global de modulos contratables."""
+    """GET /api/v1/billing/modules/ — catalogo global de modulos contratables."""
 
     permission_classes = [IsTenantUser]
     serializer_class = ModuleSerializer
+    pagination_class = ModuleCatalogPagination
 
     def get_queryset(self):
         if getattr(self, "swagger_fake_view", False):
@@ -48,7 +55,7 @@ class ModuleListView(ListAPIView):
 
 
 class SubscriptionDetailView(APIView):
-    """GET /api/billing/subscription/ — estado de la suscripcion del tenant."""
+    """GET /api/v1/billing/subscription/ — estado de la suscripcion del tenant."""
 
     permission_classes = [IsTenantUser]
 
@@ -58,7 +65,7 @@ class SubscriptionDetailView(APIView):
 
 
 class SubscribeView(APIView):
-    """POST /api/billing/subscription/subscribe/ — activa una suscripcion modular."""
+    """POST /api/v1/billing/subscription/subscribe/ — activa una suscripcion modular."""
 
     permission_classes = [IsTenantAdmin]
 
@@ -75,7 +82,7 @@ class SubscribeView(APIView):
 
 
 class ModulesView(APIView):
-    """POST /api/billing/subscription/modules/ — agrega/quita modulos."""
+    """POST /api/v1/billing/subscription/modules/ — agrega/quita modulos."""
 
     permission_classes = [IsTenantAdmin]
 
@@ -107,7 +114,7 @@ class ModulesView(APIView):
 
 
 class BillingPeriodView(APIView):
-    """POST /api/billing/subscription/billing-period/ — cambia el periodo de facturacion."""
+    """POST /api/v1/billing/subscription/billing-period/ — cambia el periodo de facturacion."""
 
     permission_classes = [IsTenantAdmin]
 
@@ -129,7 +136,7 @@ class BillingPeriodView(APIView):
 
 
 class CancelView(APIView):
-    """POST /api/billing/subscription/cancel/ — cancela (inmediata o diferida)."""
+    """POST /api/v1/billing/subscription/cancel/ — cancela (inmediata o diferida)."""
 
     permission_classes = [IsTenantAdmin]
 

--- a/backend/billing/views.py
+++ b/backend/billing/views.py
@@ -1,1 +1,154 @@
-# Create your views here.
+# backend/billing/views.py
+"""
+Vistas de la API de ciclo de vida de suscripciones (B1).
+
+La suscripcion es un singleton por tenant (OneToOne a Tenant). Toda vista
+resuelve el objetivo como ``request.tenant.subscription`` UNICAMENTE: el
+cliente nunca envia ni recibe un id de tenant/suscripcion.
+
+Las vistas NUNCA mutan ``tenant.has_*`` directamente: los signals post_save/
+post_delete sobre Subscription/SubscriptionModule re-sincronizan los flags.
+"""
+
+from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from core.permissions import IsTenantAdmin, IsTenantUser
+
+from .models import Module
+from .serializers import (
+    BillingPeriodInputSerializer,
+    CancelInputSerializer,
+    ModuleSerializer,
+    ModulesInputSerializer,
+    SubscribeInputSerializer,
+    SubscriptionSerializer,
+)
+from .services import SubscriptionManager
+
+
+def _subscription_response(subscription, request) -> Response:
+    """Serializa la suscripcion (refrescada) para devolverla en cada accion."""
+    subscription.refresh_from_db()
+    return Response(SubscriptionSerializer(subscription, context={"request": request}).data)
+
+
+class ModuleListView(ListAPIView):
+    """GET /api/billing/modules/ — catalogo global de modulos contratables."""
+
+    permission_classes = [IsTenantUser]
+    serializer_class = ModuleSerializer
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Module.objects.none()
+        return Module.objects.filter(is_active=True, is_visible=True).order_by("sort_order")
+
+
+class SubscriptionDetailView(APIView):
+    """GET /api/billing/subscription/ — estado de la suscripcion del tenant."""
+
+    permission_classes = [IsTenantUser]
+
+    def get(self, request):
+        subscription = request.tenant.subscription
+        return Response(SubscriptionSerializer(subscription, context={"request": request}).data)
+
+
+class SubscribeView(APIView):
+    """POST /api/billing/subscription/subscribe/ — activa una suscripcion modular."""
+
+    permission_classes = [IsTenantAdmin]
+
+    def post(self, request):
+        serializer = SubscribeInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        subscription = request.tenant.subscription
+        SubscriptionManager.activate_subscription(
+            subscription,
+            serializer.validated_data["module_slugs"],
+            serializer.validated_data["billing_period"],
+        )
+        return _subscription_response(subscription, request)
+
+
+class ModulesView(APIView):
+    """POST /api/billing/subscription/modules/ — agrega/quita modulos."""
+
+    permission_classes = [IsTenantAdmin]
+
+    def post(self, request):
+        serializer = ModulesInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        subscription = request.tenant.subscription
+
+        # Validar remociones ANTES de mutar (no quitar base 'web'; debe estar en la sub).
+        for slug in serializer.validated_data["remove"]:
+            module = Module.objects.filter(slug=slug).first()
+            if module is not None and module.is_base:
+                return Response(
+                    {"detail": "No se puede remover el modulo base (web)"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            if not subscription.subscription_modules.filter(module__slug=slug, is_active=True).exists():
+                return Response(
+                    {"detail": f"El modulo {slug} no esta en tu suscripcion"},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+        for slug in serializer.validated_data["add"]:
+            subscription.add_module(slug)
+        for slug in serializer.validated_data["remove"]:
+            subscription.remove_module(slug)
+
+        return _subscription_response(subscription, request)
+
+
+class BillingPeriodView(APIView):
+    """POST /api/billing/subscription/billing-period/ — cambia el periodo de facturacion."""
+
+    permission_classes = [IsTenantAdmin]
+
+    def post(self, request):
+        serializer = BillingPeriodInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        subscription = request.tenant.subscription
+        new_period = serializer.validated_data["billing_period"]
+
+        if new_period == subscription.billing_period:
+            # No-op idempotente: el periodo ya es el solicitado (spec: 200).
+            return _subscription_response(subscription, request)
+
+        # Cambiar el periodo sin tocar fechas ni recalcular (efectivo en la
+        # proxima renovacion; sin prorrateo en B1).
+        subscription.billing_period = new_period
+        subscription.save()
+        return _subscription_response(subscription, request)
+
+
+class CancelView(APIView):
+    """POST /api/billing/subscription/cancel/ — cancela (inmediata o diferida)."""
+
+    permission_classes = [IsTenantAdmin]
+
+    def post(self, request):
+        serializer = CancelInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        subscription = request.tenant.subscription
+        at_period_end = serializer.validated_data["at_period_end"]
+
+        # Ya cancelada/expirada: nada que cancelar.
+        if subscription.status in ("canceled", "expired"):
+            return Response(
+                {"detail": "La suscripcion ya esta cancelada"},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        # Cancelacion diferida ya pendiente -> idempotente 200 (spec).
+        if at_period_end and subscription.canceled_at is not None and subscription.status == "active":
+            return _subscription_response(subscription, request)
+
+        SubscriptionManager.cancel_subscription(subscription, at_period_end=at_period_end)
+        return _subscription_response(subscription, request)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -139,7 +139,7 @@ urlpatterns = [
                 path("", include("ecommerce.urls")),
                 path("services/", include("services.urls")),
                 path("bookings/", include("bookings.urls")),
-                path("billing/", include("billing.urls")),
+                path("v1/billing/", include("billing.urls")),
                 path("subscriptions/", include("subscriptions.urls")),
                 path("cart/", include("cart.urls")),
                 path("", include("orders.urls")),

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -139,6 +139,7 @@ urlpatterns = [
                 path("", include("ecommerce.urls")),
                 path("services/", include("services.urls")),
                 path("bookings/", include("bookings.urls")),
+                path("billing/", include("billing.urls")),
                 path("subscriptions/", include("subscriptions.urls")),
                 path("cart/", include("cart.urls")),
                 path("", include("orders.urls")),

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -87,11 +87,11 @@ class SubscriptionMiddleware:
         r"^/favicon\.ico$",
         # Billing read-only + reactivacion (deben funcionar con suscripcion inactiva).
         # Cancel NO se exime: un tenant inactivo no tiene nada que cancelar.
-        r"^/api/billing/modules/$",
-        r"^/api/billing/subscription/$",
-        r"^/api/billing/subscription/subscribe/$",
-        r"^/api/billing/subscription/modules/$",
-        r"^/api/billing/subscription/billing-period/$",
+        r"^/api/v1/billing/modules/$",
+        r"^/api/v1/billing/subscription/$",
+        r"^/api/v1/billing/subscription/subscribe/$",
+        r"^/api/v1/billing/subscription/modules/$",
+        r"^/api/v1/billing/subscription/billing-period/$",
     ]
 
     def __init__(self, get_response):

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -85,6 +85,13 @@ class SubscriptionMiddleware:
         r"^/__reload__/",  # Django browser reload
         r"^/subscription-expired/$",
         r"^/favicon\.ico$",
+        # Billing read-only + reactivacion (deben funcionar con suscripcion inactiva).
+        # Cancel NO se exime: un tenant inactivo no tiene nada que cancelar.
+        r"^/api/billing/modules/$",
+        r"^/api/billing/subscription/$",
+        r"^/api/billing/subscription/subscribe/$",
+        r"^/api/billing/subscription/modules/$",
+        r"^/api/billing/subscription/billing-period/$",
     ]
 
     def __init__(self, get_response):


### PR DESCRIPTION
### **User description**
## Resumen

Implementa **B1** del epic #290: la capa REST de billing para el ciclo de vida de la suscripción. `billing/views.py` estaba vacío; ahora un tenant admin puede autogestionar su plan tras el trial.

### Endpoints (`/api/billing/`)
- `GET /modules/` — catálogo de módulos (precio mensual/anual, límites)
- `GET /subscription/` — estado del tenant (status, período, días restantes, módulos, uso, `cancels_at_period_end`)
- `POST /subscription/subscribe/` — suscribirse a un plan
- `POST /subscription/modules/` — agregar/quitar módulos
- `POST /subscription/billing-period/` — cambiar mensual↔anual
- `POST /subscription/cancel/` — cancelar (inmediato o a fin de período)

### Decisiones de producto
- **Honra el trial:** suscribirse en trial inicia el período pagado en `trial_ends_at` (no pierde días)
- **Cambio de período aplica a la próxima renovación** (sin proration → B2/Stripe)
- **Re-suscribirse deshace** la cancelación diferida (limpia `canceled_at`)

### Diseño
- APIViews singleton sobre `request.tenant.subscription`; nunca expone/acepta ids
- Permisos: `IsTenantUser` (GET) / `IsTenantAdmin` (POST)
- Nuevo `SubscriptionManager.activate_subscription` basado en módulos (NO usa el `upgrade_plan`/`Plan` obsoleto)
- `cancel` reutiliza `SubscriptionManager.cancel_subscription`
- Las señales existentes sincronizan los flags del tenant — las views no tocan `tenant.has_*`
- Exención anclada en `SubscriptionMiddleware.ALLOWED_URLS` para rutas de reactivación (cancel queda gated)

### Fuera de alcance (issues aparte)
- Cron de cancelación a fin de período + expirar trials → **B3 #293**
- Cupones/descuentos → **B2 #292**
- UI → **B4 #294**
- Stripe/webhooks, multi-moneda

### Notas
- ⚠️ Gap pre-existente del gate de suscripción para tráfico JWT documentado en **#300** (no es de B1).

## Test plan
- [x] ruff check + format
- [x] 39 tests pytest (aislamiento multi-tenant, transiciones de estado, permisos, exención middleware) — 39 passed
- [x] `makemigrations --check` (sin migraciones nuevas)
- [ ] Smoke manual de los 6 endpoints en dev

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Implementa la API REST para la gestión de suscripciones.

- Permite ver catálogo, estado, suscribirse y gestionar módulos.

- Soporta cambio de periodo y cancelación (inmediata/diferida).

- Honra el trial y deshace cancelaciones diferidas al resuscribir.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[Cliente API] --> B{API Endpoints de Suscripción};
    B -- Valida/Serializa --> C[Serializadores de Billing];
    B -- Lógica de Negocio --> D[SubscriptionManager.activate_subscription];
    B -- Lógica de Negocio --> E[SubscriptionManager.cancel_subscription];
    C,D,E --> F[Modelos: Subscription, Module];
    G[SubscriptionMiddleware] -- Protege Rutas --> B;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Api serialization</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>serializers.py</strong><dd><code>Define serializadores para la API de gestión de suscripciones.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/301/files#diff-64ac0c28a0041874e42e95fc778b610f98c9edae4d3bba395e85b6598f7a5442">+205/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Business logic</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>services.py</strong><dd><code>Implementa la lógica de activación de suscripciones modulares.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/301/files#diff-555aab008e15ae102be8dfc4009435bfc399f0af5cba8e47b77251c526c29333">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tests.py</strong><dd><code>Añade pruebas exhaustivas para los endpoints de la API de </code><br><code>suscripciones.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/301/files#diff-778e3f0e3c6c48a694f9e58ff74da60991d78b6ab5cc74a9cf7e437fa810a453">+564/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Api routing</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>urls.py</strong><dd><code>Define las rutas de la API para la gestión de suscripciones.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/301/files#diff-42fff20cd844598428fa4217377e41930544225f43e5b7b992d41de76bf9d75f">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Api endpoints</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>views.py</strong><dd><code>Implementa las vistas REST para el ciclo de vida de suscripciones.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/301/files#diff-566813c6db3777513198107bdc5d282ade54f8e14f66d20b270418077bf997f4">+154/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>urls.py</strong><dd><code>Integra las URLs de la API de facturación en la configuración global.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/301/files#diff-de1cb596363b15cf3f5443a3d7ea987d18354488798e5c82d05e47c95fba3024">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Middleware</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>middleware.py</strong><dd><code>Exime rutas de facturación del control de suscripción activa.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/301/files#diff-c448b7d406680d2effd7b13326263ae8d56296405fb6901f07682873006f91bc">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nuevo sistema de gestión de suscripciones modular con capacidad de activación, adición y eliminación de módulos.
  * Endpoints para consultar estado de suscripción, cambiar período de facturación y gestionar cancelaciones.
  * Catálogo de módulos disponibles con información de precios y descuentos.

* **Tests**
  * Suite completa de tests para validar flujos de suscripción, aislamiento de tenants, permisos y middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->