### PR TITLE
feat(websites): catálogo de variantes IA por sección + fix hero aleatorio

### DIFF
--- a/backend/websites/migrations/0036_seed_section_variants.py
+++ b/backend/websites/migrations/0036_seed_section_variants.py
@@ -1,0 +1,642 @@
+"""Catálogo completo de variantes de sección (issue #296).
+
+Siembra el catálogo `SectionVariant` para las 9 secciones canónicas del home,
+de forma que la IA elija el diseño desde la BD (no por `random.choice`).
+
+Es una migración de DATOS idempotente y REVERSIBLE:
+
+1. Crea PRIMERO las 9 filas canónicas `WebsiteSection` (get_or_create por `key`)
+   con las claves que el catálogo de variantes necesita: hero, services,
+   products, about, testimonials, pricing, gallery, faq, contact. Estas claves
+   coinciden 1:1 con los dispatchers del renderer backend
+   (`_render_<section>_<variant>` en `rendering.py`) y los `switch (variant)`
+   del frontend (`components/website/sections/*.tsx`).
+
+2. Renombra IN-PLACE las claves de hero `hero-*` -> token base (`hero-centered`
+   -> `centered`, etc.) vía `.update()` keyeado por la clave vieja. NUNCA borra
+   y recrea (la clave es UNIQUE; un delete+create podría perder relaciones).
+
+3. Hace get_or_create de las variantes del resto de secciones usando los tokens
+   base EXACTOS verificados contra el renderer/frontend.
+
+4. Desactiva (`is_active=False`) las variantes `glassmorphism` (hero) y
+   `bento-grid` (services/products): existen en el código pero se retiran del
+   catálogo que la IA puede elegir.
+
+5. Cura `mood` e `industries` (M2M) por variante.
+
+La reversión restaura las claves de hero a `hero-*`, reactiva glassmorphism y
+bento-grid, y elimina las variantes/sections creadas por esta migración. No se
+borran filas preexistentes que no haya creado esta migración.
+"""
+
+from django.db import migrations
+
+# ── 1. Secciones canónicas (key -> meta) ────────────────────────────────────
+# Claves alineadas con los dispatchers del renderer y los switches del frontend.
+CANONICAL_SECTIONS = [
+    {"key": "hero", "label": "Hero", "description": "Encabezado principal", "is_default": True, "sort_order": 0},
+    {"key": "services", "label": "Servicios", "description": "Lo que hacemos", "is_default": True, "sort_order": 1},
+    {"key": "products", "label": "Productos", "description": "Nuestros productos", "is_default": False, "sort_order": 2},
+    {"key": "about", "label": "Sobre nosotros", "description": "Quiénes somos", "is_default": True, "sort_order": 3},
+    {
+        "key": "testimonials",
+        "label": "Testimonios",
+        "description": "Lo que dicen nuestros clientes",
+        "is_default": True,
+        "sort_order": 4,
+    },
+    {"key": "pricing", "label": "Precios", "description": "Planes y precios", "is_default": False, "sort_order": 5},
+    {"key": "gallery", "label": "Galería", "description": "Nuestro trabajo", "is_default": False, "sort_order": 6},
+    {"key": "faq", "label": "Preguntas frecuentes", "description": "Dudas comunes", "is_default": False, "sort_order": 7},
+    {"key": "contact", "label": "Contacto", "description": "Cómo contactarnos", "is_default": True, "sort_order": 8},
+]
+
+# ── 2. Rename de hero `hero-*` -> token base ────────────────────────────────
+# (clave vieja -> token base). El token base coincide con el switch del frontend
+# y con `_render_hero_<token>` del backend.
+HERO_RENAMES = {
+    "hero-split-image": "split-image",
+    "hero-fullwidth-image": "fullwidth-image",
+    "hero-diagonal-split": "diagonal-split",
+    "hero-centered": "centered",
+    "hero-bold-typography": "bold-typography",
+    "hero-glassmorphism": "glassmorphism",
+}
+
+# Variantes a desactivar (existen en código pero salen del catálogo de la IA).
+DEACTIVATED_KEYS = ["glassmorphism", "bento-grid"]
+
+# ── 3. Curaduría de hero tras el rename (mood + default + industrias) ────────
+# El default canónico del hero es `centered` (coincide con el `default:` del
+# switch del frontend cuando no hay imagen).
+HERO_CURATION = {
+    "centered": {"mood": "minimal", "is_default": True, "sort_order": 0, "industries": []},
+    "split-image": {"mood": "professional", "is_default": False, "sort_order": 1, "industries": []},
+    "fullwidth-image": {
+        "mood": "bold",
+        "is_default": False,
+        "sort_order": 2,
+        "industries": ["restaurant", "cafe", "events", "wedding", "travel"],
+    },
+    "diagonal-split": {
+        "mood": "elegant",
+        "is_default": False,
+        "sort_order": 3,
+        "industries": ["beauty", "spa", "fashion", "architecture"],
+    },
+    "bold-typography": {
+        "mood": "bold",
+        "is_default": False,
+        "sort_order": 4,
+        "industries": ["gym", "marketing", "creative", "tech"],
+    },
+}
+
+# ── 4. Catálogo de variantes para el resto de secciones ─────────────────────
+# Tokens base verificados contra `rendering.py` y `sections/*.tsx`.
+SECTION_VARIANTS = {
+    "services": [
+        {
+            "key": "services-grid-cards",
+            "token": "grid-cards",
+            "label": "Tarjetas en grilla",
+            "description": "Servicios en tarjetas limpias y uniformes. Default versátil.",
+            "css_class_hint": "services--grid-cards",
+            "mood": "professional",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "services-grid-cards-image",
+            "token": "grid-cards-image",
+            "label": "Tarjetas con imagen",
+            "description": "Cada servicio con foto. Ideal cuando hay buenas imágenes.",
+            "css_class_hint": "services--grid-cards-image",
+            "mood": "elegant",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": ["beauty", "spa", "restaurant", "fashion"],
+        },
+        {
+            "key": "services-list-detailed",
+            "token": "list-detailed",
+            "label": "Lista detallada",
+            "description": "Lista vertical con descripciones largas. Para servicios complejos.",
+            "css_class_hint": "services--list-detailed",
+            "mood": "professional",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": ["legal", "accounting", "consulting", "services"],
+        },
+        {
+            "key": "services-featured-highlight",
+            "token": "featured-highlight",
+            "label": "Destacado principal",
+            "description": "Un servicio grande destacado más una columna de apoyo.",
+            "css_class_hint": "services--featured-highlight",
+            "mood": "bold",
+            "is_default": False,
+            "sort_order": 3,
+            "industries": [],
+        },
+        {
+            "key": "services-horizontal-scroll",
+            "token": "horizontal-scroll",
+            "label": "Scroll horizontal",
+            "description": "Carrusel horizontal de servicios. Moderno y compacto.",
+            "css_class_hint": "services--horizontal-scroll",
+            "mood": "playful",
+            "is_default": False,
+            "sort_order": 4,
+            "industries": ["creative", "marketing", "tech"],
+        },
+        {
+            "key": "services-icon-minimal",
+            "token": "icon-minimal",
+            "label": "Iconos minimal",
+            "description": "Iconos con texto corto. Limpio y directo.",
+            "css_class_hint": "services--icon-minimal",
+            "mood": "minimal",
+            "is_default": False,
+            "sort_order": 5,
+            "industries": [],
+        },
+        # bento-grid: presente en código, desactivada del catálogo.
+        {
+            "key": "services-bento-grid",
+            "token": "bento-grid",
+            "label": "Bento grid",
+            "description": "Grilla tipo bento. Retirada del catálogo de la IA.",
+            "css_class_hint": "services--bento-grid",
+            "mood": "playful",
+            "is_default": False,
+            "sort_order": 6,
+            "industries": [],
+        },
+    ],
+    "products": [
+        {
+            "key": "products-grid-cards",
+            "token": "grid-cards",
+            "label": "Tarjetas en grilla",
+            "description": "Productos en tarjetas uniformes. Default versátil.",
+            "css_class_hint": "products--grid-cards",
+            "mood": "professional",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "products-grid-cards-image",
+            "token": "grid-cards-image",
+            "label": "Tarjetas con imagen",
+            "description": "Productos con foto destacada por tarjeta.",
+            "css_class_hint": "products--grid-cards-image",
+            "mood": "elegant",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": ["store", "fashion", "bakery"],
+        },
+        {
+            "key": "products-showcase-large",
+            "token": "showcase-large",
+            "label": "Showcase grande",
+            "description": "Producto principal a gran escala. Alto impacto visual.",
+            "css_class_hint": "products--showcase-large",
+            "mood": "bold",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": ["fashion", "creative"],
+        },
+        {
+            "key": "products-catalog-compact",
+            "token": "catalog-compact",
+            "label": "Catálogo compacto",
+            "description": "Muchos productos en poco espacio. Para catálogos amplios.",
+            "css_class_hint": "products--catalog-compact",
+            "mood": "minimal",
+            "is_default": False,
+            "sort_order": 3,
+            "industries": ["store"],
+        },
+        {
+            "key": "products-masonry-staggered",
+            "token": "masonry-staggered",
+            "label": "Masonry escalonado",
+            "description": "Mosaico con alturas variables. Dinámico y editorial.",
+            "css_class_hint": "products--masonry-staggered",
+            "mood": "playful",
+            "is_default": False,
+            "sort_order": 4,
+            "industries": ["fashion", "photography", "creative"],
+        },
+        {
+            "key": "products-price-table",
+            "token": "price-table",
+            "label": "Tabla de precios",
+            "description": "Listado con precios visibles. Para venta directa.",
+            "css_class_hint": "products--price-table",
+            "mood": "professional",
+            "is_default": False,
+            "sort_order": 5,
+            "industries": [],
+        },
+        # bento-grid: presente en código, desactivada del catálogo.
+        {
+            "key": "products-bento-grid",
+            "token": "bento-grid",
+            "label": "Bento grid",
+            "description": "Grilla tipo bento. Retirada del catálogo de la IA.",
+            "css_class_hint": "products--bento-grid",
+            "mood": "playful",
+            "is_default": False,
+            "sort_order": 6,
+            "industries": [],
+        },
+    ],
+    "about": [
+        {
+            "key": "about-text-only",
+            "token": "text-only",
+            "label": "Solo texto",
+            "description": "Narrativa limpia sin imagen. Default cuando no hay foto.",
+            "css_class_hint": "about--text-only",
+            "mood": "minimal",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "about-split-image",
+            "token": "split-image",
+            "label": "Split con imagen",
+            "description": "Texto e imagen lado a lado. Clásico y cálido.",
+            "css_class_hint": "about--split-image",
+            "mood": "professional",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": [],
+        },
+        {
+            "key": "about-stats-banner",
+            "token": "stats-banner",
+            "label": "Banner de cifras",
+            "description": "Destaca métricas y logros. Genera confianza.",
+            "css_class_hint": "about--stats-banner",
+            "mood": "bold",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": ["consulting", "tech", "marketing", "gym"],
+        },
+        {
+            "key": "about-timeline",
+            "token": "timeline",
+            "label": "Línea de tiempo",
+            "description": "Historia del negocio paso a paso. Narrativa con trayectoria.",
+            "css_class_hint": "about--timeline",
+            "mood": "elegant",
+            "is_default": False,
+            "sort_order": 3,
+            "industries": ["legal", "accounting", "architecture"],
+        },
+        {
+            "key": "about-overlapping-cards",
+            "token": "overlapping-cards",
+            "label": "Tarjetas superpuestas",
+            "description": "Tarjetas con profundidad. Moderno y dinámico.",
+            "css_class_hint": "about--overlapping-cards",
+            "mood": "playful",
+            "is_default": False,
+            "sort_order": 4,
+            "industries": ["creative", "marketing"],
+        },
+        {
+            "key": "about-fullwidth-banner",
+            "token": "fullwidth-banner",
+            "label": "Banner a ancho completo",
+            "description": "Imagen amplia con texto superpuesto. Alto impacto.",
+            "css_class_hint": "about--fullwidth-banner",
+            "mood": "bold",
+            "is_default": False,
+            "sort_order": 5,
+            "industries": ["restaurant", "events", "travel"],
+        },
+        {
+            "key": "about-asymmetric",
+            "token": "asymmetric",
+            "label": "Asimétrico",
+            "description": "Composición asimétrica editorial. Elegante y distintivo.",
+            "css_class_hint": "about--asymmetric",
+            "mood": "elegant",
+            "is_default": False,
+            "sort_order": 6,
+            "industries": ["fashion", "architecture", "photography"],
+        },
+    ],
+    "testimonials": [
+        {
+            "key": "testimonials-cards-grid",
+            "token": "cards-grid",
+            "label": "Tarjetas en grilla",
+            "description": "Varios testimonios en tarjetas. Default equilibrado.",
+            "css_class_hint": "testimonials--cards-grid",
+            "mood": "professional",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "testimonials-carousel",
+            "token": "carousel",
+            "label": "Carrusel",
+            "description": "Testimonios en carrusel rotatorio. Compacto.",
+            "css_class_hint": "testimonials--carousel",
+            "mood": "playful",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": [],
+        },
+        {
+            "key": "testimonials-single-highlight",
+            "token": "single-highlight",
+            "label": "Testimonio destacado",
+            "description": "Un testimonio grande y protagonista. Para una reseña potente.",
+            "css_class_hint": "testimonials--single-highlight",
+            "mood": "elegant",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": ["beauty", "spa", "consulting"],
+        },
+    ],
+    "pricing": [
+        {
+            "key": "pricing-cards",
+            "token": "cards",
+            "label": "Tarjetas de planes",
+            "description": "Planes en tarjetas comparables. Default claro.",
+            "css_class_hint": "pricing--cards",
+            "mood": "professional",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "pricing-comparison-table",
+            "token": "comparison-table",
+            "label": "Tabla comparativa",
+            "description": "Comparación detallada feature por feature. Para planes ricos.",
+            "css_class_hint": "pricing--comparison-table",
+            "mood": "professional",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": ["tech", "consulting"],
+        },
+        {
+            "key": "pricing-minimal-list",
+            "token": "minimal-list",
+            "label": "Lista minimal",
+            "description": "Precios en lista simple. Directo y sin ruido.",
+            "css_class_hint": "pricing--minimal-list",
+            "mood": "minimal",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": ["beauty", "barberia", "nails"],
+        },
+    ],
+    "gallery": [
+        {
+            "key": "gallery-masonry",
+            "token": "masonry",
+            "label": "Masonry",
+            "description": "Mosaico de alturas variables. Default visual y editorial.",
+            "css_class_hint": "gallery--masonry",
+            "mood": "elegant",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "gallery-grid-uniform",
+            "token": "grid-uniform",
+            "label": "Grilla uniforme",
+            "description": "Cuadrícula pareja. Ordenado y limpio.",
+            "css_class_hint": "gallery--grid-uniform",
+            "mood": "minimal",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": [],
+        },
+        {
+            "key": "gallery-slider",
+            "token": "slider",
+            "label": "Slider",
+            "description": "Carrusel de imágenes a ancho completo. Inmersivo.",
+            "css_class_hint": "gallery--slider",
+            "mood": "bold",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": ["photography", "travel", "events"],
+        },
+    ],
+    "faq": [
+        {
+            "key": "faq-classic",
+            "token": "classic",
+            "label": "Acordeón clásico",
+            "description": "Preguntas en acordeón expandible. Default conocido.",
+            "css_class_hint": "faq--classic",
+            "mood": "professional",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "faq-side-by-side",
+            "token": "side-by-side",
+            "label": "Dos columnas",
+            "description": "FAQs en dos columnas. Aprovecha el ancho.",
+            "css_class_hint": "faq--side-by-side",
+            "mood": "minimal",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": [],
+        },
+        {
+            "key": "faq-cards",
+            "token": "cards",
+            "label": "Tarjetas",
+            "description": "Cada pregunta en su tarjeta. Más visual.",
+            "css_class_hint": "faq--cards",
+            "mood": "playful",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": [],
+        },
+    ],
+    "contact": [
+        {
+            "key": "contact-cards-grid",
+            "token": "cards-grid",
+            "label": "Tarjetas de contacto",
+            "description": "Canales de contacto en tarjetas. Default completo.",
+            "css_class_hint": "contact--cards-grid",
+            "mood": "professional",
+            "is_default": True,
+            "sort_order": 0,
+            "industries": [],
+        },
+        {
+            "key": "contact-split-form",
+            "token": "split-form",
+            "label": "Formulario split",
+            "description": "Formulario más datos lado a lado. Para captar leads.",
+            "css_class_hint": "contact--split-form",
+            "mood": "professional",
+            "is_default": False,
+            "sort_order": 1,
+            "industries": ["consulting", "legal", "real_estate", "marketing"],
+        },
+        {
+            "key": "contact-centered-minimal",
+            "token": "centered-minimal",
+            "label": "Centrado minimal",
+            "description": "Datos de contacto centrados y limpios. Sin formulario.",
+            "css_class_hint": "contact--centered-minimal",
+            "mood": "minimal",
+            "is_default": False,
+            "sort_order": 2,
+            "industries": ["beauty", "barberia", "cafe"],
+        },
+    ],
+}
+
+
+def _set_industries(variant, industry_keys, Industry):
+    """Asigna el M2M industries para una variante (sólo industrias existentes)."""
+    if not industry_keys:
+        variant.industries.clear()
+        return
+    industries = list(Industry.objects.filter(key__in=industry_keys))
+    variant.industries.set(industries)
+
+
+def seed_variants(apps, schema_editor):
+    WebsiteSection = apps.get_model("websites", "WebsiteSection")
+    SectionVariant = apps.get_model("websites", "SectionVariant")
+    Industry = apps.get_model("websites", "Industry")
+
+    # 1. Secciones canónicas PRIMERO.
+    sections = {}
+    for data in CANONICAL_SECTIONS:
+        section, _ = WebsiteSection.objects.get_or_create(
+            key=data["key"],
+            defaults={
+                "label": data["label"],
+                "description": data["description"],
+                "is_default": data["is_default"],
+                "sort_order": data["sort_order"],
+                "is_active": True,
+            },
+        )
+        sections[data["key"]] = section
+
+    hero_section = sections["hero"]
+
+    # 2. Rename hero `hero-*` -> token base (in-place, keyeado por clave vieja).
+    for old_key, new_key in HERO_RENAMES.items():
+        SectionVariant.objects.filter(key=old_key).update(key=new_key, section=hero_section)
+
+    # 3. Curaduría de hero (asegura que existan aunque falte el seed previo).
+    for token, meta in HERO_CURATION.items():
+        variant, _ = SectionVariant.objects.get_or_create(
+            key=token,
+            defaults={
+                "section": hero_section,
+                "label": token.replace("-", " ").title(),
+                "mood": meta["mood"],
+                "is_default": meta["is_default"],
+                "is_active": True,
+                "sort_order": meta["sort_order"],
+            },
+        )
+        SectionVariant.objects.filter(pk=variant.pk).update(
+            section=hero_section,
+            mood=meta["mood"],
+            is_default=meta["is_default"],
+            sort_order=meta["sort_order"],
+            is_active=True,
+        )
+        variant.refresh_from_db()
+        _set_industries(variant, meta["industries"], Industry)
+
+    # 4. Variantes del resto de secciones.
+    for section_key, variants in SECTION_VARIANTS.items():
+        section = sections[section_key]
+        for data in variants:
+            variant, _ = SectionVariant.objects.get_or_create(
+                key=data["key"],
+                defaults={
+                    "section": section,
+                    "label": data["label"],
+                    "description": data["description"],
+                    "css_class_hint": data["css_class_hint"],
+                    "mood": data["mood"],
+                    "is_default": data["is_default"],
+                    "is_active": True,
+                    "sort_order": data["sort_order"],
+                },
+            )
+            SectionVariant.objects.filter(pk=variant.pk).update(
+                section=section,
+                label=data["label"],
+                description=data["description"],
+                css_class_hint=data["css_class_hint"],
+                mood=data["mood"],
+                is_default=data["is_default"],
+                sort_order=data["sort_order"],
+                is_active=True,
+            )
+            variant.refresh_from_db()
+            _set_industries(variant, data["industries"], Industry)
+
+    # 5. Desactivar glassmorphism (hero) y bento-grid (services/products).
+    SectionVariant.objects.filter(key="glassmorphism").update(is_active=False)
+    SectionVariant.objects.filter(key__in=["services-bento-grid", "products-bento-grid"]).update(is_active=False)
+
+
+def reverse_variants(apps, schema_editor):
+    WebsiteSection = apps.get_model("websites", "WebsiteSection")
+    SectionVariant = apps.get_model("websites", "SectionVariant")
+
+    # Reactivar glassmorphism y bento-grid.
+    SectionVariant.objects.filter(key="glassmorphism").update(is_active=True)
+    SectionVariant.objects.filter(key__in=["services-bento-grid", "products-bento-grid"]).update(is_active=True)
+
+    # Eliminar las variantes de las secciones no-hero creadas por esta migración.
+    non_hero_keys = [d["key"] for variants in SECTION_VARIANTS.values() for d in variants]
+    SectionVariant.objects.filter(key__in=non_hero_keys).delete()
+
+    # Restaurar las claves de hero a `hero-*`.
+    reverse_renames = {new_key: old_key for old_key, new_key in HERO_RENAMES.items()}
+    for new_key, old_key in reverse_renames.items():
+        SectionVariant.objects.filter(key=new_key).update(key=old_key)
+
+    # Eliminar las secciones canónicas creadas por esta migración que no tengan
+    # ya variantes activas asociadas (defensivo: sólo las que existan vacías).
+    created_section_keys = [d["key"] for d in CANONICAL_SECTIONS]
+    for key in created_section_keys:
+        section = WebsiteSection.objects.filter(key=key).first()
+        if section and not section.variants.exists():
+            section.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0035_slim_rules_general_block"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_variants, reverse_variants),
+    ]

--- a/backend/websites/migrations/0037_sectionvariant_composite_key_bare_tokens.py
+++ b/backend/websites/migrations/0037_sectionvariant_composite_key_bare_tokens.py
@@ -1,0 +1,48 @@
+"""Unicidad COMPUESTA (section, key) para SectionVariant — ESQUEMA (issue #296).
+
+Fix del blocker crítico: las 8 secciones no-hero se sembraron en 0036 con claves
+PREFIJADAS por sección (`services-grid-cards`, `about-split-image`, ...), pero el
+renderer (`rendering.py` -> `_render_<section>_<token>`) y el frontend
+(`sections/*.tsx` -> `switch (variant)`) consumen el token BARE. Con la clave
+prefijada, `resolve_section_variant` escribía `_variant = "about-split-image"` y
+el renderer buscaba `_render_about_about_split_image` (inexistente) -> caía al
+default. Toda variante no-hero elegida por la IA renderizaba el default.
+
+Causa raíz: `SectionVariant.key` era globalmente UNIQUE, pero los tokens bare
+colisionan entre secciones (`grid-cards` en services+products, `split-image` en
+hero+about, `cards-grid` en testimonials+contact, etc.). El prefijo era un
+workaround equivocado.
+
+Esta migración hace SÓLO el cambio de ESQUEMA: quita el UNIQUE global de `key` y
+añade unicidad COMPUESTA (section, key). El rename de datos a tokens bare vive en
+la migración SIGUIENTE (0038), separado a propósito para que ni el forward ni el
+reverse mezclen DDL y DML sobre la misma tabla en una transacción (evita el error
+de PostgreSQL "pending trigger events" al revertir).
+
+No modifica migraciones existentes (0036 etc.).
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0036_seed_section_variants"),
+    ]
+
+    operations = [
+        # Liberar el UNIQUE global de `key` (la unicidad pasa a ser compuesta).
+        migrations.AlterField(
+            model_name="sectionvariant",
+            name="key",
+            field=models.SlugField(max_length=80, verbose_name="Clave"),
+        ),
+        # Unicidad compuesta (section, key).
+        migrations.AddConstraint(
+            model_name="sectionvariant",
+            constraint=models.UniqueConstraint(
+                fields=["section", "key"],
+                name="uq_sectionvariant_section_key",
+            ),
+        ),
+    ]

--- a/backend/websites/migrations/0038_section_variants_bare_tokens.py
+++ b/backend/websites/migrations/0038_section_variants_bare_tokens.py
@@ -1,0 +1,137 @@
+"""Rename de claves a tokens BARE por sección — DATOS (issue #296).
+
+Continúa 0037 (que ya cambió el esquema a unicidad compuesta (section, key)).
+Aquí se renombra cada variante no-hero de `<section>-<token>` -> `<token>`, de
+modo que la clave del catálogo sea EXACTAMENTE el token que consume el renderer
+(`_render_<section>_<token>`) y el frontend (`switch (variant)`).
+
+Las claves de hero ya eran bare (centered, split-image, ...). Además garantizamos
+que el hero `glassmorphism` EXISTE pero queda INACTIVO (en una BD fresca, 0020 no
+lo sembró porque la sección hero aún no existía en ese punto, así que 0036 no tuvo
+nada que desactivar).
+
+Migración de DATOS pura (RunPython), idempotente y reversible. Separada del
+cambio de esquema de 0037 a propósito: así ni el forward ni el reverse mezclan
+DDL y DML sobre `websites_sectionvariant` en una misma transacción.
+
+Tras el rename, para cada sección las claves ACTIVAS igualan EXACTAMENTE los
+tokens del renderer/frontend (re-verificados contra rendering.py y sections/*.tsx).
+"""
+
+from django.db import migrations
+
+# Mapa de rename por sección: clave prefijada (sembrada en 0036) -> token bare.
+# Verificado 1:1 contra los dispatchers `_render_<section>_<token>` de
+# rendering.py y los `case '<token>'` de frontend/.../sections/*.tsx.
+NON_HERO_RENAMES = {
+    "services": {
+        "services-grid-cards": "grid-cards",
+        "services-grid-cards-image": "grid-cards-image",
+        "services-list-detailed": "list-detailed",
+        "services-featured-highlight": "featured-highlight",
+        "services-horizontal-scroll": "horizontal-scroll",
+        "services-icon-minimal": "icon-minimal",
+        "services-bento-grid": "bento-grid",
+    },
+    "products": {
+        "products-grid-cards": "grid-cards",
+        "products-grid-cards-image": "grid-cards-image",
+        "products-showcase-large": "showcase-large",
+        "products-catalog-compact": "catalog-compact",
+        "products-masonry-staggered": "masonry-staggered",
+        "products-price-table": "price-table",
+        "products-bento-grid": "bento-grid",
+    },
+    "about": {
+        "about-text-only": "text-only",
+        "about-split-image": "split-image",
+        "about-stats-banner": "stats-banner",
+        "about-timeline": "timeline",
+        "about-overlapping-cards": "overlapping-cards",
+        "about-fullwidth-banner": "fullwidth-banner",
+        "about-asymmetric": "asymmetric",
+    },
+    "testimonials": {
+        "testimonials-cards-grid": "cards-grid",
+        "testimonials-carousel": "carousel",
+        "testimonials-single-highlight": "single-highlight",
+    },
+    "pricing": {
+        "pricing-cards": "cards",
+        "pricing-comparison-table": "comparison-table",
+        "pricing-minimal-list": "minimal-list",
+    },
+    "gallery": {
+        "gallery-masonry": "masonry",
+        "gallery-grid-uniform": "grid-uniform",
+        "gallery-slider": "slider",
+    },
+    "faq": {
+        "faq-classic": "classic",
+        "faq-side-by-side": "side-by-side",
+        "faq-cards": "cards",
+    },
+    "contact": {
+        "contact-cards-grid": "cards-grid",
+        "contact-split-form": "split-form",
+        "contact-centered-minimal": "centered-minimal",
+    },
+}
+
+
+def rename_to_bare_tokens(apps, schema_editor):
+    """Renombra `<section>-<token>` -> `<token>` por sección (idempotente)."""
+    SectionVariant = apps.get_model("websites", "SectionVariant")
+    WebsiteSection = apps.get_model("websites", "WebsiteSection")
+
+    for section_key, renames in NON_HERO_RENAMES.items():
+        for prefixed_key, bare_key in renames.items():
+            SectionVariant.objects.filter(
+                section__key=section_key,
+                key=prefixed_key,
+            ).update(key=bare_key)
+
+    # En una BD fresca, 0020 no sembró el hero `glassmorphism` (la sección hero
+    # aún no existía entonces), así que 0036 no tenía nada que desactivar.
+    # Garantizamos aquí que glassmorphism EXISTE pero queda INACTIVA, para que el
+    # catálogo sea completo y la desactivación sea determinista en cualquier BD.
+    hero_section = WebsiteSection.objects.filter(key="hero").first()
+    if hero_section is not None:
+        SectionVariant.objects.update_or_create(
+            section=hero_section,
+            key="glassmorphism",
+            defaults={
+                "label": "Glassmorphism",
+                "description": "Efecto cristal con fondo difuminado. Retirado del catálogo de la IA.",
+                "css_class_hint": "hero--glassmorphism",
+                "mood": "elegant",
+                "is_default": False,
+                "is_active": False,
+                "sort_order": 5,
+            },
+        )
+
+
+def restore_prefixed_keys(apps, schema_editor):
+    """Reversa: `<token>` -> `<section>-<token>` por sección (idempotente)."""
+    SectionVariant = apps.get_model("websites", "SectionVariant")
+
+    # Eliminar el glassmorphism creado en BD fresca (sólo la fila inactiva).
+    SectionVariant.objects.filter(section__key="hero", key="glassmorphism", is_active=False).delete()
+
+    for section_key, renames in NON_HERO_RENAMES.items():
+        for prefixed_key, bare_key in renames.items():
+            SectionVariant.objects.filter(
+                section__key=section_key,
+                key=bare_key,
+            ).update(key=prefixed_key)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0037_sectionvariant_composite_key_bare_tokens"),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_to_bare_tokens, restore_prefixed_keys),
+    ]

--- a/backend/websites/models.py
+++ b/backend/websites/models.py
@@ -862,7 +862,11 @@ class SectionVariant(models.Model):
         related_name="variants",
         verbose_name="Sección",
     )
-    key = models.SlugField("Clave", max_length=80, unique=True)
+    # El `key` es el token BARE que consume el renderer (`_render_<section>_<key>`)
+    # y el frontend (`switch (variant)`). Los tokens colisionan entre secciones
+    # (ej. `grid-cards` en services+products), así que la unicidad es COMPUESTA
+    # por (section, key), no global.
+    key = models.SlugField("Clave", max_length=80)
     label = models.CharField("Etiqueta", max_length=100)
     description = models.TextField("Descripción", blank=True)
     css_class_hint = models.CharField("Clase CSS sugerida", max_length=100, blank=True)
@@ -885,6 +889,12 @@ class SectionVariant(models.Model):
         verbose_name = "Variante de sección"
         verbose_name_plural = "Variantes de sección"
         ordering = ["section", "sort_order", "label"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["section", "key"],
+                name="uq_sectionvariant_section_key",
+            ),
+        ]
 
     def __str__(self):
         return f"{self.label} ({self.section.key})"

--- a/backend/websites/services/ai_prompts.py
+++ b/backend/websites/services/ai_prompts.py
@@ -111,6 +111,7 @@ def _build_variant_instructions(section_keys: list[str]) -> str:
     variants = (
         SectionVariant.objects.filter(is_active=True, section__key__in=section_keys)
         .select_related("section")
+        .prefetch_related("industries")
         .order_by("section__key", "sort_order")
     )
     if not variants:
@@ -130,9 +131,16 @@ def _build_variant_instructions(section_keys: list[str]) -> str:
             lines.append(f"  CSS: `{v.css_class_hint}`")
         if v.mood:
             lines.append(f"  Mood: {v.get_mood_display()}")
+        industry_labels = [ind.label for ind in v.industries.all()]
+        if industry_labels:
+            lines.append(f"  Industrias: {', '.join(industry_labels)}")
 
     lines.append("")
     lines.append('Para cada seccion, elige UNA variante y devuelvela en el campo `"_variant"` del JSON de esa seccion.')
+    lines.append(
+        "Prefiere variantes cuyo Mood e Industrias encajen con este negocio; "
+        "si ninguna encaja claramente, usa la marcada como [DEFAULT]."
+    )
     return "\n".join(lines)
 
 

--- a/backend/websites/services/generation.py
+++ b/backend/websites/services/generation.py
@@ -7,13 +7,13 @@ desde el endpoint quick-start o desde cualquier flujo de onboarding unificado.
 """
 
 import logging
-import random
 
 from core.models import Tenant
 from websites.models import WebsiteConfig, WebsiteTemplate
 from websites.services.ai_service import AIService
 from websites.services.pages import derive_enabled_pages
 from websites.services.unsplash_service import UnsplashService
+from websites.services.variants import resolve_hero_variant
 
 logger = logging.getLogger(__name__)
 
@@ -285,11 +285,7 @@ def _inject_images_and_variants(content: dict, images: dict) -> None:
             content["hero"]["_image"] = hero_imgs[0]
             content["hero"]["_image_alternatives"] = hero_imgs[1:]
             unsplash.trigger_download(hero_imgs[0].get("download_location", ""))
-            variant = random.choice(["split-image", "fullwidth-image", "diagonal-split"])
-        else:
-            variant = random.choice(["centered", "bold-typography", "glassmorphism"])
-        content["hero"]["_variant"] = variant
-        content["hero"]["_variant_ai_recommended"] = variant
+        resolve_hero_variant(content, has_image=bool(hero_imgs))
 
     if "about" in content:
         about_imgs = images.get("about", [])

--- a/backend/websites/services/variants.py
+++ b/backend/websites/services/variants.py
@@ -1,0 +1,102 @@
+# backend/websites/services/variants.py
+"""Resolución determinista de variantes de sección a partir del catálogo.
+
+Reemplaza la antigua elección aleatoria (`random.choice`) por una resolución
+basada en el catálogo `SectionVariant`, para CUALQUIER sección:
+
+1. Si la IA propuso un `_variant` y ese token coincide con una variante ACTIVA
+   del catálogo de esa sección, se respeta.
+2. Si no, se cae a la variante marcada como `is_default` (ordenada por
+   `sort_order`). Para el hero existe además un fallback canónico (`centered`).
+3. `_variant_ai_recommended` guarda SIEMPRE la elección real de la IA (o `None`
+   si no propuso ninguna), para que el panel de edición pueda mostrarla.
+
+El catálogo es la fuente de verdad: las claves activas se leen de la BD, no se
+hardcodean. `SectionVariant`/`WebsiteSection` son modelos GLOBALES (sin tenant).
+"""
+
+# Default canónico cuando el catálogo no tiene ninguna variante de hero marcada
+# como `is_default` (defensivo). Coincide con el `default:` del switch del
+# frontend y con `_render_hero_centered` del renderer backend.
+_HERO_FALLBACK_KEY = "centered"
+
+
+def _active_variant_keys(section_key: str) -> set[str]:
+    """Devuelve las claves de variantes ACTIVAS del catálogo para una sección."""
+    from websites.models import SectionVariant
+
+    return set(
+        SectionVariant.objects.filter(
+            is_active=True,
+            section__key=section_key,
+        ).values_list("key", flat=True)
+    )
+
+
+def _active_hero_variant_keys() -> set[str]:
+    """Claves de variantes de hero ACTIVAS (compatibilidad retro)."""
+    return _active_variant_keys("hero")
+
+
+def _default_variant_key(section_key: str) -> str | None:
+    """Clave de la variante por defecto ACTIVA de una sección (o None).
+
+    Prefiere la variante activa marcada como `is_default`, ordenada por
+    `sort_order`. Para el hero cae al fallback canónico (`centered`) si no hay
+    ninguna marcada como default.
+    """
+    from websites.models import SectionVariant
+
+    default_key = (
+        SectionVariant.objects.filter(
+            is_active=True,
+            section__key=section_key,
+            is_default=True,
+        )
+        .order_by("sort_order")
+        .values_list("key", flat=True)
+        .first()
+    )
+    if default_key:
+        return default_key
+    if section_key == "hero":
+        return _HERO_FALLBACK_KEY
+    return None
+
+
+def resolve_section_variant(content: dict, section_key: str) -> None:
+    """Resuelve `_variant` de una sección de forma determinista (sin aleatoriedad).
+
+    Muta `content[section_key]` in-place:
+    - `_variant_ai_recommended`: la elección REAL de la IA (str) o `None`.
+    - `_variant`: la recomendación de la IA si es una clave activa del catálogo
+      de esa sección; en caso contrario, la variante por defecto del catálogo.
+
+    No hace nada si `section_key` no está en `content`.
+    """
+    if section_key not in content:
+        return
+
+    section = content[section_key]
+    ai_choice = section.get("_variant")
+    active_keys = _active_variant_keys(section_key)
+
+    # Registrar la elección real de la IA (o None si no propuso nada).
+    section["_variant_ai_recommended"] = ai_choice if ai_choice else None
+
+    if ai_choice and ai_choice in active_keys:
+        section["_variant"] = ai_choice
+    else:
+        default_key = _default_variant_key(section_key)
+        if default_key is not None:
+            section["_variant"] = default_key
+
+
+def resolve_hero_variant(content: dict, has_image: bool) -> None:
+    """Resuelve el `_variant` del hero (delega en `resolve_section_variant`).
+
+    `has_image` se conserva en la firma por compatibilidad con los llamadores
+    (generation.py / onboarding.py); hoy el default del catálogo (`centered`) ya
+    es el indicado cuando no hay imagen, así que el parámetro no se usa.
+    """
+    resolve_section_variant(content, "hero")

--- a/backend/websites/tasks.py
+++ b/backend/websites/tasks.py
@@ -7,7 +7,6 @@ el request HTTP del usuario.
 """
 
 import logging
-import random
 from datetime import timedelta
 
 from celery import shared_task
@@ -278,6 +277,7 @@ def _inject_images_and_variants(content: dict, images: dict) -> None:
     para reutilizar en la tarea asincrona.
     """
     from websites.services import UnsplashService
+    from websites.services.variants import resolve_section_variant
 
     unsplash = UnsplashService()
 
@@ -288,11 +288,7 @@ def _inject_images_and_variants(content: dict, images: dict) -> None:
             content["hero"]["_image"] = hero_imgs[0]
             content["hero"]["_image_alternatives"] = hero_imgs[1:]
             unsplash.trigger_download(hero_imgs[0].get("download_location", ""))
-            variant = random.choice(["split-image", "fullwidth-image", "diagonal-split"])
-        else:
-            variant = random.choice(["centered", "bold-typography", "glassmorphism"])
-        content["hero"]["_variant"] = variant
-        content["hero"]["_variant_ai_recommended"] = variant
+        resolve_section_variant(content, "hero")
 
     # About
     if "about" in content:
@@ -301,31 +297,18 @@ def _inject_images_and_variants(content: dict, images: dict) -> None:
             content["about"]["_image"] = about_imgs[0]
             content["about"]["_image_alternatives"] = about_imgs[1:]
             unsplash.trigger_download(about_imgs[0].get("download_location", ""))
-            variant = random.choice(["split-image", "stats-banner", "fullwidth-banner"])
-        else:
-            variant = random.choice(["text-only", "stats-banner", "timeline", "overlapping-cards", "fullwidth-banner"])
-        content["about"]["_variant"] = variant
-        content["about"]["_variant_ai_recommended"] = variant
+        resolve_section_variant(content, "about")
 
     # Services
     if "services" in content:
         section_imgs = images.get("services", [])
         items = content["services"].get("items", [])
-        has_images = False
         for i, item in enumerate(items):
             if i < len(section_imgs):
                 item["_image"] = section_imgs[i]
                 unsplash.trigger_download(section_imgs[i].get("download_location", ""))
-                has_images = True
-        if has_images:
-            variant = random.choice(["grid-cards-image", "featured-highlight"])
-        else:
-            variant = random.choice(["grid-cards", "list-detailed", "horizontal-scroll", "icon-minimal"])
-        content["services"]["_variant"] = variant
-        content["services"]["_variant_ai_recommended"] = variant
+        resolve_section_variant(content, "services")
 
     # Products
     if "products" in content:
-        variant = random.choice(["grid-cards", "price-table"])
-        content["products"]["_variant"] = variant
-        content["products"]["_variant_ai_recommended"] = variant
+        resolve_section_variant(content, "products")

--- a/backend/websites/tests/test_section_variants.py
+++ b/backend/websites/tests/test_section_variants.py
@@ -1,0 +1,351 @@
+"""Tests del catálogo de variantes de sección + resolución del hero (issue #296).
+
+Cubre:
+- `resolve_hero_variant`: respeta la elección de la IA si es una clave de hero
+  ACTIVA del catálogo; si no, cae a la variante por defecto (`centered` cuando
+  no hay imagen). Nunca usa aleatoriedad. `_variant_ai_recommended` guarda la
+  elección real de la IA (o `None`).
+- La migración 0036 siembra las 9 secciones canónicas con tokens base que
+  coinciden con los dispatchers del renderer backend.
+- glassmorphism (hero) y bento-grid (services/products) quedan desactivadas.
+- `_build_variant_instructions` incluye guía blanda de mood e industrias.
+
+`WebsiteSection`/`SectionVariant`/`Industry` son modelos GLOBALES (sin tenant).
+La BD de test corre todas las migraciones, así que el catálogo ya está sembrado.
+"""
+
+import pytest
+
+from websites.models import SectionVariant, WebsiteSection
+from websites.services.ai_prompts import _build_variant_instructions
+from websites.services.variants import (
+    _active_hero_variant_keys,
+    _active_variant_keys,
+    resolve_hero_variant,
+    resolve_section_variant,
+)
+from websites.tasks import _inject_images_and_variants
+
+pytestmark = pytest.mark.django_db
+
+CANONICAL_SECTION_KEYS = {
+    "hero",
+    "services",
+    "products",
+    "about",
+    "testimonials",
+    "pricing",
+    "gallery",
+    "faq",
+    "contact",
+}
+
+
+# ---------------------------------------------------------------------------
+# resolve_hero_variant — service logic
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_respects_valid_ai_variant():
+    """Si la IA propone una clave de hero ACTIVA, se respeta tal cual."""
+    active = _active_hero_variant_keys()
+    assert "split-image" in active
+    content = {"hero": {"_variant": "split-image"}}
+    resolve_hero_variant(content, has_image=True)
+    assert content["hero"]["_variant"] == "split-image"
+    assert content["hero"]["_variant_ai_recommended"] == "split-image"
+
+
+def test_resolve_falls_back_for_unknown_ai_variant():
+    """Una clave inexistente cae al default del catálogo; recommended preserva la cruda."""
+    content = {"hero": {"_variant": "no-existe-xyz"}}
+    resolve_hero_variant(content, has_image=False)
+    assert content["hero"]["_variant"] == "centered"
+    assert content["hero"]["_variant_ai_recommended"] == "no-existe-xyz"
+
+
+def test_resolve_default_is_centered_when_no_ai_choice():
+    """Sin `_variant` de la IA, el default es `centered` y recommended es None."""
+    content = {"hero": {}}
+    resolve_hero_variant(content, has_image=False)
+    assert content["hero"]["_variant"] == "centered"
+    assert content["hero"]["_variant_ai_recommended"] is None
+
+
+def test_resolve_falls_back_for_deactivated_glassmorphism():
+    """glassmorphism está desactivada: no se respeta aunque la IA la pida."""
+    assert "glassmorphism" not in _active_hero_variant_keys()
+    content = {"hero": {"_variant": "glassmorphism"}}
+    resolve_hero_variant(content, has_image=False)
+    assert content["hero"]["_variant"] == "centered"
+    assert content["hero"]["_variant_ai_recommended"] == "glassmorphism"
+
+
+def test_resolve_no_hero_is_noop():
+    """Sin sección hero en el content, la función no toca nada."""
+    content = {"services": {"_variant": "grid-cards"}}
+    resolve_hero_variant(content, has_image=True)
+    assert "hero" not in content
+    assert content["services"]["_variant"] == "grid-cards"
+
+
+# ---------------------------------------------------------------------------
+# Catálogo sembrado por la migración 0036
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_sections_seeded():
+    """Las 9 secciones canónicas existen con sus claves exactas."""
+    keys = set(WebsiteSection.objects.filter(key__in=CANONICAL_SECTION_KEYS).values_list("key", flat=True))
+    assert keys == CANONICAL_SECTION_KEYS
+
+
+def test_hero_keys_renamed_to_bare_tokens():
+    """Las claves de hero usan tokens base, no el prefijo legacy `hero-*`."""
+    hero_keys = set(SectionVariant.objects.filter(section__key="hero").values_list("key", flat=True))
+    assert "centered" in hero_keys
+    assert "split-image" in hero_keys
+    assert not any(k.startswith("hero-") for k in hero_keys)
+
+
+def test_bento_grid_and_glassmorphism_deactivated():
+    """bento-grid (services/products) y glassmorphism (hero) NO están activas.
+
+    Las claves son BARE (token), así que se identifican por (section, key), no
+    por una clave prefijada global. bento-grid existe pero inactiva; glassmorphism
+    queda inactiva (0037 garantiza su existencia inactiva en BD fresca).
+    """
+    services_bento = SectionVariant.objects.filter(section__key="services", key="bento-grid")
+    products_bento = SectionVariant.objects.filter(section__key="products", key="bento-grid")
+    assert services_bento.exists()
+    assert products_bento.exists()
+    assert not services_bento.filter(is_active=True).exists()
+    assert not products_bento.filter(is_active=True).exists()
+
+    # glassmorphism nunca debe estar ACTIVA en hero (esté presente o no).
+    assert not SectionVariant.objects.filter(section__key="hero", key="glassmorphism", is_active=True).exists()
+    # 0037 la siembra inactiva, así que debe existir como inactiva.
+    assert SectionVariant.objects.filter(section__key="hero", key="glassmorphism", is_active=False).exists()
+
+
+# Tokens canónicos por sección, verificados 1:1 contra los dispatchers
+# `_render_<section>_<token>` de rendering.py y los `case '<token>'` de
+# frontend/.../sections/*.tsx. Las claves del catálogo deben ser EXACTAMENTE
+# estos tokens BARE (sin prefijo de sección).
+CANONICAL_TOKENS = {
+    "hero": {"centered", "split-image", "fullwidth-image", "bold-typography", "diagonal-split"},
+    "services": {
+        "grid-cards",
+        "grid-cards-image",
+        "list-detailed",
+        "featured-highlight",
+        "horizontal-scroll",
+        "icon-minimal",
+    },
+    "products": {
+        "grid-cards",
+        "grid-cards-image",
+        "showcase-large",
+        "catalog-compact",
+        "masonry-staggered",
+        "price-table",
+    },
+    "about": {
+        "text-only",
+        "split-image",
+        "stats-banner",
+        "timeline",
+        "overlapping-cards",
+        "fullwidth-banner",
+        "asymmetric",
+    },
+    "testimonials": {"cards-grid", "carousel", "single-highlight"},
+    "pricing": {"cards", "comparison-table", "minimal-list"},
+    "gallery": {"masonry", "grid-uniform", "slider"},
+    "faq": {"classic", "side-by-side", "cards"},
+    "contact": {"cards-grid", "split-form", "centered-minimal"},
+}
+
+
+def test_active_variant_keys_are_exact_bare_tokens():
+    """Cada clave ACTIVA es EXACTAMENTE un token bare del renderer (sin prefijo).
+
+    Comprueba `v.key` SIN ningún stripping: si una clave volviera a sembrarse
+    prefijada (`services-grid-cards`), este test falla — que es justo el bug que
+    se nos escapó antes.
+    """
+    for section_key, tokens in CANONICAL_TOKENS.items():
+        active_keys = set(
+            SectionVariant.objects.filter(section__key=section_key, is_active=True).values_list("key", flat=True)
+        )
+        assert active_keys == tokens, (
+            f"Sección {section_key}: claves activas {active_keys} != tokens del renderer {tokens}"
+        )
+
+
+def test_each_section_has_exactly_one_active_default():
+    """Cada sección canónica tiene exactamente una variante activa por defecto."""
+    for section_key in CANONICAL_SECTION_KEYS:
+        defaults = SectionVariant.objects.filter(section__key=section_key, is_active=True, is_default=True)
+        assert defaults.count() == 1, f"La sección {section_key} debe tener 1 default activo"
+
+
+# ---------------------------------------------------------------------------
+# Prompt instructions — guía blanda de mood / industrias
+# ---------------------------------------------------------------------------
+
+
+def test_variant_instructions_include_mood_and_industries():
+    """El prompt de variantes incluye Mood e Industrias (selección blanda)."""
+    text = _build_variant_instructions(["hero", "services", "contact"])
+    assert "## Variantes de Diseno Disponibles" in text
+    assert "Mood:" in text
+    assert "Industrias:" in text
+    # Mensaje de selección blanda con fallback al default.
+    assert "[DEFAULT]" in text
+
+
+# ---------------------------------------------------------------------------
+# resolve_section_variant — secciones no-hero
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_section_respects_valid_ai_variant_non_hero():
+    """Una clave activa BARE del catálogo de `about` se respeta tal cual."""
+    active = _active_variant_keys("about")
+    assert "split-image" in active
+    content = {"about": {"_variant": "split-image"}}
+    resolve_section_variant(content, "about")
+    assert content["about"]["_variant"] == "split-image"
+    assert content["about"]["_variant_ai_recommended"] == "split-image"
+
+
+def test_resolve_section_falls_back_to_default_when_ai_omits_non_hero():
+    """Sin `_variant`, `about` cae a su default activo y recommended es None."""
+    default_key = (
+        SectionVariant.objects.filter(section__key="about", is_active=True, is_default=True)
+        .order_by("sort_order")
+        .values_list("key", flat=True)
+        .first()
+    )
+    content = {"about": {}}
+    resolve_section_variant(content, "about")
+    assert content["about"]["_variant"] == default_key
+    assert content["about"]["_variant_ai_recommended"] is None
+
+
+def test_resolve_section_falls_back_for_unknown_token_non_hero():
+    """Un token inexistente cae al default; recommended preserva el crudo."""
+    default_key = (
+        SectionVariant.objects.filter(section__key="services", is_active=True, is_default=True)
+        .order_by("sort_order")
+        .values_list("key", flat=True)
+        .first()
+    )
+    content = {"services": {"_variant": "no-existe-xyz"}}
+    resolve_section_variant(content, "services")
+    assert content["services"]["_variant"] == default_key
+    assert content["services"]["_variant_ai_recommended"] == "no-existe-xyz"
+
+
+def test_resolve_section_no_section_is_noop():
+    """Sin la sección en el content, no se toca nada."""
+    content = {"hero": {"_variant": "centered"}}
+    resolve_section_variant(content, "products")
+    assert "products" not in content
+
+
+# ---------------------------------------------------------------------------
+# tasks.py — la inyección ya no produce variantes aleatorias/fuera del catálogo
+# ---------------------------------------------------------------------------
+
+
+def test_inject_images_and_variants_uses_catalog_only():
+    """`_inject_images_and_variants` resuelve variantes del catálogo, no random.
+
+    Sin elección de la IA, cada sección debe quedar con su variante por defecto
+    ACTIVA del catálogo (determinista), y nunca con un token fuera del catálogo.
+    """
+    content = {
+        "hero": {},
+        "about": {},
+        "services": {"items": [{}, {}]},
+        "products": {},
+    }
+    # Sin imágenes: ejercita la rama "sin imagen" de cada sección.
+    _inject_images_and_variants(content, images={})
+
+    for section_key in ("hero", "about", "services", "products"):
+        resolved = content[section_key]["_variant"]
+        active = _active_variant_keys(section_key)
+        assert resolved in active, f"{section_key}: '{resolved}' no es una variante activa del catálogo"
+        # La elección real de la IA fue None (no propuso ninguna).
+        assert content[section_key]["_variant_ai_recommended"] is None
+
+
+def test_inject_images_and_variants_respects_ai_choice():
+    """Si la IA propuso una variante válida (BARE token), se respeta tal cual."""
+    content = {
+        "hero": {"_variant": "split-image"},
+        "services": {"_variant": "list-detailed", "items": []},
+    }
+    _inject_images_and_variants(content, images={})
+    assert content["hero"]["_variant"] == "split-image"
+    assert content["hero"]["_variant_ai_recommended"] == "split-image"
+    assert content["services"]["_variant"] == "list-detailed"
+    assert content["services"]["_variant_ai_recommended"] == "list-detailed"
+
+
+# ---------------------------------------------------------------------------
+# Contrato de token end-to-end: la variante resuelta DEBE mapear a un
+# `_render_<section>_<token>` real del renderer (no caer al default).
+# Este test habría atrapado el bug de las claves prefijadas.
+# ---------------------------------------------------------------------------
+
+
+# El renderer despacha `getattr(self, f"_render_<section>_<token>", default)`.
+# Tokens que el dispatcher resuelve SIN un método dedicado (caen a su default o a
+# un método especial nombrado distinto) — válidos pero no tienen
+# `_render_<section>_<token>` literal:
+_DISPATCH_SPECIAL_TOKENS = {
+    ("services", "grid-cards"),  # -> _render_services_default
+    ("services", "grid-cards-image"),  # -> _render_services_image
+    ("products", "grid-cards"),  # -> _render_services_default
+    ("products", "grid-cards-image"),  # -> _render_services_image
+}
+
+
+def _renderer_method_for(section_key: str, token: str) -> str:
+    """Nombre del método que el renderer buscaría para (section, token)."""
+    return f"_render_{section_key}_{token.replace('-', '_')}"
+
+
+def test_resolved_non_hero_variant_maps_to_real_renderer_method():
+    """Cada token ACTIVO no-hero mapea a un `_render_<section>_<token>` real.
+
+    Reproduce el contrato del dispatcher de `rendering.py`: el token resuelto por
+    `resolve_section_variant` debe (a) tener un método `_render_<section>_<token>`
+    dedicado, o (b) ser uno de los tokens con manejo especial documentado. Si la
+    clave volviera a ser prefijada (`about-split-image`), el método
+    `_render_about_about_split_image` no existiría y este test fallaría — que es
+    exactamente el bug que se nos escapó.
+    """
+    from websites.rendering import SiteRenderer
+
+    non_hero = [k for k in CANONICAL_SECTION_KEYS if k != "hero"]
+    for section_key in non_hero:
+        active_tokens = _active_variant_keys(section_key)
+        for token in active_tokens:
+            # La IA propone el token; el resolver lo respeta (es activo).
+            content = {section_key: {"_variant": token}}
+            resolve_section_variant(content, section_key)
+            resolved = content[section_key]["_variant"]
+            assert resolved == token, f"{section_key}: resolver alteró un token activo ({token} -> {resolved})"
+
+            if (section_key, resolved) in _DISPATCH_SPECIAL_TOKENS:
+                continue
+            method_name = _renderer_method_for(section_key, resolved)
+            assert hasattr(SiteRenderer, method_name), (
+                f"{section_key}: token '{resolved}' no tiene método de renderer '{method_name}' "
+                f"(caería al default — bug de catálogo no funcional)"
+            )

--- a/backend/websites/views/onboarding.py
+++ b/backend/websites/views/onboarding.py
@@ -2,7 +2,6 @@
 """Views para el proceso de onboarding del website builder."""
 
 import logging
-import random
 
 from django.db import models, transaction
 from rest_framework import generics, status
@@ -14,6 +13,7 @@ from ..models import OnboardingQuestion, OnboardingResponse, WebsiteConfig, Webs
 from ..services.ai_service import AIService
 from ..services.pages import derive_enabled_pages
 from ..services.unsplash_service import UnsplashService
+from ..services.variants import resolve_hero_variant
 
 logger = logging.getLogger(__name__)
 from ..serializers import (
@@ -480,11 +480,7 @@ class QuickStartView(OnboardingView):
                 content["hero"]["_image"] = hero_imgs[0]
                 content["hero"]["_image_alternatives"] = hero_imgs[1:]
                 unsplash.trigger_download(hero_imgs[0].get("download_location", ""))
-                variant = random.choice(["split-image", "fullwidth-image", "diagonal-split"])
-            else:
-                variant = random.choice(["centered", "bold-typography", "glassmorphism"])
-            content["hero"]["_variant"] = variant
-            content["hero"]["_variant_ai_recommended"] = variant
+            resolve_hero_variant(content, has_image=bool(hero_imgs))
 
         if "about" in content:
             about_imgs = images.get("about", [])


### PR DESCRIPTION
### **User description**
## Resumen

Cierra #296. El motor de render ya soportaba ~40 variantes de diseño en 3 capas (PromptBlocks → SectionVariant → React+CSS), pero el catálogo solo sembraba el **hero** y un `random.choice` pisaba la decisión de la IA. Resultado: el resto de secciones siempre salían con el mismo diseño y el hero era aleatorio, no una decisión intencional según el negocio.

Ahora la IA elige variantes **intencionalmente por sección**, respetando el skill maestro `nerbis-design-identity`.

## Cambios

- **`services/variants.py`** (nuevo): `resolve_section_variant` determinista — respeta la elección de la IA si es una key activa del catálogo, si no fallback al `is_default`. `_variant_ai_recommended` guarda la elección real de la IA (o `None`).
- **Fix hero aleatorio**: elimina `random.choice` en los **3 paths** de generación (`generation.py`, `views/onboarding.py`, `tasks.py` — este último el path Celery de producción) + `import random` huérfano.
- **Migración 0036**: siembra las 9 `WebsiteSection` canónicas + variantes para services/products/about/testimonials/pricing/gallery/faq/contact con los tokens canónicos que el render ya consume; renombra keys hero a tokens base; desactiva `glassmorphism` y `bento-grid` (violan `nerbis-design-identity`: blobs animados / bento decorativo); cura `mood` + `industries`.
- **Migraciones 0037/0038**: unicidad compuesta `(section, key)` + tokens base (split DDL/DML por reversibilidad en Postgres). Resuelve el choque de tokens entre secciones (`grid-cards`, `split-image`).
- **`ai_prompts._build_variant_instructions`**: guía soft de selección por mood/industria en el prompt.

## Notas

- Sin impacto multi-tenant: `SectionVariant`/`WebsiteSection` son globales.
- El código de render de glassmorphism/bento-grid se mantiene por compat de sitios ya publicados; solo salen del catálogo que ve la IA.

## Test plan

- [x] `ruff check backend/` + `ruff format --check backend/`
- [x] `makemigrations websites --check` limpio
- [x] `pytest websites/tests/test_section_variants.py` → 18 passed (DB de test aislada)
- [x] Contrato verificado: cada token activo mapea a un `_render_<section>_<token>` real + case del frontend
- [ ] Revisar render visual de las nuevas variantes en preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Habilita la selección intencional de variantes de diseño por IA en todas las secciones.

- Elimina la selección aleatoria de variantes de diseño en hero y otras secciones.

- Introduce un servicio de resolución determinista de variantes con fallbacks.

- Actualiza el catálogo de variantes con tokens base y unicidad compuesta.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AI Prompt"] -- "Guía de selección" --> B["_build_variant_instructions"];
  B -- "Lee catálogo" --> C["SectionVariant (DB)"];
  C -- "Define lógica" --> D["resolve_section_variant"];
  D -- "Aplica en generación" --> E["generation.py"];
  D -- "Aplica en tareas" --> F["tasks.py"];
  D -- "Aplica en onboarding" --> G["onboarding.py"];
  E,F,G -- "Generan contenido" --> H["Website Content"];
  H -- "Renderiza" --> I["Frontend Renderer"];
  J["Migraciones DB"] -- "Actualizan esquema y datos" --> C;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Data seeding</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0036_seed_section_variants.py</strong><dd><code>Siembra el catálogo completo de variantes para todas las secciones.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-3b7c9e9726b90b4945121229e01993736519776421b4403dda55f19fcc8a985a">+642/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Schema migration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0037_sectionvariant_composite_key_bare_tokens.py</strong><dd><code>Modifica el esquema de `SectionVariant` a clave compuesta.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-8db425d1335ceef58c47057965e254dea56a5c117b6b4af6282df3c498276f30">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Data migration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0038_section_variants_bare_tokens.py</strong><dd><code>Renombra claves de variantes a tokens base por sección.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-97e656f038aa3123cca8c91d025413c12d090c34844e7997c88f9cc542418007">+137/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Model changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>models.py</strong><dd><code>Actualiza el modelo `SectionVariant` para unicidad compuesta.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-8d588ffaf3e82dce7a29be70522fd161e3ee28a99b95e2e9b5ba7ee1f08a99a3">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Ai prompt engineering</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ai_prompts.py</strong><dd><code>Mejora las instrucciones de variantes para la IA con mood e </code><br><code>industrias.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-5038f8f1fe03874f1b48187485a85f6cea416e5599e7533e4d92fe6df12cf5a0">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>generation.py</strong><dd><code>Elimina la selección aleatoria de variantes de hero.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-8184cca021829dc12fccf22f70f06a981d7570ddada83ca7fa216977d910c1a8">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.py</strong><dd><code>Elimina la selección aleatoria de variantes en tareas asíncronas.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-fe8a3a830c0dc5f1a3e2950072319731f3a3b5e45d07bf5c11f601e2a972bb7d">+5/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>onboarding.py</strong><dd><code>Elimina la selección aleatoria de variantes de hero en el flujo de </code><br><code>onboarding.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-f3e634af116bfdc71550491d99a55bce337cf1d1b163fc8c263e0fe315986969">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>New feature</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>variants.py</strong><dd><code>Nuevo servicio para resolución determinista de variantes de sección.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-9aea36b021538afe2e7fcac4a54bba7b861fa63ebaf1cfbc424468db43618689">+102/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_section_variants.py</strong><dd><code>Nuevos tests para el catálogo y la resolución determinista de </code><br><code>variantes.</code></dd></td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/302/files#diff-6be137d6e7c897c4c613c7a8af84fa5cc77f5c1f08e40e2cf7c5c23c4feec16a">+351/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

