### PR TITLE
fix(auth): marketing consent checkbox + email check fix

### DIFF
--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -19,6 +19,7 @@ import {
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { socialLinkOnly } from '@/lib/api/auth';
+import { apiClient } from '@/lib/api/client';
 import { features } from '@/lib/features';
 import type { SocialProvider } from '@/types';
 import {
@@ -123,11 +124,10 @@ export function RegisterForm({
     }
     const timer = setTimeout(async () => {
       try {
-        const res = await fetch(`/api/public/check-tenant-email/?email=${encodeURIComponent(emailValue)}`);
-        if (res.ok) {
-          const data = await res.json();
-          setEmailExists(!!data.exists);
-        }
+        const { data } = await apiClient.get('/public/check-tenant-email/', {
+          params: { email: emailValue },
+        });
+        setEmailExists(!!data.exists);
       } catch {
         // Silently fail — non-critical check
       }
@@ -343,18 +343,20 @@ export function RegisterForm({
             control={form.control}
             name="data_consent"
             render={({ field }) => (
-              <FormItem className="flex items-start gap-2.5 space-y-0 pt-1">
-                <FormControl>
-                  <Checkbox
-                    checked={field.value === true}
-                    onCheckedChange={(checked) => field.onChange(checked === true)}
-                    disabled={isLoading}
-                    className="mt-0.5 shrink-0"
-                  />
-                </FormControl>
+              <FormItem className="flex gap-2.5 space-y-0 pt-1">
+                <div className="flex items-center h-[18px] mt-px">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value === true}
+                      onCheckedChange={(checked) => field.onChange(checked === true)}
+                      disabled={isLoading}
+                      className="shrink-0"
+                    />
+                  </FormControl>
+                </div>
                 <div>
                   <FormLabel
-                    className="text-[0.75rem] leading-[1.6] font-normal cursor-pointer inline"
+                    className="text-[0.75rem] leading-[18px] font-normal cursor-pointer inline"
                     style={{
                       color: 'var(--auth-text-muted)',
                       fontFamily: 'var(--auth-font-body)',
@@ -378,6 +380,37 @@ export function RegisterForm({
                     </Link>
                   </FormLabel>
                   <FormMessage role="alert" aria-live="polite" className="mt-1" />
+                </div>
+              </FormItem>
+            )}
+          />
+
+          {/* Marketing consent (optional — GDPR / Ley 1581) */}
+          <FormField
+            control={form.control}
+            name="marketing_consent"
+            render={({ field }) => (
+              <FormItem className="flex gap-2.5 space-y-0 -mt-2">
+                <div className="flex items-center h-[18px]">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value === true}
+                      onCheckedChange={(checked) => field.onChange(checked === true)}
+                      disabled={isLoading}
+                      className="shrink-0"
+                    />
+                  </FormControl>
+                </div>
+                <div>
+                  <FormLabel
+                    className="text-[0.75rem] leading-[18px] font-normal cursor-pointer inline"
+                    style={{
+                      color: 'var(--auth-text-muted)',
+                      fontFamily: 'var(--auth-font-body)',
+                    }}
+                  >
+                    Acepto recibir novedades y ofertas de NERBIS por email
+                  </FormLabel>
                 </div>
               </FormItem>
             )}


### PR DESCRIPTION
### **User description**
## Summary
- Add optional marketing consent checkbox to registration form (GDPR / Ley 1581 compliance — separate consent for promotional emails)
- Fix email existence check: `fetch()` was hitting Next.js server (localhost:3000) instead of Django backend via `apiClient`, causing a silent 308 redirect — the "email already exists" warning never appeared

## Changes
- `RegisterForm.tsx`: Added marketing consent `<Checkbox>` + switched email check from `fetch()` to `apiClient.get()`

## Test plan
- [ ] Register form shows both checkboxes (data consent required, marketing optional)
- [ ] Type an existing tenant email → "Ya existe una cuenta con este email" message appears
- [ ] Registration works with marketing consent checked and unchecked
- [ ] `core_user.marketing_consent` and `marketing_consent_date` saved correctly in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Añade casilla de consentimiento de marketing opcional.

- Corrige verificación de email con `apiClient`.

- Muestra advertencia de email existente.

- Ajusta estilos de casillas de consentimiento.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RegisterForm["frontend/src/components/auth/RegisterForm.tsx"]
  apiClient["apiClient"]

  RegisterForm -- "Verifica email con" --> apiClient
  RegisterForm -- "Añade" --> MarketingConsentCheckbox["Casilla de Consentimiento de Marketing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RegisterForm.tsx</strong><dd><code>Implementa consentimiento de marketing y corrige verificación de email</code></dd></summary>
<hr>

frontend/src/components/auth/RegisterForm.tsx

<ul><li>Se añadió una casilla de verificación opcional para el consentimiento <br>de marketing (<code>marketing_consent</code>).<br> <li> Se corrigió la verificación de existencia de correo electrónico, <br>cambiando <code>fetch()</code> por <code>apiClient.get()</code> para una comunicación correcta <br>con el backend.<br> <li> Se importó <code>apiClient</code> para la integración con la API.<br> <li> Se realizaron ajustes de estilo en las casillas de consentimiento <br>existentes y nuevas para una mejor alineación visual.</ul>


</details>


  </td>
  <td><a href="https://github.com/nerbis-platform/nerbis-platform/pull/307/files#diff-20c082e576949d7630368c6813b7fb1d63ca701a0f55f6b2edf2203f467575dc">+48/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funciones**
  * Se añadió una opción de consentimiento opcional para recibir novedades y ofertas por email durante el registro.
* **Mejoras**
  * Se ajustó la validación de correo para verificar disponibilidad de forma más estable en segundo plano.
  * Se mejoró el diseño y alineación del bloque de consentimiento legal para una presentación más consistente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->